### PR TITLE
Chrome Debug Port

### DIFF
--- a/webdev/README.md
+++ b/webdev/README.md
@@ -32,13 +32,14 @@ Usage: webdev serve [arguments] [<directory>[:<port>]]...
                                   (defaults to on)
 
 -v, --verbose                     Enables verbose logging.
+    --chrome-debug-port           Specify which port the Chrome debugger is listenting on. If used with launch-in-chrome Chrome will be started with the debugger listening on this port.
     --hostname                    Specify the hostname to serve on.
                                   (defaults to "localhost")
 
     --hot-restart                 Automatically reloads changed modules after each build and restarts your application.
                                   Can't be used with live-reload.
 
-    --launch-in-chrome            Automatically launches your application in chrome.
+    --launch-in-chrome            Automatically launches your application in Chrome with the debug port open. Use chrome-debug-port to specify a specific port.
     --live-reload                 Automatically refreshes the page after each successful build.
                                   Can't be used with hot-restart.
 

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -6,6 +6,7 @@ import 'package:args/args.dart';
 
 import '../serve/reload_client/configuration.dart';
 
+const chromeDebugPortFlag = 'chrome-debug-port';
 const hostnameFlag = 'hostname';
 const hotReloadFlag = 'hot-reload';
 const hotRestartFlag = 'hot-restart';
@@ -40,6 +41,7 @@ ReloadConfiguration _parseReloadConfiguration(ArgResults argResults) {
 }
 
 class Configuration {
+  final int _chromeDebugPort;
   final String _hostname;
   final bool _launchInChrome;
   final bool _logRequests;
@@ -50,6 +52,7 @@ class Configuration {
   final bool _verbose;
 
   Configuration._({
+    int chromeDebugPort,
     String hostname,
     bool launchInChrome,
     bool logRequests,
@@ -58,7 +61,8 @@ class Configuration {
     bool release,
     bool requireBuildWebCompilers,
     bool verbose,
-  })  : _hostname = hostname,
+  })  : _chromeDebugPort = chromeDebugPort,
+        _hostname = hostname,
         _launchInChrome = launchInChrome,
         _logRequests = logRequests,
         _output = output,
@@ -66,6 +70,8 @@ class Configuration {
         _reload = reload,
         _requireBuildWebCompilers = requireBuildWebCompilers,
         _verbose = verbose;
+
+  int get chromeDebugPort => _chromeDebugPort ?? 0;
 
   String get hostname => _hostname ?? 'localhost';
 
@@ -87,6 +93,10 @@ class Configuration {
   static Configuration fromArgs(ArgResults argResults) {
     var defaultConfiguration = Configuration._();
     if (argResults == null) return defaultConfiguration;
+
+    var chromeDebugPort = argResults.options.contains(chromeDebugPortFlag)
+        ? argResults[chromeDebugPortFlag] as int
+        : defaultConfiguration.chromeDebugPort;
 
     var hostname = argResults.options.contains(hostnameFlag)
         ? argResults[hostnameFlag] as String
@@ -118,6 +128,7 @@ class Configuration {
         : defaultConfiguration.verbose;
 
     return Configuration._(
+        chromeDebugPort: chromeDebugPort,
         hostname: hostname,
         launchInChrome: launchInChrome,
         logRequests: logRequests,

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -30,13 +30,17 @@ class ServerOptions {
 
 class WebDevServer {
   HttpServer _server;
+  BuildResultsHandler _buildResultsHandler;
 
-  WebDevServer._(this._server);
+  WebDevServer._(this._server, this._buildResultsHandler);
 
   String get host => _server.address.host;
   int get port => _server.port;
 
-  Future<void> stop() => _server.close(force: true);
+  Future<void> stop() async {
+    await _buildResultsHandler.close();
+    await _server.close(force: true);
+  }
 
   static Future<WebDevServer> start(
     ServerOptions options,
@@ -65,6 +69,6 @@ class WebDevServer {
     shelf_io.serveRequests(server, pipeline.addHandler(cascade.handler));
     print('Serving `${options.target}` on '
         'http://${options.configuration.hostname}:${options.port}');
-    return WebDevServer._(server);
+    return WebDevServer._(server, buildResultsHandler);
   }
 }

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   args: ^1.2.0
-  build_daemon: ^0.4.0
+  build_daemon: ^0.4.1
   crypto: ^2.0.6
   io: ^0.3.2+1
   meta: ^1.1.2

--- a/webdev/test/serve/chrome_test.dart
+++ b/webdev/test/serve/chrome_test.dart
@@ -2,20 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:webdev/src/serve/chrome.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-const _googleUrl = 'http://www.google.com/';
-
 void main() {
   Chrome chrome;
-  setUp(() async {
-    // The url doesn't matter.
-    chrome = await Chrome.start([_googleUrl]);
-  });
+
+  Future<void> launchChrome({int port}) async {
+    chrome = await Chrome.start([_googleUrl], port: port);
+  }
 
   tearDown(() async {
     await chrome?.close();
@@ -23,14 +22,23 @@ void main() {
   });
 
   test('can launch chrome', () async {
+    await launchChrome();
     expect(chrome, isNotNull);
   }, skip: Platform.isWindows);
 
   test('debugger is working', () async {
+    await launchChrome();
     var tabs = await chrome.chromeConnection.getTabs();
     expect(
         tabs,
         contains(const TypeMatcher<ChromeTab>()
             .having((t) => t.url, 'url', _googleUrl)));
   }, skip: Platform.isWindows);
+
+  test('uses open debug port if provided port is 0', () async {
+    await launchChrome(port: 0);
+    expect(chrome.debugPort, isNot(equals(0)));
+  }, skip: Platform.isWindows);
 }
+
+const _googleUrl = 'http://www.google.com/';


### PR DESCRIPTION
- Add new flag `--chrome-debug-port` to either specify a debug port for Chrome to use or an existing port to connect to
- Rely on latest `package:build_daemon` so that we can close the client if there is an issue

Towards: https://github.com/dart-lang/webdev/issues/133