### PR TITLE
restore original build_runner constraints, fail on --live-reload if you are on <0.10.1

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.4
 
-- Added support for the --live-reload flag, and require build_runner 0.10.1.
+- Added support for the --live-reload flag, if on build_runner >=0.10.1.
 
 ## 0.2.3+2
 

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -34,11 +34,11 @@ Usage: webdev serve [arguments] [<directory>[:<port>]]...
     --[no-]build-web-compilers    If a dependency on `build_web_compilers` is required to run.
                                   (defaults to on)
 
-    --live-reload                 Automatically refreshes the page after each build.
     --hostname                    Specify the hostname to serve on
                                   (defaults to "localhost")
 
     --log-requests                Enables logging for each request to the server.
+    --live-reload                 Automatically refreshes the page after each build.
 
 Run "webdev help" to see global options.
 ```
@@ -61,8 +61,6 @@ Usage: webdev build [arguments]
 -v, --verbose                     Enables verbose logging.
     --[no-]build-web-compilers    If a dependency on `build_web_compilers` is required to run.
                                   (defaults to on)
-
-    --live-reload                 Automatically refreshes the page after each build.
 
 Run "webdev help" to see global options.
 ```

--- a/webdev/bin/webdev.dart
+++ b/webdev/bin/webdev.dart
@@ -27,7 +27,10 @@ Future main(List<String> args) async {
     }
     exitCode = ExitCode.config.code;
   } on PackageException catch (e) {
-    print(red.wrap('$_boldApp could not run for this project.'));
+    var withUnsupportedArg =
+        e.unsupportedArgument != null ? ' with --${e.unsupportedArgument}' : '';
+    print(red
+        .wrap('$_boldApp could not run$withUnsupportedArg for this project.'));
     for (var detail in e.details) {
       print(yellow.wrap(detail.error));
       if (detail.description != null) {

--- a/webdev/lib/src/command/command_base.dart
+++ b/webdev/lib/src/command/command_base.dart
@@ -16,7 +16,6 @@ const _packagesFileName = '.packages';
 const _release = 'release';
 const _output = 'output';
 const _verbose = 'verbose';
-const _liveReload = 'live-reload';
 
 const outputNone = 'NONE';
 
@@ -54,14 +53,10 @@ abstract class CommandBase extends Command<int> {
       ..addFlag(_requireBuildWebCompilers,
           defaultsTo: true,
           negatable: true,
-          help: 'If a dependency on `build_web_compilers` is required to run.')
-      ..addFlag(_liveReload,
-          defaultsTo: false,
-          negatable: false,
-          help: 'Automatically refreshes the page after each build.');
+          help: 'If a dependency on `build_web_compilers` is required to run.');
   }
 
-  List<String> getArgs() {
+  List<String> getArgs(PubspecLock pubspecLock) {
     var arguments = <String>[];
     if ((argResults[_release] as bool) ?? releaseDefault) {
       arguments.add('--$_release');
@@ -75,22 +70,20 @@ abstract class CommandBase extends Command<int> {
     if (argResults[_verbose] as bool) {
       arguments.add('--$_verbose');
     }
-    if (argResults[_liveReload] as bool) {
-      arguments.add('--$_liveReload');
-    }
     return arguments;
   }
 
   Future<int> runCore(String command, {List<String> extraArgs}) async {
-    await checkPubspecLock(
+    var pubspecLock = await PubspecLock.read();
+    await checkPubspecLock(pubspecLock,
         requireBuildWebCompilers:
             argResults[_requireBuildWebCompilers] as bool);
 
-    var buildRunnerScript = await _buildRunnerScript();
-
     final arguments = [command]
       ..addAll(extraArgs ?? const [])
-      ..addAll(getArgs());
+      ..addAll(getArgs(pubspecLock));
+
+    var buildRunnerScript = await _buildRunnerScript();
 
     var exitCode = 0;
 


### PR DESCRIPTION
Also moved the arg to only be supported for the serve command.