### PR TITLE
Enable getScripts, getVersion and getScripts => Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .dart_tool
 .packages
 pubspec.lock
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .dart_tool
 .packages
 pubspec.lock
+.vscode

--- a/dwds/lib/service.dart
+++ b/dwds/lib/service.dart
@@ -54,9 +54,12 @@ class DebugService {
   }
 
   static Future<DebugService> start(
-      String hostname, ChromeConnection chromeConnection, String url) async {
+      String hostname,
+      ChromeConnection chromeConnection,
+      Future<String> Function(String) assetHandler,
+      String url) async {
     var chromeProxyService =
-        await ChromeProxyService.create(chromeConnection, url);
+        await ChromeProxyService.create(chromeConnection, assetHandler, url);
     var cascade = Cascade()
         .add(webSocketHandler(_createNewConnectionHandler(chromeProxyService)));
 

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -29,10 +29,15 @@ class ChromeProxyService implements VmServiceInterface {
   /// The connection with the chrome debug service for the tab.
   final WipConnection _tabConnection;
 
+  /// A handler for application assets, e.g. Dart sources.
+  final Future<String> Function(String) _assetHandler;
+
   final _classes = <String, Class>{};
   final _libraries = <String, Future<Library>>{};
+  final _scriptRefs = <String, ScriptRef>{};
 
-  ChromeProxyService._(this._vm, this._isolate, this._tabConnection) {
+  ChromeProxyService._(
+      this._vm, this._isolate, this._tabConnection, this._assetHandler) {
     // Listen for `registerExtension` and `postEvent` calls.
     _tabConnection.runtime.onConsoleAPICalled.listen((ConsoleAPIEvent event) {
       if (event.type != 'debug') return;
@@ -57,8 +62,8 @@ class ChromeProxyService implements VmServiceInterface {
     });
   }
 
-  static Future<ChromeProxyService> create(
-      ChromeConnection chromeConnection, String tabUrl) async {
+  static Future<ChromeProxyService> create(ChromeConnection chromeConnection,
+      Future<String> Function(String) assetHandler, String tabUrl) async {
     var tab = await chromeConnection.getTab((tab) => tab.url == tabUrl);
     var id = createId();
     var isolate = Isolate()
@@ -114,7 +119,7 @@ class ChromeProxyService implements VmServiceInterface {
       ..startTime = DateTime.now().millisecondsSinceEpoch
       ..version = Platform.version;
 
-    return ChromeProxyService._(vm, isolate, tabConnection);
+    return ChromeProxyService._(vm, isolate, tabConnection, assetHandler);
   }
 
   @override
@@ -259,11 +264,15 @@ require("dart_sdk").developer.invokeExtension(
   @override
   Future getIsolate(String isolateId) async => _getIsolate(isolateId);
 
+  LibraryRef _getLibraryRef(String isolateId, String objectId) {
+    return _getIsolate(isolateId)
+        .libraries
+        .firstWhere((l) => l.id == objectId, orElse: () => null);
+  }
+
   Future<Library> _getLibrary(String isolateId, String objectId) async {
     return _libraries.putIfAbsent(objectId, () async {
-      var libraryRef = _getIsolate(isolateId)
-          .libraries
-          .firstWhere((l) => l.id == objectId, orElse: () => null);
+      var libraryRef = _getLibraryRef(isolateId, objectId);
       if (libraryRef == null) return null;
 
       // Fetch information about all the classes in this library.
@@ -321,6 +330,12 @@ ${_getLibrarySnippet(libraryRef.uri)}
           ..subclasses = [];
       }
 
+      var scriptRef = ScriptRef()
+        ..uri = libraryRef.uri
+        ..id = createId();
+
+      _scriptRefs[scriptRef.id] = scriptRef;
+
       return Library()
         ..id = libraryRef.id
         ..name = libraryRef.name
@@ -329,7 +344,7 @@ ${_getLibrarySnippet(libraryRef.uri)}
         ..debuggable = true
         ..dependencies = []
         ..functions = []
-        ..scripts = [ScriptRef()..uri = libraryRef.uri]
+        ..scripts = [scriptRef]
         ..variables = [];
     });
   }
@@ -341,6 +356,9 @@ ${_getLibrarySnippet(libraryRef.uri)}
     if (library != null) return library;
     var clazz = _classes[objectId];
     if (clazz != null) return clazz;
+    var scriptRef = _scriptRefs[objectId];
+    if (scriptRef != null) return await _getScript(isolateId, scriptRef);
+
     throw UnsupportedError(
         'Only libraries and classes are supported for getObject');
   }
@@ -349,6 +367,19 @@ ${_getLibrarySnippet(libraryRef.uri)}
   Future<ScriptList> getScripts(String isolateId) async {
     var scripts = await _getScripts(isolateId);
     return ScriptList()..scripts = scripts;
+  }
+
+  Future<Script> _getScript(String isolateId, ScriptRef scriptRef) async {
+    var libraryId = scriptRef.uri;
+    var scriptPath = libraryId.replaceAll('package:', 'packages/');
+    var script = await _assetHandler(scriptPath);
+    return Script()
+      ..library = _getLibraryRef(isolateId, libraryId)
+      ..id = scriptRef.id
+      ..uri = libraryId
+      // TODO(grouma) - Fill in to enable break points.
+      ..tokenPosTable = []
+      ..source = script;
   }
 
   Future<List<ScriptRef>> _getScripts(String isolateId) async {

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -287,6 +287,7 @@ require("dart_sdk").developer.invokeExtension(
   Future getIsolate(String isolateId) async => _getIsolate(isolateId);
 
   LibraryRef _getLibraryRef(String isolateId, String objectId) {
+    // TODO(grouma) - We should get a set of LibraryRefs to improve performance.
     return _getIsolate(isolateId)
         .libraries
         .firstWhere((l) => l.id == objectId, orElse: () => null);
@@ -352,6 +353,8 @@ ${_getLibrarySnippet(libraryRef.uri)}
           ..subclasses = [];
       }
 
+      // TODO(grouma) - This currently does not support part files.
+      // Figure out how to support them.
       var scriptRef = ScriptRef()
         ..uri = libraryRef.uri
         ..id = createId();

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -6,6 +6,7 @@ description: >-
 environment:
   sdk: ^2.1.0
 dependencies:
+  pub_semver: ^1.4.2
   source_maps: ^0.10.0
   vm_service_lib: 3.14.3-dev.3
   webkit_inspection_protocol: ^0.4.0

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -297,6 +297,8 @@ void main() {
     var scripts = await service.getScripts(isolateId);
     expect(scripts, isNotNull);
     expect(scripts.scripts.length, greaterThan(0));
+    // Test for a known script
+    expect(scripts.scripts.map((s) => s.uri), contains(endsWith('path.dart')));
   });
 
   test('clearVMTimeline', () {

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -279,6 +279,7 @@ void main() {
 
     test('Scripts', () async {
       var scripts = await service.getScripts(isolate.id);
+      assert(scripts.scripts.isNotEmpty);
       for (var scriptRef in scripts.scripts) {
         var script =
             await service.getObject(isolate.id, scriptRef.id) as Script;

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -277,7 +277,7 @@ void main() {
           ]));
     });
 
-    test('getScript', () async {
+    test('Scripts', () async {
       var scripts = await service.getScripts(isolate.id);
       for (var scriptRef in scripts.scripts) {
         var script =

--- a/webdev/lib/src/serve/handlers/asset_handler.dart
+++ b/webdev/lib/src/serve/handlers/asset_handler.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:shelf/shelf.dart';
 import 'package:shelf_proxy/shelf_proxy.dart';
 
@@ -11,14 +13,24 @@ import 'package:shelf_proxy/shelf_proxy.dart';
 class AssetHandler {
   final int _daemonPort;
   final String _target;
+  final int _applicationPort;
+  final String _applicationHost;
 
   Handler _handler;
 
-  AssetHandler(
-    this._daemonPort,
-    this._target,
-  );
+  AssetHandler(this._daemonPort, this._target, this._applicationHost,
+      this._applicationPort);
 
   Handler get handler =>
       _handler ??= proxyHandler('http://localhost:$_daemonPort/$_target/');
+
+  /// Returns the asset from a relative [path].
+  ///
+  /// For example the path `main.dart` should return the raw text value of that
+  /// corresponding file.
+  Future<String> getRelativeAsset(String path) async {
+    var response = await handler(Request(
+        'GET', Uri.parse('http://$_applicationHost:$_applicationPort/$path')));
+    return await response.readAsString();
+  }
 }

--- a/webdev/lib/src/serve/handlers/dev_handler.dart
+++ b/webdev/lib/src/serve/handlers/dev_handler.dart
@@ -15,6 +15,7 @@ import 'package:sse/server/sse_handler.dart';
 import '../data/devtools_request.dart';
 import '../data/serializers.dart' as webdev;
 import '../debugger/devtools.dart';
+import '../handlers/asset_handler.dart';
 
 /// SSE handler to enable development features like hot reload and
 /// opening DevTools.
@@ -23,8 +24,10 @@ class DevHandler {
   final SseHandler _sseHandler = SseHandler(Uri.parse(r'/$sseHandler'));
   final _connections = Set<SseConnection>();
   final Future<DevTools> _devtoolsFuture;
+  final AssetHandler _assetHandler;
 
-  DevHandler(Stream<BuildResult> buildResults, this._devtoolsFuture) {
+  DevHandler(Stream<BuildResult> buildResults, this._devtoolsFuture,
+      this._assetHandler) {
     _sub = buildResults.listen(_emitBuildResults);
     _listen();
   }
@@ -58,6 +61,7 @@ class DevHandler {
           debugService = await DebugService.start(
             devTools.hostname,
             chrome.chromeConnection,
+            _assetHandler.getRelativeAsset,
             message.url,
           );
           print('Debug service listening on '

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -48,7 +48,8 @@ class WebDevServer {
     Stream<BuildResults> buildResults,
     Future<DevTools> devtoolsFuture,
   ) async {
-    var assetHandler = AssetHandler(options.daemonPort, options.target);
+    var assetHandler = AssetHandler(options.daemonPort, options.target,
+        options.configuration.hostname, options.port);
     var cascade = Cascade();
     var pipeline = const Pipeline();
 
@@ -64,6 +65,7 @@ class WebDevServer {
       buildResults.asyncMap<BuildResult>((results) => results.results
           .firstWhere((result) => result.target == options.target)),
       devtoolsFuture,
+      assetHandler,
     );
     cascade = cascade.add(devHandler.handler).add(assetHandler.handler);
 


### PR DESCRIPTION
- Implement `getVersion()`
- Implement `getScripts()`
- Implement `getObject` => Script (with source)
- Update `AssetHandler` to return an asset from a relative path
- Plumb `AssetHandler` through to `DevHandler`
- Add corresponding tests