### PR TITLE
Support connecting through the webkit inspection protocol

### DIFF
--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -17,10 +17,11 @@ dependencies:
   meta: ^1.1.2
   path: ^1.5.1
   pub_semver: ^1.3.2
-  shelf: ^0.7.4 
+  shelf: ^0.7.4
   shelf_proxy: ^0.1.0+5
   stack_trace: ^1.9.2
   sse: ^0.0.1
+  webkit_inspection_protocol: ^0.3.6
   yaml: ^2.1.13
 
 dev_dependencies:

--- a/webdev/test/chrome_test.dart
+++ b/webdev/test/chrome_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:test/test.dart';
 import 'package:webdev/src/serve/chrome.dart';
 
@@ -19,10 +21,10 @@ void main() {
 
   test('can launch chrome', () async {
     expect(chrome, isNotNull);
-  });
+  }, skip: Platform.isWindows);
 
   test('debugger is working', () async {
     var tabs = await chrome.chromeConnection.getTabs();
     expect(tabs.length, equals(1));
-  });
+  }, skip: Platform.isWindows);
 }

--- a/webdev/test/chrome_test.dart
+++ b/webdev/test/chrome_test.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:webdev/src/serve/chrome.dart';
+
+void main() {
+  Chrome chrome;
+  setUp(() async {
+    // The url doesn't matter.
+    chrome = await Chrome.start(['www.google.com']);
+  });
+
+  tearDown(() {
+    chrome?.close();
+    chrome = null;
+  });
+
+  test('can launch chrome', () async {
+    expect(chrome, isNotNull);
+  });
+
+  test('debugger is working', () async {
+    var tabs = await chrome.chromeConnection.getTabs();
+    expect(tabs.length, equals(1));
+  });
+}


### PR DESCRIPTION
Add basic support for connecting the webkit inspector. What we expose through the Chrome class will almost certainly change.

Towards  https://github.com/dart-lang/webdev/issues/133