### PR TITLE
Enable live reload through build daemon

### DIFF
--- a/webdev/lib/src/command/serve2_command.dart
+++ b/webdev/lib/src/command/serve2_command.dart
@@ -14,6 +14,10 @@ import '../serve/daemon_client.dart';
 import '../serve/server_manager.dart';
 import 'command_base.dart';
 
+const _hostnameFlag = 'hostname';
+const _logRequestsFlag = 'log-requests';
+const _liveReloadFlag = 'live-reload';
+
 Map<String, int> _parseDirectoryArgs(List<String> args) {
   var result = <String, int>{};
   for (var arg in args) {
@@ -37,12 +41,17 @@ class Serve2Command extends CommandBase {
 
   Serve2Command() : super(releaseDefault: false, outputDefault: outputNone) {
     argParser
-      ..addOption('hostname',
+      ..addOption(_hostnameFlag,
           help: 'Specify the hostname to serve on', defaultsTo: 'localhost')
-      ..addFlag('log-requests',
+      ..addFlag(_logRequestsFlag,
           defaultsTo: false,
           negatable: false,
-          help: 'Enables logging for each request to the server.');
+          help: 'Enables logging for each request to the server.')
+      ..addFlag(_liveReloadFlag,
+          defaultsTo: false,
+          negatable: false,
+          help:
+              'Automatically refreshes the page after each successful build.');
   }
 
   @override
@@ -63,8 +72,9 @@ class Serve2Command extends CommandBase {
   Future<int> run() async {
     var workingDirectory = Directory.current.path;
 
-    var hostname = argResults['hostname'] as String;
-    var logRequests = argResults['log-requests'] as bool;
+    var hostname = argResults[_hostnameFlag] as String;
+    var logRequests = argResults[_logRequestsFlag] as bool;
+    var liveReload = argResults[_liveReloadFlag] as bool;
 
     var directoryArgs =
         argResults.rest.where((arg) => arg.contains(':')).toList();
@@ -99,10 +109,12 @@ class Serve2Command extends CommandBase {
     }
 
     var manager = ServerManager(
+      client.buildResults,
       daemonPort(workingDirectory),
       hostname,
       targetPorts,
       logRequests,
+      liveReload,
     );
 
     print('Starting resource servers...');

--- a/webdev/lib/src/serve/handlers/build_results_handler.dart
+++ b/webdev/lib/src/serve/handlers/build_results_handler.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:build_daemon/data/build_status.dart';
+import 'package:build_daemon/data/serializers.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf_web_socket/shelf_web_socket.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+final _buildResultsProtocol = r'$buildResults';
+
+/// Web socket handler to inform clients of build results.
+class BuildResultsHandler {
+  final _connections = Set<WebSocketChannel>();
+  StreamSubscription _sub;
+
+  Handler _handler;
+  BuildResultsHandler(Stream<BuildResult> buildResults) {
+    _sub = buildResults.listen(_emitBuildResults);
+    _handler =
+        webSocketHandler(_handleConnection, protocols: [_buildResultsProtocol]);
+  }
+
+  Handler get handler => _handler;
+
+  Future<void> close() async {
+    await _sub.cancel();
+    for (var connection in _connections) {
+      await connection.sink.close();
+    }
+  }
+
+  void _emitBuildResults(BuildResult result) {
+    if (result.status != BuildStatus.succeeded) return;
+    for (var connection in _connections) {
+      connection.sink.add(jsonEncode(serializers.serialize(result)));
+    }
+  }
+
+  void _handleConnection(WebSocketChannel webSocket, String protocol) async {
+    _connections.add(webSocket);
+    await webSocket.stream.drain();
+    _connections.remove(webSocket);
+  }
+}

--- a/webdev/lib/src/serve/handlers/webdev_handler.dart
+++ b/webdev/lib/src/serve/handlers/webdev_handler.dart
@@ -12,15 +12,14 @@ import 'build_results_handler.dart';
 class WebDevHandler {
   final bool _logRequests;
   final AssetHandler _assetHandler;
-  final BuildResultsHandler _buildResultsHandler;
+  BuildResultsHandler _buildResultsHandler;
 
   Handler _handler;
 
   WebDevHandler(
-    this._assetHandler,
-    this._buildResultsHandler,
-    this._logRequests,
-  );
+      this._assetHandler, this._logRequests,
+      {BuildResultsHandler buildResultsHandler})
+      : _buildResultsHandler = buildResultsHandler;
 
   Handler get handler {
     if (_handler == null) {

--- a/webdev/lib/src/serve/handlers/webdev_handler.dart
+++ b/webdev/lib/src/serve/handlers/webdev_handler.dart
@@ -4,28 +4,37 @@
 
 import 'package:shelf/shelf.dart';
 
+import '../middlewares/reload_middleware.dart';
 import 'asset_handler.dart';
+import 'build_results_handler.dart';
 
 /// A composition of handlers for all WebDev requests.
 class WebDevHandler {
   final bool _logRequests;
   final AssetHandler _assetHandler;
+  final BuildResultsHandler _buildResultsHandler;
 
   Handler _handler;
 
   WebDevHandler(
     this._assetHandler,
+    this._buildResultsHandler,
     this._logRequests,
   );
 
   Handler get handler {
     if (_handler == null) {
-      // TODO(grouma) - add custom handler for hot reload requests.
+      var cascade = Cascade();
       var pipeline = const Pipeline();
       if (_logRequests) {
         pipeline = pipeline.addMiddleware(logRequests());
       }
-      _handler = pipeline.addHandler(_assetHandler.handler);
+      if (_buildResultsHandler != null) {
+        pipeline = pipeline.addMiddleware(injectLiveReloadClientCode);
+        cascade = cascade.add(_buildResultsHandler.handler);
+      }
+      cascade = cascade.add(_assetHandler.handler);
+      _handler = pipeline.addHandler(cascade.handler);
     }
     return _handler;
   }

--- a/webdev/lib/src/serve/handlers/webdev_handler.dart
+++ b/webdev/lib/src/serve/handlers/webdev_handler.dart
@@ -12,12 +12,11 @@ import 'build_results_handler.dart';
 class WebDevHandler {
   final bool _logRequests;
   final AssetHandler _assetHandler;
-  BuildResultsHandler _buildResultsHandler;
+  final BuildResultsHandler _buildResultsHandler;
 
   Handler _handler;
 
-  WebDevHandler(
-      this._assetHandler, this._logRequests,
+  WebDevHandler(this._assetHandler, this._logRequests,
       {BuildResultsHandler buildResultsHandler})
       : _buildResultsHandler = buildResultsHandler;
 

--- a/webdev/lib/src/serve/middlewares/reload_middleware.dart
+++ b/webdev/lib/src/serve/middlewares/reload_middleware.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:crypto/crypto.dart';
+
+import 'package:shelf/shelf.dart';
+
+final injectLiveReloadClientCode =
+    _injectBuildResultsClientCode('live_reload_client');
+
+const clientPrefix = 'webdev/src/serve/reload_client/';
+const entrypointExtensionMarker = '/* ENTRYPOINT_EXTENTION_MARKER */';
+
+String _buildResultsInjectedJS(String scriptName) => '''\n
+// Injected by webdev for build results support.
+window.\$dartLoader.forceLoadModule('$clientPrefix/$scriptName');
+''';
+
+Handler Function(Handler) _injectBuildResultsClientCode(String scriptName) =>
+    (innerHandler) {
+      return (Request request) async {
+        if (!request.url.path.endsWith('.js')) {
+          return innerHandler(request);
+        }
+        if (request.url.path == '$clientPrefix/$scriptName.js') {
+          var uri = await Isolate.resolvePackageUri(
+              Uri.parse('package:$clientPrefix/$scriptName.js'));
+          var result = await File(uri.toFilePath()).readAsString();
+          return Response.ok(result, headers: {
+            HttpHeaders.contentTypeHeader: 'application/javascript'
+          });
+        }
+        var response = await innerHandler(request);
+        var body = await response.readAsString();
+        if (body.startsWith(entrypointExtensionMarker)) {
+          body += _buildResultsInjectedJS(scriptName);
+          var originalEtag = response.headers[HttpHeaders.etagHeader];
+          if (originalEtag != null) {
+            var newEtag = base64.encode(md5.convert(body.codeUnits).bytes);
+            var newHeaders = Map.of(response.headers);
+            newHeaders[HttpHeaders.etagHeader] = newEtag;
+            if (request.headers[HttpHeaders.ifNoneMatchHeader] == newEtag) {
+              return Response.notModified(headers: newHeaders);
+            }
+            response = response.change(headers: newHeaders);
+          }
+        }
+        return response.change(body: body);
+      };
+    };

--- a/webdev/lib/src/serve/reload_client/live_reload_client.js
+++ b/webdev/lib/src/serve/reload_client/live_reload_client.js
@@ -1,0 +1,8 @@
+(function () {
+    var _buildUpdatesProtocol = '$buildResults';
+
+    var ws = new WebSocket('ws://' + location.host, [_buildUpdatesProtocol]);
+    ws.onmessage = function (event) {
+        location.reload();
+    };
+})()

--- a/webdev/lib/src/serve/server_manager.dart
+++ b/webdev/lib/src/serve/server_manager.dart
@@ -4,24 +4,30 @@
 
 import 'dart:async';
 
+import 'package:build_daemon/data/build_status.dart';
+
 import 'webdev_server.dart';
 
 /// Manages a set of [WebDevServer]s.
 ///
 /// Starts a [WebDevServer] for each target port pair.
 class ServerManager {
+  final Stream<BuildResults> _buildResults;
   final int _daemonPort;
   final String _hostname;
   final Map<String, int> _targetPorts;
   final bool _logRequests;
+  final bool _liveReload;
 
   final _servers = Set<WebDevServer>();
 
   ServerManager(
+    this._buildResults,
     this._daemonPort,
     this._hostname,
     this._targetPorts,
     this._logRequests,
+    this._liveReload,
   );
 
   Future<void> start() async {
@@ -32,6 +38,8 @@ class ServerManager {
         _daemonPort,
         target,
         _logRequests,
+        _liveReload,
+        _buildResults,
       );
       _servers.add(server);
     }

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -38,8 +38,8 @@ class WebDevServer {
           buildResults.asyncMap<BuildResult>((results) =>
               results.results.firstWhere((result) => result.target == target)));
     }
-    var webDevHandler =
-        WebDevHandler(assetHandler, buildResultsHandler, logRequests);
+    var webDevHandler = WebDevHandler(assetHandler, logRequests,
+        buildResultsHandler: buildResultsHandler);
     var server = await HttpServer.bind(hostname, port);
     shelf_io.serveRequests(server, webDevHandler.handler);
     print('Serving `$target` on http://$hostname:$port');

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   args: ^1.2.0
   build_daemon: ^0.2.0
+  crypto: ^2.0.6
   io: ^0.3.2+1
   meta: ^1.1.2
   path: ^1.5.1

--- a/webdev/test/handlers/build_results_handler_test.dart
+++ b/webdev/test/handlers/build_results_handler_test.dart
@@ -1,0 +1,144 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:build_daemon/data/build_status.dart';
+import 'package:build_daemon/data/serializers.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:test/test.dart';
+import 'package:webdev/src/serve/handlers/build_results_handler.dart';
+
+void main() {
+  StreamController<BuildResult> streamController;
+  HttpServer server;
+
+  group('BuildResultsHandler', () {
+    setUp(() async {
+      streamController = StreamController<BuildResult>();
+      var handler = BuildResultsHandler(streamController.stream);
+      server = await shelf_io.serve(handler.handler, 'localhost', 0);
+    });
+
+    tearDown(() async {
+      await server.close();
+    });
+    test('updates a single client', () async {
+      var client = await WebSocket.connect('ws://localhost:${server.port}',
+          protocols: [r'$buildResults']);
+      streamController.add(DefaultBuildResult((b) => b
+        ..target = 'foo'
+        ..status = BuildStatus.succeeded));
+      var event = await client.first;
+      var result =
+          serializers.deserialize(jsonDecode(event as String)) as BuildResult;
+      expect(result.status, BuildStatus.succeeded);
+    });
+
+    test('updates multiple clients', () async {
+      var clientA = await WebSocket.connect('ws://localhost:${server.port}',
+          protocols: [r'$buildResults']);
+      var clientB = await WebSocket.connect('ws://localhost:${server.port}',
+          protocols: [r'$buildResults']);
+      streamController.add(DefaultBuildResult((b) => b
+        ..target = 'foo'
+        ..status = BuildStatus.succeeded));
+      var eventA = await clientA.first;
+      var resultA =
+          serializers.deserialize(jsonDecode(eventA as String)) as BuildResult;
+      var eventB = await clientB.first;
+      var resultB =
+          serializers.deserialize(jsonDecode(eventB as String)) as BuildResult;
+
+      expect(resultA.status, BuildStatus.succeeded);
+      expect(resultB.status, BuildStatus.succeeded);
+    });
+
+    test('does not update disconnected clients', () async {
+      var client = await WebSocket.connect('ws://localhost:${server.port}',
+          protocols: [r'$buildResults']);
+
+      var events = 0;
+      client.listen((_) {
+        events++;
+      });
+
+      streamController.add(DefaultBuildResult((b) => b
+        ..target = 'foo'
+        ..status = BuildStatus.succeeded));
+      await pumpEventQueue();
+
+      await client.close();
+      await pumpEventQueue();
+
+      streamController.add(DefaultBuildResult((b) => b
+        ..target = 'foo'
+        ..status = BuildStatus.succeeded));
+      await pumpEventQueue();
+
+      expect(events, 1);
+    });
+
+    test('updates non disconnected clients', () async {
+      var clientA = await WebSocket.connect('ws://localhost:${server.port}',
+          protocols: [r'$buildResults']);
+      var clientB = await WebSocket.connect('ws://localhost:${server.port}',
+          protocols: [r'$buildResults']);
+
+      streamController.add(DefaultBuildResult((b) => b
+        ..target = 'foo'
+        ..status = BuildStatus.succeeded));
+
+      var events = 0;
+      clientA.listen((_) {
+        events++;
+      });
+
+      await clientB.first;
+      await clientB.close();
+      await pumpEventQueue();
+
+      streamController.add(DefaultBuildResult((b) => b
+        ..target = 'foo'
+        ..status = BuildStatus.succeeded));
+      await pumpEventQueue();
+
+      expect(events, 2);
+    });
+
+    test('only forwards success results', () async {
+      var client = await WebSocket.connect('ws://localhost:${server.port}',
+          protocols: [r'$buildResults']);
+
+      var events = 0;
+      client.listen((_) {
+        events++;
+      });
+
+      streamController.add(DefaultBuildResult((b) => b
+        ..target = 'foo'
+        ..status = BuildStatus.succeeded));
+      await pumpEventQueue();
+
+      streamController.add(DefaultBuildResult((b) => b
+        ..target = 'foo'
+        ..status = BuildStatus.started));
+      await pumpEventQueue();
+
+      streamController.add(DefaultBuildResult((b) => b
+        ..target = 'foo'
+        ..status = BuildStatus.failed));
+      await pumpEventQueue();
+
+      streamController.add(DefaultBuildResult((b) => b
+        ..target = 'foo'
+        ..status = BuildStatus.succeeded));
+      await pumpEventQueue();
+
+      expect(events, 2);
+    });
+  });
+}

--- a/webdev/test/middlewares/reload_middleware_test.dart
+++ b/webdev/test/middlewares/reload_middleware_test.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:test/test.dart';
+import 'package:webdev/src/serve/middlewares/reload_middleware.dart';
+
+void main() {
+  HttpServer server;
+
+  group('ReloadMiddleware', () {
+    setUp(() async {
+      var pipeline = const Pipeline().addMiddleware(injectLiveReloadClientCode);
+      server = await shelf_io.serve(pipeline.addHandler((request) {
+        if (request.url.path.endsWith('entrypoint.js')) {
+          return Response.ok('$entrypointExtensionMarker',
+              headers: {HttpHeaders.etagHeader: 'entry etag'});
+        } else if (request.url.path.endsWith('foo.js')) {
+          return Response.ok('some js',
+              headers: {HttpHeaders.etagHeader: 'some etag'});
+        } else {
+          return Response.notFound('Not found');
+        }
+      }), 'localhost', 0);
+    });
+
+    tearDown(() async {
+      await server.close();
+    });
+
+    test('leaves non-entrypoints untouched', () async {
+      var result = await http.get('http://localhost:${server.port}/foo.js');
+      expect(result.body, 'some js');
+    });
+
+    test('does not update etags for non-entrypoints', () async {
+      var result = await http.get('http://localhost:${server.port}/foo.js');
+      expect(result.headers[HttpHeaders.etagHeader], 'some etag');
+    });
+
+    test('injects client for entrypoints', () async {
+      var result =
+          await http.get('http://localhost:${server.port}/entrypoint.js');
+      expect(result.body.contains('Injected by webdev'), isTrue);
+    });
+
+    test('updates etags for injected responses', () async {
+      var result =
+          await http.get('http://localhost:${server.port}/entrypoint.js');
+      expect(result.headers[HttpHeaders.etagHeader], isNot('entry etag'));
+    });
+
+    test('ignores non-js requests', () async {
+      var result = await http.get('http://localhost:${server.port}/main.dart');
+      expect(result.body, 'Not found');
+    });
+  });
+}


### PR DESCRIPTION
- Add `live-reload` argument to `serve2` command
- Create a new build results handler which forwards results over a websocket
- Create middleware to inject js which creates a websocket connection for build result updates
- Add corresponding tests

Closes https://github.com/dart-lang/webdev/issues/107