### PR TITLE
Integrate WebDev and build_runner daemon

### DIFF
--- a/webdev/lib/src/command/command_base.dart
+++ b/webdev/lib/src/command/command_base.dart
@@ -73,12 +73,16 @@ abstract class CommandBase extends Command<int> {
     return arguments;
   }
 
-  Future<int> runCore(String command, {List<String> extraArgs}) async {
-    var pubspecLock = await PubspecLock.read();
+  Future<PubspecLock> readPubspecLock([String path]) async {
+    var pubspecLock = await PubspecLock.read(path);
     await checkPubspecLock(pubspecLock,
         requireBuildWebCompilers:
             argResults[_requireBuildWebCompilers] as bool);
+    return pubspecLock;
+  }
 
+  Future<int> runCore(String command, {List<String> extraArgs}) async {
+    var pubspecLock = await readPubspecLock();
     final arguments = [command]
       ..addAll(extraArgs ?? const [])
       ..addAll(getArgs(pubspecLock));

--- a/webdev/lib/src/command/serve2_command.dart
+++ b/webdev/lib/src/command/serve2_command.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:build_daemon/client.dart';
+import 'package:build_daemon/data/build_target.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:webdev/src/pubspec.dart';
+
+import '../serve/daemon_client.dart';
+import '../serve/server_manager.dart';
+import 'command_base.dart';
+
+Map<String, int> _parseDirectoryArgs(List<String> args) {
+  var result = <String, int>{};
+  for (var arg in args) {
+    var splitOption = arg.split(':');
+    assert(splitOption.length == 2);
+    result[splitOption.first] = int.parse(splitOption.last);
+  }
+  return result;
+}
+
+/// Command to run a server for local web development.
+///
+/// This command will eventually replace the existing serve command.
+class Serve2Command extends CommandBase {
+  @override
+  final name = 'serve2';
+
+  @override
+  final description = 'Run a local web development server and a file system'
+      ' watcher that re-builds on changes.';
+
+  Serve2Command() : super(releaseDefault: false, outputDefault: outputNone) {
+    argParser
+      ..addOption('hostname',
+          help: 'Specify the hostname to serve on', defaultsTo: 'localhost')
+      ..addFlag('log-requests',
+          defaultsTo: false,
+          negatable: false,
+          help: 'Enables logging for each request to the server.')
+      // For development purposes.
+      ..addOption(
+        'working-directory',
+        hide: true,
+        help: 'Set the working directory for this command.',
+      );
+  }
+
+  @override
+  bool get hidden => true;
+
+  @override
+  String get invocation => '${super.invocation} [<directory>[:<port>]]...';
+
+  @override
+  List<String> getArgs(PubspecLock pubspecLock) {
+    var issues = pubspecLock.checkPackage(
+        'build_runner', new VersionConstraint.parse('>=1.2.0 <2.0.0'));
+    if (issues.isNotEmpty) throw new PackageException(issues);
+    return super.getArgs(pubspecLock);
+  }
+
+  @override
+  Future<int> run() async {
+    var workingDirectory = argResults['working-directory'] as String;
+    workingDirectory ??= Directory.current.path;
+
+    var hostname = argResults['hostname'] as String;
+    var logRequests = argResults['log-requests'] as bool;
+
+    var directoryArgs =
+        argResults.rest.where((arg) => arg.contains(':')).toList();
+    if (directoryArgs.isEmpty) {
+      print('No directories provided.\n\n');
+      printUsage();
+      return -1;
+    }
+
+    var pubspecLock = await readPubspecLock('$workingDirectory/pubspec.lock');
+    // Forward remaining arguments as Build Options to the Daemon
+    var buildOptions = getArgs(pubspecLock)
+      ..addAll(argResults.rest.where((arg) => !arg.contains(':')).toList());
+
+    print('Connecting to the build daemon...');
+    BuildDaemonClient client;
+    try {
+      client = await connectClient(workingDirectory, buildOptions);
+    } on OptionsSkew {
+      print('\nIncompatible options with current running build daemon.\n\n'
+          'Please stop other WebDev instances running in this directory '
+          'before starting a new instance with these options.');
+      // TODO(grouma) - Give an option to kill the running daemon.
+      return -1;
+    }
+    client.serverLogs.listen((serverLog) => print(serverLog.log));
+
+    print('Registering build targets...');
+    var targetPorts = _parseDirectoryArgs(directoryArgs);
+    for (var target in targetPorts.keys) {
+      client.registerBuildTarget(DefaultBuildTarget((b) => b.target = target));
+    }
+
+    var manager = ServerManager(
+      getDaemonPort(workingDirectory),
+      hostname,
+      targetPorts,
+      logRequests,
+    );
+
+    print('Starting resource servers...');
+    await manager.start();
+
+    print('Starting initial build...');
+    client.startBuild();
+
+    await client.finished;
+    await manager.stop();
+    return 0;
+  }
+}

--- a/webdev/lib/src/command/serve2_command.dart
+++ b/webdev/lib/src/command/serve2_command.dart
@@ -42,13 +42,7 @@ class Serve2Command extends CommandBase {
       ..addFlag('log-requests',
           defaultsTo: false,
           negatable: false,
-          help: 'Enables logging for each request to the server.')
-      // For development purposes.
-      ..addOption(
-        'working-directory',
-        hide: true,
-        help: 'Set the working directory for this command.',
-      );
+          help: 'Enables logging for each request to the server.');
   }
 
   @override
@@ -67,8 +61,7 @@ class Serve2Command extends CommandBase {
 
   @override
   Future<int> run() async {
-    var workingDirectory = argResults['working-directory'] as String;
-    workingDirectory ??= Directory.current.path;
+    var workingDirectory = Directory.current.path;
 
     var hostname = argResults['hostname'] as String;
     var logRequests = argResults['log-requests'] as bool;
@@ -106,7 +99,7 @@ class Serve2Command extends CommandBase {
     }
 
     var manager = ServerManager(
-      getDaemonPort(workingDirectory),
+      daemonPort(workingDirectory),
       hostname,
       targetPorts,
       logRequests,

--- a/webdev/lib/src/serve/daemon_client.dart
+++ b/webdev/lib/src/serve/daemon_client.dart
@@ -17,7 +17,7 @@ Future<BuildDaemonClient> connectClient(
     );
 
 /// Returns the port of the daemon asset server.
-int getDaemonPort(String workingDirectory) {
+int daemonPort(String workingDirectory) {
   var portFile = File(_assetServerPortFilePath(workingDirectory));
   if (!portFile.existsSync())
     throw Exception('Unable to read daemon asset port file.');

--- a/webdev/lib/src/serve/daemon_client.dart
+++ b/webdev/lib/src/serve/daemon_client.dart
@@ -7,13 +7,14 @@ import 'dart:io';
 
 import 'package:build_daemon/client.dart';
 import 'package:build_daemon/constants.dart';
+import 'package:webdev/src/util.dart';
 
 /// Connects to the `build_runner` daemon.
 Future<BuildDaemonClient> connectClient(
         String workingDirectory, List<String> options) =>
     BuildDaemonClient.connect(
       workingDirectory,
-      ['pub', 'run', 'build_runner', 'daemon']..addAll(options),
+      [pubPath, 'run', 'build_runner', 'daemon']..addAll(options),
     );
 
 /// Returns the port of the daemon asset server.

--- a/webdev/lib/src/serve/daemon_client.dart
+++ b/webdev/lib/src/serve/daemon_client.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:build_daemon/client.dart';
+import 'package:build_daemon/constants.dart';
+
+/// Connects to the `build_runner` daemon.
+Future<BuildDaemonClient> connectClient(
+        String workingDirectory, List<String> options) =>
+    BuildDaemonClient.connect(
+      workingDirectory,
+      ['pub', 'run', 'build_runner', 'daemon']..addAll(options),
+    );
+
+/// Returns the port of the daemon asset server.
+int getDaemonPort(String workingDirectory) {
+  var portFile = File(_assetServerPortFilePath(workingDirectory));
+  if (!portFile.existsSync())
+    throw Exception('Unable to read daemon asset port file.');
+  return int.parse(portFile.readAsStringSync());
+}
+
+String _assetServerPortFilePath(String workingDirectory) =>
+    '${daemonWorkspace(workingDirectory)}/.asset_server_port';

--- a/webdev/lib/src/serve/handlers/asset_handler.dart
+++ b/webdev/lib/src/serve/handlers/asset_handler.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:shelf/shelf.dart';
+import 'package:shelf_proxy/shelf_proxy.dart';
+
+/// A handler for a build target's assets.
+///
+/// Proxies requests to the build daemon asset server.
+class AssetHandler {
+  final int _daemonPort;
+  final String _target;
+
+  Handler _handler;
+
+  AssetHandler(
+    this._daemonPort,
+    this._target,
+  );
+
+  Handler get handler {
+    _handler ??= Cascade()
+        .add(proxyHandler('http://localhost:$_daemonPort/$_target/'))
+        .handler;
+    return _handler;
+  }
+}

--- a/webdev/lib/src/serve/handlers/asset_handler.dart
+++ b/webdev/lib/src/serve/handlers/asset_handler.dart
@@ -20,9 +20,7 @@ class AssetHandler {
   );
 
   Handler get handler {
-    _handler ??= Cascade()
-        .add(proxyHandler('http://localhost:$_daemonPort/$_target/'))
-        .handler;
+    _handler ??= proxyHandler('http://localhost:$_daemonPort/$_target/');
     return _handler;
   }
 }

--- a/webdev/lib/src/serve/handlers/webdev_handler.dart
+++ b/webdev/lib/src/serve/handlers/webdev_handler.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:shelf/shelf.dart';
+
+import 'asset_handler.dart';
+
+/// A composition of handlers for all WebDev requests.
+class WebDevHandler {
+  final bool _logRequests;
+  final AssetHandler _assetHandler;
+
+  Handler _handler;
+
+  WebDevHandler(
+    this._assetHandler,
+    this._logRequests,
+  );
+
+  Handler get handler {
+    if (_handler == null) {
+      // TODO(grouma) - add custom handler for hot reload requests.
+      var pipeline = const Pipeline();
+      if (_logRequests) {
+        pipeline = pipeline.addMiddleware(logRequests());
+      }
+      _handler = pipeline.addHandler(_assetHandler.handler);
+    }
+    return _handler;
+  }
+}

--- a/webdev/lib/src/serve/server_manager.dart
+++ b/webdev/lib/src/serve/server_manager.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'webdev_server.dart';
+
+/// Manages a set of [WebDevServer]s.
+///
+/// Starts a [WebDevServer] for each target port pair.
+class ServerManager {
+  final int _daemonPort;
+  final String _hostname;
+  final Map<String, int> _targetPorts;
+  final bool _logRequests;
+
+  final _servers = Set<WebDevServer>();
+
+  ServerManager(
+    this._daemonPort,
+    this._hostname,
+    this._targetPorts,
+    this._logRequests,
+  );
+
+  Future<void> start() async {
+    for (var target in _targetPorts.keys) {
+      var server = await WebDevServer.start(
+        _hostname,
+        _targetPorts[target],
+        _daemonPort,
+        target,
+        _logRequests,
+      );
+      _servers.add(server);
+    }
+  }
+
+  Future<void> stop() async {
+    for (var server in _servers) {
+      await server.stop();
+    }
+  }
+}

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:shelf/shelf_io.dart' as shelf_io;
+
+import 'handlers/asset_handler.dart';
+import 'handlers/webdev_handler.dart';
+
+class WebDevServer {
+  HttpServer _server;
+
+  WebDevServer._(this._server);
+
+  int get port => _server.port;
+
+  Future<void> stop() => _server.close(force: true);
+
+  static Future<WebDevServer> start(
+    String hostname,
+    int port,
+    int daemonPort,
+    String target,
+    bool logRequests,
+  ) async {
+    var assetHandler = AssetHandler(daemonPort, target);
+    var webDevHandler = WebDevHandler(assetHandler, logRequests);
+    var server = await HttpServer.bind(hostname, port);
+    shelf_io.serveRequests(server, webDevHandler.handler);
+    print('Serving `$target` on http://$hostname:$port');
+    return WebDevServer._(server);
+  }
+}

--- a/webdev/lib/src/webdev_command_runner.dart
+++ b/webdev/lib/src/webdev_command_runner.dart
@@ -8,6 +8,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 
 import 'command/build_command.dart';
+import 'command/serve2_command.dart';
 import 'command/serve_command.dart';
 import 'util.dart';
 import 'version.dart';
@@ -23,6 +24,7 @@ class _CommandRunner extends CommandRunner<int> {
         negatable: false, help: 'Prints the version of webdev.');
     addCommand(new BuildCommand());
     addCommand(new ServeCommand());
+    addCommand(new Serve2Command());
   }
 
   @override

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -11,10 +11,13 @@ environment:
 
 dependencies:
   args: ^1.2.0
+  build_daemon: ^0.2.0
   io: ^0.3.2+1
   meta: ^1.1.2
   path: ^1.5.1
   pub_semver: ^1.3.2
+  shelf: ^0.7.4 
+  shelf_proxy: ^0.1.0+5
   stack_trace: ^1.9.2
   yaml: ^2.1.13
 

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -96,47 +96,48 @@ void main() {
   });
 
   group('should serve with valid configuration', () {
-    for (var withDDC in [true, false]) {
-      test(withDDC ? 'DDC' : 'dart2js', () async {
-        var openPort = await _getOpenPort();
-        var args = ['serve', 'web:$openPort'];
-        if (!withDDC) {
-          args.add('--release');
-        }
-
-        var process = await runWebDev(args, workingDirectory: exampleDirectory);
-
-        var hostUrl = 'http://localhost:$openPort';
-
-        await expectLater(
-            process.stdout, emitsThrough('Serving `web` on $hostUrl'));
-
-        var client = new HttpClient();
-
-        try {
-          for (var entry in _testItems.entries) {
-            var url = Uri.parse('$hostUrl/${entry.key}');
-
-            var request = await client.getUrl(url);
-            var response = await request.close();
-
-            var shouldExist = (entry.value ?? withDDC) == withDDC;
-
-            expect(response.statusCode, shouldExist ? 200 : 404,
-                reason: 'Expecting "$url"? $shouldExist');
+    for (var command in ['serve', 'serve2']) {
+      for (var withDDC in [true, false]) {
+        var type = withDDC ? 'DDC' : 'dart2js';
+        var name = 'using $command with $type';
+        test(name, () async {
+          var openPort = await _getOpenPort();
+          var args = [command, 'web:$openPort'];
+          if (!withDDC) {
+            args.add('--release');
           }
-        } finally {
-          client.close(force: true);
-        }
 
-        if (Platform.isWindows) {
+          var process =
+              await runWebDev(args, workingDirectory: exampleDirectory);
+
+          var hostUrl = 'http://localhost:$openPort';
+
+          // Wait for the initial build to finish.
+          await expectLater(
+              process.stdout, emitsThrough(contains('Succeeded')));
+
+          var client = new HttpClient();
+
+          try {
+            for (var entry in _testItems.entries) {
+              var url = Uri.parse('$hostUrl/${entry.key}');
+
+              var request = await client.getUrl(url);
+              var response = await request.close();
+
+              var shouldExist = (entry.value ?? withDDC) == withDDC;
+
+              expect(response.statusCode, shouldExist ? 200 : 404,
+                  reason: 'Expecting "$url"? $shouldExist');
+            }
+          } finally {
+            client.close(force: true);
+          }
+
           await process.kill();
-          await process.shouldExit(-1);
-        } else {
-          process.signal(ProcessSignal.sigint);
-          await process.shouldExit(0);
-        }
-      });
+          await process.shouldExit();
+        });
+      }
     }
   });
 }

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -97,6 +97,7 @@ void main() {
 
   group('should serve with valid configuration', () {
     for (var command in ['serve', 'serve2']) {
+      if (command == 'serve2' && Platform.isWindows) return;
       for (var withDDC in [true, false]) {
         var type = withDDC ? 'DDC' : 'dart2js';
         var name = 'using $command with $type';


### PR DESCRIPTION
- Create new command `serve2` which will eventually replace `serve`
- The new command will:
  - be hidden for the time being
  - connect to the build daemon
  - create a proxy server for each requested build target 
    - this server forward requests to the daemon asset server
    - in the future this server will have hooks for hot reload / hot restart
- Add and E2E integration test
  - This test is expected to fail until `package:build_runner` version `1.2.1` is released