### PR TITLE
Pass the remaining args when running serve

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5
+
+- Pass the arguments supporting `directory:port` for the `serve` command.
+
 ## 0.1.4
 
 - Require and use features from `build_runner` 0.8.2.

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -49,6 +49,9 @@ class ServeCommand extends CommandBase {
       arguments.add('--log-requests');
     }
 
+    // The remaining arguments should be interpreted as [<directory>[:<port>]].
+    arguments.addAll(argResults.rest);
+
     return arguments;
   }
 

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdev
-version: 0.1.4
+version: 0.1.5-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-


### PR DESCRIPTION
Allows you so specify a directory:port when running the serve command.