### PR TITLE
Improved serve logging

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.0
 
-- Support building with `package:build_daemon` through `serve2` command.
+- Support building with `package:build_daemon` through `serve` command.
 
 ## 1.0.1
 

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -10,6 +10,7 @@ import 'package:build_daemon/data/build_target.dart';
 
 import '../serve/daemon_client.dart';
 import '../serve/server_manager.dart';
+import '../serve/utils.dart';
 import '../serve/webdev_server.dart';
 import 'command_base.dart';
 
@@ -90,6 +91,7 @@ class ServeCommand extends CommandBase {
     var liveReload = argResults[_liveReloadFlag] as bool;
     var hotRestart = argResults[_hotRestartFlag] as bool;
     var hotReload = argResults[_hotReloadFlag] as bool;
+    var verbose = argResults['verbose'] as bool;
 
     if (hotReload) {
       print('Hot reload is not ready yet, using --$_hotRestartFlag');
@@ -118,7 +120,11 @@ class ServeCommand extends CommandBase {
     print('Connecting to the build daemon...');
     BuildDaemonClient client;
     try {
-      client = await connectClient(workingDirectory, buildOptions);
+      client = await connectClient(
+        workingDirectory,
+        buildOptions,
+        (serverLog) => writeServerLog(serverLog, verbose),
+      );
     } on OptionsSkew {
       print('\nIncompatible options with current running build daemon.\n\n'
           'Please stop other WebDev instances running in this directory '
@@ -126,7 +132,6 @@ class ServeCommand extends CommandBase {
       // TODO(grouma) - Give an option to kill the running daemon.
       return -1;
     }
-    client.serverLogs.listen((serverLog) => print(serverLog.log));
 
     print('Registering build targets...');
     var targetPorts = _parseDirectoryArgs(directoryArgs);

--- a/webdev/lib/src/serve/daemon_client.dart
+++ b/webdev/lib/src/serve/daemon_client.dart
@@ -7,11 +7,12 @@ import 'dart:io';
 
 import 'package:build_daemon/client.dart';
 import 'package:build_daemon/constants.dart';
+import 'package:build_daemon/data/server_log.dart';
 import 'package:webdev/src/util.dart';
 
 /// Connects to the `build_runner` daemon.
-Future<BuildDaemonClient> connectClient(
-        String workingDirectory, List<String> options) =>
+Future<BuildDaemonClient> connectClient(String workingDirectory,
+        List<String> options, Function(ServerLog) logHandler) =>
     BuildDaemonClient.connect(
         workingDirectory,
         // On Windows we need to call the snapshot directly otherwise
@@ -19,7 +20,8 @@ Future<BuildDaemonClient> connectClient(
         // STDIO.
         (Platform.isWindows ? [dartPath, pubSnapshot] : ['pub'])
           ..addAll(['run', 'build_runner', 'daemon'])
-          ..addAll(options));
+          ..addAll(options),
+        logHandler: logHandler);
 
 /// Returns the port of the daemon asset server.
 int daemonPort(String workingDirectory) {

--- a/webdev/lib/src/serve/utils.dart
+++ b/webdev/lib/src/serve/utils.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:build_daemon/data/server_log.dart';
+import 'package:io/ansi.dart';
+import 'package:logging/logging.dart';
+
+/// Colors and writes daemon [ServerLog]s
+void writeServerLog(ServerLog serverLog, bool verbose) {
+  var recordLevel = _levelForLog(serverLog);
+  if (recordLevel == null) {
+    stdout.writeln(serverLog.log);
+  } else {
+    AnsiCode color;
+    if (recordLevel < Level.WARNING) {
+      color = cyan;
+    } else if (recordLevel < Level.SEVERE) {
+      color = yellow;
+    } else {
+      color = red;
+    }
+    var message = serverLog.log.replaceFirst('[$recordLevel]', '');
+    var eraseLine = verbose ? '' : '\x1b[2K\r';
+    var level = color.wrap('[$recordLevel]');
+
+    stdout.write('$eraseLine$level$message');
+    if (recordLevel > Level.INFO || verbose) {
+      stdout.writeln('');
+    }
+  }
+}
+
+/// Detects if the [ServerLog] contains a [Level] and returns the
+/// resulting value.
+///
+/// If the [ServerLog] does not contain a [Level], null will be returned.
+Level _levelForLog(ServerLog serverLog) {
+  var log = serverLog.log;
+  Level recordLevel;
+  for (var level in Level.LEVELS) {
+    if (log.startsWith('[$level]')) {
+      recordLevel = level;
+      break;
+    }
+  }
+  return recordLevel;
+}

--- a/webdev/lib/src/serve/utils.dart
+++ b/webdev/lib/src/serve/utils.dart
@@ -23,11 +23,13 @@ void writeServerLog(ServerLog serverLog, bool verbose) {
       color = red;
     }
     var message = serverLog.log.replaceFirst('[$recordLevel]', '');
+    var multiline = message.contains('\n');
     var eraseLine = verbose ? '' : '\x1b[2K\r';
     var level = color.wrap('[$recordLevel]');
 
     stdout.write('$eraseLine$level$message');
-    if (recordLevel > Level.INFO || verbose) {
+    // Prevent multilines and severe messages from being erased.
+    if (recordLevel > Level.INFO || verbose || multiline) {
       stdout.writeln('');
     }
   }

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   args: ^1.2.0
-  build_daemon: ^0.2.0
+  build_daemon: ^0.4.0
   crypto: ^2.0.6
   io: ^0.3.2+1
   meta: ^1.1.2


### PR DESCRIPTION
Previously the daemon command handled color logging which proved to be problematic. Initial log messages from outside the daemon command, e.g. the generate build script action, were not colored correctly. `package:build_runner` was updated to always write simplified logs through the daemon command. `package:build_daemon` was updated to easily handle initial logs, those prior to the daemon client connection. 

For this change: rev to the latest `package:build_daemon` and migrate color logging over to webdev which ensures consistency of terminal log messages.