### PR TITLE
Fix hot-reload caching bug

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -38,6 +38,7 @@
   versions.
 
 ## 0.2.2
+
 - Add default value for `--output` to be `build:web` for the `build` command
   and `NONE` for the `serve` command.
 - Update to use lower-case constants from Dart `^2.0.0-dev.54`.

--- a/webdev/lib/src/serve/middlewares/reload_middleware.dart
+++ b/webdev/lib/src/serve/middlewares/reload_middleware.dart
@@ -17,7 +17,13 @@ final injectHotRestartClientCode =
     _injectBuildResultsClientCode('hot_restart_client');
 
 const clientPrefix = 'webdev/src/serve/reload_client/';
+
+/// Marker placed by build_web_compilers for where to put injected JS code.
 const entrypointExtensionMarker = '/* ENTRYPOINT_EXTENTION_MARKER */';
+
+/// File extension that build_web_compilers will place the
+/// [entrypointExtensionMarker] in.
+const bootstrapJsExtension = '.bootstrap.js';
 
 String _buildResultsInjectedJS(String scriptName) => '''\n
 // Injected by webdev for build results support.
@@ -34,7 +40,7 @@ Handler Function(Handler) _injectBuildResultsClientCode(String scriptName) =>
           return Response.ok(result, headers: {
             HttpHeaders.contentTypeHeader: 'application/javascript'
           });
-        } else if (request.url.path.endsWith('.bootstrap.js')) {
+        } else if (request.url.path.endsWith(bootstrapJsExtension)) {
           var ifNoneMatch = request.headers[HttpHeaders.ifNoneMatchHeader];
           if (ifNoneMatch != null) {
             // Disable caching of the inner hander by manually modifying the


### PR DESCRIPTION
There was an additional edge case here when going from non-hot-reload to hot-reload.

This fixes it by modifying the if-none-match header before forwarding to the proxy, which effectively disables caching for the bootstrap.js files.

Also fixes https://github.com/dart-lang/webdev/issues/120