### PR TITLE
Refactor DebugService

### DIFF
--- a/dwds/lib/service.dart
+++ b/dwds/lib/service.dart
@@ -6,18 +6,17 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-// ignore: implementation_imports
-import 'package:dwds/src/chrome_proxy_service.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import '../chrome.dart';
-import '../utils.dart';
+import './src/chrome_proxy_service.dart';
+import './src/helpers.dart';
 
-void Function(WebSocketChannel, String) _handleNewConnection(
+void Function(WebSocketChannel, String) _createNewConnectionHandler(
     ChromeProxyService chromeProxyService) {
   return (webSocket, protocol) {
     var responseController = StreamController<Map<String, Object>>();
@@ -55,11 +54,11 @@ class DebugService {
   }
 
   static Future<DebugService> start(
-      String hostname, Chrome chrome, String url) async {
+      String hostname, ChromeConnection chromeConnection, String url) async {
     var chromeProxyService =
-        await ChromeProxyService.create(chrome.chromeConnection, url);
+        await ChromeProxyService.create(chromeConnection, url);
     var cascade = Cascade()
-        .add(webSocketHandler(_handleNewConnection(chromeProxyService)));
+        .add(webSocketHandler(_createNewConnectionHandler(chromeProxyService)));
 
     var port = await findUnusedPort();
 

--- a/dwds/lib/src/helpers.dart
+++ b/dwds/lib/src/helpers.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 IsolateRef toIsolateRef(Isolate isolate) => IsolateRef()
@@ -16,4 +18,22 @@ int _nextId = 0;
 String createId() {
   _nextId++;
   return '$_nextId';
+}
+
+/// Returns a port that is probably, but not definitely, not in use.
+///
+/// This has a built-in race condition: another process may bind this port at
+/// any time after this call has returned.
+Future<int> findUnusedPort() async {
+  int port;
+  ServerSocket socket;
+  try {
+    socket =
+        await ServerSocket.bind(InternetAddress.loopbackIPv6, 0, v6Only: true);
+  } on SocketException {
+    socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  }
+  port = socket.port;
+  await socket.close();
+  return port;
 }

--- a/dwds/tool/standalone_proxy.dart
+++ b/dwds/tool/standalone_proxy.dart
@@ -2,22 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:convert';
-
 import 'package:args/args.dart';
-import 'package:dwds/src/chrome_proxy_service.dart';
+import 'package:dwds/service.dart';
+import 'package:dwds/src/helpers.dart';
 import 'package:webdev/src/serve/chrome.dart';
-import 'package:webdev/src/serve/utils.dart';
-import 'package:vm_service_lib/vm_service_lib.dart';
-import 'package:shelf/shelf.dart' as shelf;
-import 'package:shelf/shelf_io.dart';
-import 'package:shelf_web_socket/shelf_web_socket.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
-
-/// Shared debugService for all clients.
-ChromeProxyService debugService;
-final serviceExtensionRegistry = ServiceExtensionRegistry();
 
 /// Sets up a web app with the debug service.
 ///
@@ -37,11 +25,6 @@ void main(List<String> args) async {
 
   var chrome = await Chrome.start([appUri]);
 
-  debugService =
-      await ChromeProxyService.create(chrome.chromeConnection, appUri);
-
-  var cascade = shelf.Cascade().add(webSocketHandler(handleNewConnection));
-
   var host = parsed['host'] as String;
   int port;
   if (parsed['port'] != null) {
@@ -50,26 +33,7 @@ void main(List<String> args) async {
     port = await findUnusedPort();
   }
 
-  await serve(cascade.handler, host, port);
+  await DebugService.start(host, chrome.chromeConnection, appUri);
+
   print('Debug service running at ws://$host:$port');
-}
-
-/// Creates a new VmServer instance for each client, reusing the global service
-/// object.
-void handleNewConnection(WebSocketChannel webSocket, String protocol) {
-  var responseController = StreamController<Map<String, Object>>();
-  webSocket.sink.addStream(responseController.stream.map(jsonEncode));
-  var inputStream = webSocket.stream.map((value) {
-    if (value is List<int>) {
-      value = utf8.decode(value as List<int>);
-    } else if (value is! String) {
-      throw StateError(
-          'Got value with unexpected type ${value.runtimeType} from web '
-          'socket, expected a List<int> or String.');
-    }
-    return jsonDecode(value as String) as Map<String, Object>;
-  });
-
-  VmServerConnection(inputStream, responseController.sink,
-      serviceExtensionRegistry, debugService);
 }


### PR DESCRIPTION
- Expose `DebugService` as the public API from `DWDS`
- Use the new public API from `WebDev`
- Add some additional log messages when spawning the service
- Update the `standalone_proxy` to use the new public API