### PR TITLE
populate Isolate.extensionRPCs on initial connection

### DIFF
--- a/dwds/example/hello_world/main.dart
+++ b/dwds/example/hello_world/main.dart
@@ -31,6 +31,10 @@ void main() async {
     });
   };
 
+  // Register one up front before the proxy connects, the isolate should still
+  // recognize this as an available extension.
+  registerExtension('ext.hello_world.existing', (_, __) {});
+
   window.console.debug('Page Ready');
 }
 

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -95,6 +95,17 @@ class ChromeProxyService implements VmServiceInterface {
     // library being the root one (the last library is the bootstrap lib).
     isolate.rootLib = isolate.libraries[isolate.libraries.length - 2];
 
+    // Find all the already registered extensions on the page and add them
+    // to extension rpcs
+    var extensionsResult =
+        await tabConnection.runtime.sendCommand('Runtime.evaluate', params: {
+      'expression': "require('dart_sdk').developer._extensions.keys.toList();",
+      'returnByValue': true
+    });
+    _handleErrorIfPresent(extensionsResult);
+    isolate.extensionRPCs.addAll(
+        (extensionsResult.result['result']['value'] as List).cast<String>());
+
     // TODO: What about `architectureBits`, `targetCPU`, `hostCPU` and `pid`?
     final vm = VM()
       ..isolates = [isolateRef]
@@ -129,8 +140,11 @@ class ChromeProxyService implements VmServiceInterface {
     // Validate the isolate id is correct, _getIsolate throws if not.
     if (isolateId != null) _getIsolate(isolateId);
     args ??= <String, String>{};
+    var stringArgs = args.map((k, v) => MapEntry(
+        k is String ? k : jsonEncode(k), v is String ? v : jsonEncode(v)));
     var expression = '''
-require("dart_sdk").developer.invokeExtension("$method", JSON.stringify(${jsonEncode(args)}));
+require("dart_sdk").developer.invokeExtension(
+    "$method", JSON.stringify(${jsonEncode(stringArgs)}));
 ''';
     var response =
         await _tabConnection.runtime.sendCommand('Runtime.evaluate', params: {

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -95,8 +95,8 @@ class ChromeProxyService implements VmServiceInterface {
     // library being the root one (the last library is the bootstrap lib).
     isolate.rootLib = isolate.libraries[isolate.libraries.length - 2];
 
-    // Find all the already registered extensions on the page and add them
-    // to extension rpcs
+    // Find all the previously registered extensions on the page and add them
+    // to `extensionRPCs`.
     var extensionsResult =
         await tabConnection.runtime.sendCommand('Runtime.evaluate', params: {
       'expression': "require('dart_sdk').developer._extensions.keys.toList();",

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -84,9 +84,23 @@ void main() {
       await tabConnection.runtime
           .evaluate('registerExtension("$serviceMethod");');
 
-      var result = await service
-          .callServiceExtension(serviceMethod, args: {'example': 'response'});
-      expect(result.json, {'example': 'response'});
+      // The non-string keys/values get auto json-encoded to match the vm
+      // behavior.
+      var args = {
+        'bool': true,
+        'list': [1, '2', 3],
+        'map': {'foo': 'bar'},
+        'num': 1.0,
+        'string': 'hello',
+        1: 2,
+        false: true,
+      };
+      var result =
+          await service.callServiceExtension(serviceMethod, args: args);
+      expect(
+          result.json,
+          args.map((k, v) => MapEntry(k is String ? k : jsonEncode(k),
+              v is String ? v : jsonEncode(v))));
     });
 
     test('failure', () async {
@@ -211,6 +225,7 @@ void main() {
             predicate((LibraryRef lib) => lib.uri == 'package:path/path.dart'),
             predicate((LibraryRef lib) => lib.uri == 'hello_world/main.dart'),
           ]));
+      expect(isolate.extensionRPCs, contains('ext.hello_world.existing'));
     });
 
     test('throws for invalid ids', () async {


### PR DESCRIPTION
This lights up all the buttons in the flutter inspector, and most of them even work :fireworks: :champagne: :tada: .

Also fixed up the `callServiceExtension` method to auto-serialize the keys and values if they aren't strings (The `ServiceExtensionHandler` only accepts a `Map<String, String>`, but the protocol allows any type of Map).