### PR TITLE
feature: print `Creating build script` at the start of execution

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.4+1
+
+- Print `Creating build script` on startup so the user is aware of what the
+  process is doing.
+
 ## 0.2.4
 
 - Added support for the --live-reload flag, if on build_runner >=0.10.1.

--- a/webdev/lib/src/command/command_base.dart
+++ b/webdev/lib/src/command/command_base.dart
@@ -83,7 +83,10 @@ abstract class CommandBase extends Command<int> {
       ..addAll(extraArgs ?? const [])
       ..addAll(getArgs(pubspecLock));
 
+    stdout.write('Creating build script');
+    var stopwatch = new Stopwatch()..start();
     var buildRunnerScript = await _buildRunnerScript();
+    stdout.writeln(', took ${stopwatch.elapsedMilliseconds}ms');
 
     var exitCode = 0;
 

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdev
-version: 0.2.4
+version: 0.2.4+1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-


### PR DESCRIPTION
This part of the process can take 7+ seconds. Until we find a way to
bring that down, it's good to minimize the time a user waits for any
output