### PR TITLE
Fix multiline messages

### DIFF
--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -101,7 +101,7 @@ Future<DevTools> _startDevTools(
   if (configuration.debug) {
     var devTools = await DevTools.start(configuration.hostname);
     logHandler(Level.INFO,
-        'Serving DevTools at http://${devTools.hostname}:${devTools.port}');
+        'Serving DevTools at http://${devTools.hostname}:${devTools.port}\n');
     return devTools;
   }
   return null;

--- a/webdev/lib/src/serve/utils.dart
+++ b/webdev/lib/src/serve/utils.dart
@@ -40,11 +40,12 @@ void colorLog(Level level, String message, {bool verbose}) {
   } else {
     color = red;
   }
-  var multiline = message.contains('\n');
+  var multiline = message.contains('\n') && !message.endsWith('\n');
   var eraseLine = verbose ? '' : '\x1b[2K\r';
   var colorLevel = color.wrap('[$level]');
 
   stdout.write('$eraseLine$colorLevel $message');
+
   // Prevent multilines and severe messages from being erased.
   if (level > Level.INFO || verbose || multiline) {
     stdout.writeln('');


### PR DESCRIPTION
Messages that end in a new line are not erased. However, messages that contain multiple lines and not a trailing new line should not be erased. This fixes the double new line logging weirdness. Also add a new line to the devtools message so that sticks around.