### PR TITLE
Consistent logging

### DIFF
--- a/webdev/lib/src/serve/debugger/devtools.dart
+++ b/webdev/lib/src/serve/debugger/devtools.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart';
@@ -55,7 +56,8 @@ class DevTools {
 
     var server = await serve(handler, hostname, await findUnusedPort());
 
-    print('Serving DevTools at http://${server.address.host}:${server.port}');
+    colorLog(Level.INFO,
+        'Serving DevTools at http://${server.address.host}:${server.port}');
     return DevTools._(chrome, server.address.host, server.port, server);
   }
 }

--- a/webdev/lib/src/serve/handlers/dev_handler.dart
+++ b/webdev/lib/src/serve/handlers/dev_handler.dart
@@ -8,10 +8,12 @@ import 'dart:convert';
 import 'package:build_daemon/data/build_status.dart';
 import 'package:build_daemon/data/serializers.dart';
 import 'package:dwds/service.dart';
+import 'package:logging/logging.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart';
 import 'package:sse/server/sse_handler.dart';
 
+import '../../serve/utils.dart';
 import '../data/devtools_request.dart';
 import '../data/serializers.dart' as webdev;
 import '../debugger/devtools.dart';
@@ -64,8 +66,10 @@ class DevHandler {
             _assetHandler.getRelativeAsset,
             message.url,
           );
-          print('Debug service listening on '
-              'ws://${debugService.hostname}:${debugService.port}');
+          colorLog(
+              Level.INFO,
+              'Debug service listening on '
+              'ws://${debugService.hostname}:${debugService.port}\n');
         }
         await chrome.chromeConnection
             // Chrome protocol for spawning a new tab.
@@ -76,8 +80,10 @@ class DevHandler {
     unawaited(connection.onClose.then((_) async {
       if (debugService != null) {
         await debugService.close();
-        print('Stopped debug service on '
-            'ws://${debugService.hostname}:${debugService.port}');
+        colorLog(
+            Level.INFO,
+            'Stopped debug service on '
+            'ws://${debugService.hostname}:${debugService.port}\n');
         debugService = null;
       }
       _connections.remove(connection);

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -6,10 +6,12 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:build_daemon/data/build_status.dart';
+import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 
 import '../command/configuration.dart';
+import '../serve/utils.dart';
 import 'debugger/devtools.dart';
 import 'handlers/asset_handler.dart';
 import 'handlers/dev_handler.dart';
@@ -72,8 +74,10 @@ class WebDevServer {
     var server =
         await HttpServer.bind(options.configuration.hostname, options.port);
     shelf_io.serveRequests(server, pipeline.addHandler(cascade.handler));
-    print('Serving `${options.target}` on '
-        'http://${options.configuration.hostname}:${options.port}');
+    colorLog(
+        Level.INFO,
+        'Serving `${options.target}` on '
+        'http://${options.configuration.hostname}:${options.port}\n');
     return WebDevServer._(server, devHandler);
   }
 }


### PR DESCRIPTION
WebDev called `print` directly a handful of times. For a consistent logging experience we should color the log with a level. 