### PR TITLE
stub out the GC/Timeline streams

### DIFF
--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -241,6 +241,10 @@ require("dart_sdk").developer.invokeExtension("$method", JSON.stringify(${jsonEn
         // TODO: right now we only support the `ServiceExtensionAdded` event for
         // the Isolate stream.
         case 'Isolate':
+        // TODO: https://github.com/dart-lang/webdev/issues/168
+        case 'GC':
+        // TODO: https://github.com/dart-lang/webdev/issues/168
+        case 'Timeline':
         case '_Service':
           return StreamController<Event>.broadcast();
         case 'Stdout':

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -298,7 +298,7 @@ void main() {
     });
 
     test('GC', () async {
-      expect(() => service.streamListen('GC'), throwsUnimplementedError);
+      expect(service.streamListen('GC'), completion(isSuccess));
     });
 
     test('Isolate', () async {
@@ -315,7 +315,7 @@ void main() {
     });
 
     test('Timeline', () async {
-      expect(() => service.streamListen('Timeline'), throwsUnimplementedError);
+      expect(service.streamListen('Timeline'), completion(isSuccess));
     });
 
     test('Stdout', () async {


### PR DESCRIPTION
We need to have these return success for devtools to not complain, but we won't actually implement them yet. I filed https://github.com/dart-lang/webdev/issues/168 to track investigating/implementing them.