### PR TITLE
implement Extension stream an  ServiceExtensionAdded event for Isolate stream

### DIFF
--- a/dwds/example/hello_world/index.html
+++ b/dwds/example/hello_world/index.html
@@ -1,0 +1,7 @@
+<html>
+
+<head>
+  <script defer src="main.dart.js"></script>
+</head>
+
+</html>

--- a/dwds/example/hello_world/main.dart
+++ b/dwds/example/hello_world/main.dart
@@ -20,7 +20,5 @@ void main() async {
     });
   };
 
-  // Help with flakyness on travis, don't fire this event right away.
-  await Future.delayed(Duration(seconds: 1));
   window.console.debug('Page Ready');
 }

--- a/dwds/example/hello_world/main.dart
+++ b/dwds/example/hello_world/main.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:developer';
+import 'dart:html';
+import 'dart:js';
+
+void main() async {
+  context['postEvent'] = (String kind) {
+    postEvent(kind, {'example': 'data'});
+  };
+
+  context['registerExtension'] = (String method) {
+    registerExtension(method,
+        (String method, Map<String, String> parameters) async {
+      return ServiceExtensionResponse.result(
+          jsonEncode({'example': 'response'}));
+    });
+  };
+
+  // Help with flakyness on travis, don't fire this event right away.
+  await Future.delayed(Duration(seconds: 1));
+  window.console.debug('Page Ready');
+}

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -297,12 +297,11 @@ class ChromeProxyService implements VmServiceInterface {
   @override
   Future<Success> setVMName(String name) async {
     _vm.name = name;
-    var controller = _streamControllers['VM'];
-    if (controller != null) {
-      controller.add(Event()
-        ..kind = EventKind.kVMUpdate
-        ..vm = toVMRef(_vm));
-    }
+    _streamNotify(
+        'VM',
+        Event()
+          ..kind = EventKind.kVMUpdate
+          ..vm = toVMRef(_vm));
     return Success();
   }
 

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -28,7 +28,30 @@ class ChromeProxyService implements VmServiceInterface {
   /// The connection with the chrome debug service for the tab.
   final WipConnection _tabConnection;
 
-  ChromeProxyService._(this._vm, this._isolate, this._tabConnection);
+  ChromeProxyService._(this._vm, this._isolate, this._tabConnection) {
+    // Listen for `registerExtension` and `postEvent` calls.
+    _tabConnection.runtime.onConsoleAPICalled.listen((ConsoleAPIEvent event) {
+      if (event.type != 'debug') return;
+      var firstArgValue = event.args[0].value;
+      if (firstArgValue == 'dart.developer.registerExtension') {
+        var service = event.args[1].value;
+        _isolate.extensionRPCs.add(service);
+        _streamNotify(
+            'Isolate',
+            Event()
+              ..kind = EventKind.kServiceExtensionAdded
+              ..extensionRPC = service);
+      } else if (firstArgValue == 'dart.developer.postEvent') {
+        _streamNotify(
+            'Extension',
+            Event()
+              ..kind = EventKind.kExtension
+              ..extensionKind = event.args[1].value
+              ..extensionData =
+                  ExtensionData.parse(jsonDecode(event.args[2].value) as Map));
+      }
+    });
+  }
 
   static Future<ChromeProxyService> create(
       ChromeConnection chromeConnection, String tabUrl) async {
@@ -40,7 +63,8 @@ class ChromeProxyService implements VmServiceInterface {
       ..name = '${tab.url}:main()'
       ..runnable = true
       ..breakpoints = []
-      ..libraries = [];
+      ..libraries = []
+      ..extensionRPCs = [];
     var isolateRef = toIsolateRef(isolate);
     isolate.pauseEvent = Event()
       ..kind = EventKind.kResume
@@ -185,6 +209,12 @@ class ChromeProxyService implements VmServiceInterface {
   Stream<Event> onEvent(String streamId) {
     return _streamControllers.putIfAbsent(streamId, () {
       switch (streamId) {
+        case 'Extension':
+        // TODO: right now we only support the `ServiceExtensionAdded` event for
+        // the Isolate stream.
+        case 'Isolate':
+        case '_Service':
+          return StreamController<Event>.broadcast();
         case 'Stdout':
           return _chromeConsoleStreamController(
               (e) => _stdoutTypes.contains(e.type));
@@ -208,8 +238,15 @@ class ChromeProxyService implements VmServiceInterface {
   }
 
   @override
-  Future<Success> registerService(String service, String alias) {
-    throw UnimplementedError();
+  // TODO: what does `alias` represent here?
+  Future<Success> registerService(String service, String alias) async {
+    _isolate.extensionRPCs.add(service);
+    _streamNotify(
+        '_Service',
+        Event()
+          ..kind = EventKind.kServiceRegistered
+          ..extensionRPC = service);
+    return Success();
   }
 
   @override
@@ -325,10 +362,18 @@ class ChromeProxyService implements VmServiceInterface {
     });
     return controller;
   }
+
+  /// Adds [event] to the stream with [streamId] if there is anybody listening
+  /// on that stream.
+  void _streamNotify(String streamId, Event event) {
+    var controller = _streamControllers[streamId];
+    if (controller == null) return;
+    controller.add(event);
+  }
 }
 
 /// The `type`s of [ConsoleAPIEvent]s that are treated as `stderr` logs.
 const _stderrTypes = ['error'];
 
 /// The `type`s of [ConsoleAPIEvent]s that are treated as `stdout` logs.
-const _stdoutTypes = ['log', 'debug', 'info', 'warning'];
+const _stdoutTypes = ['log', 'info', 'warning'];

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
   webkit_inspection_protocol: ^0.3.6
 dev_dependencies:
   args: ^1.0.0
+  build_runner: ^1.0.0
+  build_web_compilers: ^1.0.0
   test: ^1.0.0
   webdev:
     path: ../webdev

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -29,12 +29,15 @@ void main() {
     webdev.stderr
         .transform(const Utf8Decoder())
         .transform(const LineSplitter())
-        .listen(printOnFailure);
+        .listen(print);
     await webdev.stdout
         .transform(const Utf8Decoder())
         .transform(const LineSplitter())
         .takeWhile((line) => !line.contains('$port'))
-        .drain();
+        .map((line) {
+      print(line);
+      return line;
+    }).drain();
     appUrl = 'http://localhost:$port/hello_world/';
     chrome = await Chrome.start([appUrl]);
     var connection = chrome.chromeConnection;

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -26,11 +26,15 @@ void main() {
     var port = await findUnusedPort();
     webdev = await Process.start(
         'pub', ['global', 'run', 'webdev', 'serve', 'example:$port']);
+    webdev.stderr.listen(print);
     await webdev.stdout
         .transform(const Utf8Decoder())
         .transform(const LineSplitter())
         .takeWhile((line) => !line.contains('$port'))
-        .drain();
+        .map((line) {
+      print(line);
+      return line;
+    }).drain();
     appUrl = 'http://localhost:$port/hello_world/';
     chrome = await Chrome.start([appUrl]);
     var connection = chrome.chromeConnection;

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -24,20 +24,17 @@ void main() {
 
   setUpAll(() async {
     var port = await findUnusedPort();
-    webdev = await Process.start(
-        'pub', ['global', 'run', 'webdev', 'serve', 'example:$port']);
+    webdev =
+        await Process.start('pub', ['run', 'webdev', 'serve', 'example:$port']);
     webdev.stderr
         .transform(const Utf8Decoder())
         .transform(const LineSplitter())
-        .listen(print);
+        .listen(printOnFailure);
     await webdev.stdout
         .transform(const Utf8Decoder())
         .transform(const LineSplitter())
         .takeWhile((line) => !line.contains('$port'))
-        .map((line) {
-      print(line);
-      return line;
-    }).drain();
+        .drain();
     appUrl = 'http://localhost:$port/hello_world/';
     chrome = await Chrome.start([appUrl]);
     var connection = chrome.chromeConnection;

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -26,7 +26,10 @@ void main() {
     var port = await findUnusedPort();
     webdev = await Process.start(
         'pub', ['global', 'run', 'webdev', 'serve', 'example:$port']);
-    webdev.stderr.listen(print);
+    webdev.stderr
+        .transform(const Utf8Decoder())
+        .transform(const LineSplitter())
+        .listen(print);
     await webdev.stdout
         .transform(const Utf8Decoder())
         .transform(const LineSplitter())

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -24,20 +24,18 @@ void main() {
 
   setUpAll(() async {
     var port = await findUnusedPort();
-    webdev =
-        await Process.start('pub', ['run', 'webdev', 'serve', 'example:$port']);
+    await Process.run('pub', ['global', 'activate', 'webdev']);
+    webdev = await Process.start(
+        'pub', ['global', 'run', 'webdev', 'serve', 'example:$port']);
     webdev.stderr
         .transform(const Utf8Decoder())
         .transform(const LineSplitter())
-        .listen(print);
+        .listen(printOnFailure);
     await webdev.stdout
         .transform(const Utf8Decoder())
         .transform(const LineSplitter())
         .takeWhile((line) => !line.contains('$port'))
-        .map((line) {
-      print(line);
-      return line;
-    }).drain();
+        .drain();
     appUrl = 'http://localhost:$port/hello_world/';
     chrome = await Chrome.start([appUrl]);
     var connection = chrome.chromeConnection;

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -276,7 +276,8 @@ void main() {
           emitsThrough(predicate((Event event) =>
               event.kind == EventKind.kServiceExtensionAdded &&
               event.extensionRPC == extensionMethod)));
-      await tabConnection.runtime.evaluate("registerExtension('ext.foo.bar');");
+      await tabConnection.runtime
+          .evaluate("registerExtension('$extensionMethod');");
     });
 
     test('Timeline', () async {
@@ -320,12 +321,13 @@ void main() {
     test('_Service', () async {
       expect(service.streamListen('_Service'), completion(isSuccess));
       var stream = service.onEvent('_Service');
+      var extensionMethod = 'ext.foo.bar';
       expect(
           stream,
           emitsThrough(predicate((Event event) =>
               event.kind == EventKind.kServiceRegistered &&
-              event.extensionRPC == 'ext.foo.bar')));
-      await service.registerService('ext.foo.bar', null);
+              event.extensionRPC == extensionMethod)));
+      await service.registerService(extensionMethod, null);
     });
   });
 }


### PR DESCRIPTION
This allows posting of events through dart:debugger and registering of extensions, but we don't yet have a way of invoking extensions.