### PR TITLE
Isolate refactor

### DIFF
--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -174,12 +174,30 @@ class ChromeProxyService implements VmServiceInterface {
 
     _vm.isolates.add(isolateRef);
     _isolate = isolate;
+
+    _streamNotify(
+        'Isolate',
+        Event()
+          ..kind = EventKind.kIsolateStart
+          ..isolate = isolateRef);
+    _streamNotify(
+        'Isolate',
+        Event()
+          ..kind = EventKind.kIsolateRunnable
+          ..isolate = isolateRef);
   }
 
   /// Should be called when there is a hot restart or full page refresh.
   ///
   /// Clears out [_isolate] and all related cached information.
   void destroyIsolate() {
+    _streamNotify(
+        'Isolate',
+        Event()
+          ..kind = EventKind.kIsolateExit
+          ..isolate = toIsolateRef(_isolate));
+    _vm.isolates.removeWhere((ref) => ref.id == _isolate.id);
+
     _isolate = null;
     _classes.clear();
     _scriptRefs.clear();

--- a/webdev/lib/src/serve/handlers/dev_handler.dart
+++ b/webdev/lib/src/serve/handlers/dev_handler.dart
@@ -127,9 +127,11 @@ class _WebdevClient {
         (request) => requestController.sink
             .add(jsonDecode(request) as Map<String, dynamic>));
     client.registerServiceCallback('hotRestart', (request) async {
+      debugService.chromeProxyService.destroyIsolate();
       await debugService.chromeProxyService.tabConnection.runtime.sendCommand(
           'Runtime.evaluate',
           params: {'expression': r'$dartHotRestart();', 'awaitPromise': true});
+      unawaited(debugService.chromeProxyService.createIsolate());
       return {'result': Success().toJson()};
     });
     await client.registerService('hotRestart', 'WebDev');

--- a/webdev/test/serve/injected/devtools_test.dart
+++ b/webdev/test/serve/injected/devtools_test.dart
@@ -79,6 +79,7 @@ void main() {
 
     test('destroys and recreates the isolate during a hot restart', () async {
       var client = await vmServiceConnect('localhost', debugPort);
+      await client.streamListen('Isolate');
       await fixture.changeInput();
 
       var eventsDone = expectLater(
@@ -92,8 +93,8 @@ void main() {
 
       expect(await client.callServiceExtension('hotRestart'),
           const TypeMatcher<Success>());
-      await eventsDone;
 
+      await eventsDone;
       await fixture.webdev.kill();
     });
   }, tags: ['webdriver']);

--- a/webdev/test/serve/injected/devtools_test.dart
+++ b/webdev/test/serve/injected/devtools_test.dart
@@ -76,5 +76,25 @@ void main() {
       expect(source, contains('Gary is awesome!'));
       await fixture.webdev.kill();
     });
+
+    test('destroys and recreates the isolate during a hot restart', () async {
+      var client = await vmServiceConnect('localhost', debugPort);
+      await fixture.changeInput();
+
+      var eventsDone = expectLater(
+          client.onIsolateEvent,
+          emitsThrough(emitsInOrder([
+            predicate((Event event) => event.kind == EventKind.kIsolateExit),
+            predicate((Event event) => event.kind == EventKind.kIsolateStart),
+            predicate(
+                (Event event) => event.kind == EventKind.kIsolateRunnable),
+          ])));
+
+      expect(await client.callServiceExtension('hotRestart'),
+          const TypeMatcher<Success>());
+      await eventsDone;
+
+      await fixture.webdev.kill();
+    });
   }, tags: ['webdriver']);
 }


### PR DESCRIPTION
Part of https://github.com/dart-lang/webdev/issues/202

- Adds `createIsolate` and `destroyIsolate` methods to `ChromeProxyService`.
- Update webdev to invoke these before/after a hot restart