### PR TITLE
Fix starting the client on Windows

### DIFF
--- a/webdev/lib/src/serve/daemon_client.dart
+++ b/webdev/lib/src/serve/daemon_client.dart
@@ -13,9 +13,13 @@ import 'package:webdev/src/util.dart';
 Future<BuildDaemonClient> connectClient(
         String workingDirectory, List<String> options) =>
     BuildDaemonClient.connect(
-      workingDirectory,
-      [pubPath, 'run', 'build_runner', 'daemon']..addAll(options),
-    );
+        workingDirectory,
+        // On Windows we need to call the snapshot directly otherwise
+        // the process will start in a disjoint cmd without access to
+        // STDIO.
+        (Platform.isWindows ? [dartPath, pubSnapshot] : ['pub'])
+          ..addAll(['run', 'build_runner', 'daemon'])
+          ..addAll(options));
 
 /// Returns the port of the daemon asset server.
 int daemonPort(String workingDirectory) {

--- a/webdev/lib/src/util.dart
+++ b/webdev/lib/src/util.dart
@@ -18,5 +18,7 @@ final String _sdkDir = (() {
 })();
 
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
+final String pubSnapshot =
+    p.join(_sdkDir, 'bin', 'snapshots', 'pub.dart.snapshot');
 final String pubPath =
     p.join(_sdkDir, 'bin', Platform.isWindows ? 'pub.bat' : 'pub');

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -97,7 +97,6 @@ void main() {
 
   group('should serve with valid configuration', () {
     for (var command in ['serve', 'serve2']) {
-      if (command == 'serve2' && Platform.isWindows) return;
       for (var withDDC in [true, false]) {
         var type = withDDC ? 'DDC' : 'dart2js';
         var name = 'using $command with $type';


### PR DESCRIPTION
When starting a `pub.bat` process with mode `ProcessStartMode.detachedWithStdio` the corresponding process will start a detached window (regardless of the `runInShell` option) that does not forward STDIO. The daemon client expects ready signals on STDIO and thus must work around this limitation by starting the pub snapshot directly.

This work around is still somewhat clunky on Windows as a blank cmd window (which presumably "hosts" the daemon) is opened. If the window is closed it will reopen upon a rebuild. Further windows will not open if one already exists. Even with this oddity I believe this is a preferable alternative to https://github.com/dart-lang/build/pull/2009.

I'll need to investigate further but the root cause of this oddity is likely within pub or the SDK. 

This is a workaround for https://github.com/dart-lang/sdk/issues/35809