### PR TITLE
Make local testing easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
   - "wget http://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip"
   - unzip chromedriver_linux64.zip
   - "export PATH=$PATH:$PWD"
-  - "chromedriver --port=4444 --url-base=wd/hub &"
 
 jobs:
   include:

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -16,18 +16,25 @@ import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:webdriver/io.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-// To run locally first run:
-//  chromedriver --port=4444 --url-base=wd/hub --verbose
 void main() {
   String appUrl;
   ChromeProxyService service;
   WipConnection tabConnection;
   Process webdev;
   WebDriver webDriver;
+  Process chromeDriver;
   int port;
 
   setUpAll(() async {
     port = await findUnusedPort();
+    try {
+      chromeDriver = await Process.start(
+          'chromedriver', ['--port=4444', '--url-base=wd/hub']);
+    } catch (e) {
+      throw StateError(
+          'Could not start ChromeDriver. Is it installed?\nError: $e');
+    }
+
     await Process.run('pub', ['global', 'activate', 'webdev']);
     webdev = await Process.start(
         'pub', ['global', 'run', 'webdev', 'serve', 'example:$port']);
@@ -76,6 +83,7 @@ void main() {
     webdev.kill();
     await webdev.exitCode;
     await webDriver?.quit();
+    chromeDriver.kill();
   });
 
   test('addBreakPoint', () {

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -12,4 +12,3 @@ travis:
     - wget http://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip
     - unzip chromedriver_linux64.zip
     - export PATH=$PATH:$PWD
-    - chromedriver --port=4444 --url-base=wd/hub &

--- a/webdev/test/serve/injected/devtools_test.dart
+++ b/webdev/test/serve/injected/devtools_test.dart
@@ -12,8 +12,6 @@ import 'package:webdriver/io.dart';
 
 import 'injected_fixture.dart';
 
-// To run locally first run:
-//  chromedriver --port=4444 --url-base=wd/hub --verbose
 void main() {
   InjectedFixture fixture;
   Process chromeDriver;

--- a/webdev/test/serve/injected/devtools_test.dart
+++ b/webdev/test/serve/injected/devtools_test.dart
@@ -5,6 +5,7 @@
 @Timeout(Duration(minutes: 5))
 @Tags(['requires-edge-sdk'])
 import 'dart:async';
+import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:webdriver/io.dart';
@@ -15,6 +16,21 @@ import 'injected_fixture.dart';
 //  chromedriver --port=4444 --url-base=wd/hub --verbose
 void main() {
   InjectedFixture fixture;
+  Process chromeDriver;
+
+  setUpAll(() async {
+    try {
+      chromeDriver = await Process.start(
+          'chromedriver', ['--port=4444', '--url-base=wd/hub']);
+    } catch (e) {
+      throw StateError(
+          'Could not start ChromeDriver. Is it installed?\nError: $e');
+    }
+  });
+
+  tearDownAll(() {
+    chromeDriver.kill();
+  });
 
   group('Injected client', () {
     setUp(() async {

--- a/webdev/test/serve/injected/reload_test.dart
+++ b/webdev/test/serve/injected/reload_test.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Timeout(Duration(minutes: 5))
+import 'dart:io';
+
 import 'package:test/test.dart';
 
 import 'injected_fixture.dart';
@@ -11,6 +13,21 @@ import 'injected_fixture.dart';
 //  chromedriver --port=4444 --url-base=wd/hub --verbose
 void main() {
   InjectedFixture fixture;
+  Process chromeDriver;
+
+  setUpAll(() async {
+    try {
+      chromeDriver = await Process.start(
+          'chromedriver', ['--port=4444', '--url-base=wd/hub']);
+    } catch (e) {
+      throw StateError(
+          'Could not start ChromeDriver. Is it installed?\nError: $e');
+    }
+  });
+
+  tearDownAll(() {
+    chromeDriver.kill();
+  });
 
   group('Injected client', () {
     setUp(() async {

--- a/webdev/test/serve/injected/reload_test.dart
+++ b/webdev/test/serve/injected/reload_test.dart
@@ -9,8 +9,6 @@ import 'package:test/test.dart';
 
 import 'injected_fixture.dart';
 
-// To run locally first run:
-//  chromedriver --port=4444 --url-base=wd/hub --verbose
 void main() {
   InjectedFixture fixture;
   Process chromeDriver;


### PR DESCRIPTION
Start `ChromeDriver` as a part of the test and throw with a helpful error if it isn't found.

Closes https://github.com/dart-lang/webdev/issues/187