### PR TITLE
Support the `Inspect` events from the `Debug` stream.

### DIFF
--- a/dwds/example/hello_world/main.dart
+++ b/dwds/example/hello_world/main.dart
@@ -9,8 +9,14 @@ import 'dart:js';
 
 import 'package:path/path.dart' as p;
 
+final myInstance = MyTestClass();
+
 void main() async {
   print(p.join('Hello', 'World'));
+
+  context['inspectInstance'] = () {
+    inspect(myInstance);
+  };
 
   context['postEvent'] = (String kind) {
     postEvent(kind, {'example': 'data'});

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -64,7 +64,7 @@ class ChromeProxyService implements VmServiceInterface {
             ..id = event.args[1].objectId
             ..classRef = null;
           _streamNotify(
-              '_Debug',
+              'Debug',
               Event()
                 ..kind = EventKind.kInspect
                 ..inspectee = inspectee

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -62,7 +62,9 @@ class ChromeProxyService implements VmServiceInterface {
           var inspectee = InstanceRef()
             ..kind = InstanceKind.kPlainInstance
             ..id = event.args[1].objectId
-            ..classRef = null;
+            // TODO: A real classref? we need something here so it can properly
+            // serialize, but it isn't used by the widget inspector.
+            ..classRef = ClassRef();
           _streamNotify(
               'Debug',
               Event()

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -390,10 +390,6 @@ void main() {
         eventStream = service.onEvent('Debug');
       });
 
-      tearDown(() async {
-        await service.streamCancel('Debug');
-      });
-
       test('basic Pause/Resume', () async {
         await tabConnection.debugger.pause();
         // Need to actually execute some JS code for the pause to take effect.
@@ -418,9 +414,9 @@ void main() {
                     (e) => e.inspectee,
                     'inspectee',
                     const TypeMatcher<InstanceRef>()
-                        .having((instance) => instance.id, 'id', isNotNull))
-                .having((instance) => instance.kind, 'kind',
-                    InstanceKind.kPlainInstance)));
+                        .having((instance) => instance.id, 'id', isNotNull)
+                        .having((instance) => instance.kind, 'inspectee.kind',
+                            InstanceKind.kPlainInstance))));
         await tabConnection.runtime.evaluate('inspectInstance()');
       });
     });


### PR DESCRIPTION
~This doesn't fully appear to get things working yet (the goal is to have it so if you inspect an element in the app it would select it in devtools), but the basic events should now be working and some more investigation is needed.~

This now selects the correct object in the widget inspector when you inspect in the app.