### PR TITLE
Updated logs

### DIFF
--- a/webdev/lib/src/command/daemon_command.dart
+++ b/webdev/lib/src/command/daemon_command.dart
@@ -12,6 +12,7 @@ import '../daemon/app_domain.dart';
 import '../daemon/daemon.dart';
 import '../daemon/daemon_domain.dart';
 import '../serve/dev_workflow.dart';
+import '../serve/logging.dart';
 import '../serve/utils.dart';
 import 'configuration.dart';
 import 'shared.dart';
@@ -50,11 +51,10 @@ class DaemonCommand extends Command<int> {
   Future<int> run() async {
     var daemon = Daemon(_stdinCommandStream, _stdoutCommandResponse);
     var daemonDomain = DaemonDomain(daemon);
-    // Override the default logHandler.
-    logHandler = (level, message) {
+    setLogHandler((level, message, {verbose}) {
       daemonDomain.sendEvent(
           'daemon.logMessage', {'level': '$level', 'message': message});
-    };
+    });
     daemon.registerDomain(daemonDomain);
     var configuration = Configuration(launchInChrome: true, debug: true);
     var pubspecLock = await readPubspecLock(configuration);

--- a/webdev/lib/src/command/daemon_command.dart
+++ b/webdev/lib/src/command/daemon_command.dart
@@ -50,16 +50,21 @@ class DaemonCommand extends Command<int> {
   Future<int> run() async {
     var daemon = Daemon(_stdinCommandStream, _stdoutCommandResponse);
     var daemonDomain = DaemonDomain(daemon);
+    // Override the default logHandler.
+    logHandler = (level, message) {
+      daemonDomain.sendEvent(
+          'daemon.logMessage', {'level': '$level', 'message': message});
+    };
     daemon.registerDomain(daemonDomain);
     var configuration = Configuration(launchInChrome: true, debug: true);
     var pubspecLock = await readPubspecLock(configuration);
     var buildOptions = buildRunnerArgs(pubspecLock, configuration);
     var port = await findUnusedPort();
     var workflow = await DevWorkflow.start(
-        configuration, buildOptions, {'web': port}, (level, message) {
-      daemonDomain.sendEvent(
-          'daemon.logMessage', {'level': '$level', 'message': message});
-    });
+      configuration,
+      buildOptions,
+      {'web': port},
+    );
     daemon.registerDomain(AppDomain(daemon, workflow.serverManager));
     await daemon.onExit;
     await workflow.shutDown();

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -9,7 +9,6 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 
 import '../serve/dev_workflow.dart';
-import '../serve/utils.dart';
 import 'configuration.dart';
 import 'shared.dart';
 
@@ -101,8 +100,8 @@ class ServeCommand extends Command<int> {
         .where((arg) => arg.contains(':') || !arg.startsWith('--'))
         .toList();
     var targetPorts = _parseDirectoryArgs(directoryArgs);
-    var workflow = await DevWorkflow.start(
-        configuration, buildOptions, targetPorts, colorLog);
+    var workflow =
+        await DevWorkflow.start(configuration, buildOptions, targetPorts);
     await workflow.done;
     return 0;
   }

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -9,6 +9,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 
 import '../serve/dev_workflow.dart';
+import '../serve/utils.dart';
 import 'configuration.dart';
 import 'shared.dart';
 
@@ -89,6 +90,8 @@ class ServeCommand extends Command<int> {
   Future<int> run() async {
     Configuration configuration;
     configuration = Configuration.fromArgs(argResults);
+    // Globally trigger verbose logs.
+    verboseLogs = configuration.verbose;
     var pubspecLock = await readPubspecLock(configuration);
     // Forward remaining arguments as Build Options to the Daemon.
     // This isn't documented. Should it be advertised?

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -9,7 +9,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 
 import '../serve/dev_workflow.dart';
-import '../serve/utils.dart';
+import '../serve/logging.dart';
 import 'configuration.dart';
 import 'shared.dart';
 
@@ -91,7 +91,7 @@ class ServeCommand extends Command<int> {
     Configuration configuration;
     configuration = Configuration.fromArgs(argResults);
     // Globally trigger verbose logs.
-    verboseLogs = configuration.verbose;
+    setVerbosity(configuration.verbose);
     var pubspecLock = await readPubspecLock(configuration);
     // Forward remaining arguments as Build Options to the Daemon.
     // This isn't documented. Should it be advertised?

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -13,6 +13,7 @@ import '../command/configuration.dart';
 import '../serve/chrome.dart';
 import '../serve/daemon_client.dart';
 import '../serve/debugger/devtools.dart';
+import '../serve/logging.dart';
 import '../serve/server_manager.dart';
 import '../serve/utils.dart';
 import '../serve/webdev_server.dart';

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -20,7 +20,6 @@ import '../serve/webdev_server.dart';
 Future<BuildDaemonClient> _startBuildDaemon(
   String workingDirectory,
   List<String> buildOptions,
-  void Function(Level level, String message) logHandler,
 ) async {
   logHandler(Level.INFO, 'Connecting to the build daemon...');
   try {
@@ -68,7 +67,6 @@ Future<ServerManager> _startServerManager(
   String workingDirectory,
   BuildDaemonClient client,
   DevTools devTools,
-  void Function(Level level, String message) logHandler,
 ) async {
   var assetPort = daemonPort(workingDirectory);
   var serverOptions = Set<ServerOptions>();
@@ -96,7 +94,6 @@ Future<ServerManager> _startServerManager(
 
 Future<DevTools> _startDevTools(
   Configuration configuration,
-  void Function(Level level, String message) logHandler,
 ) async {
   if (configuration.debug) {
     var devTools = await DevTools.start(configuration.hostname);
@@ -132,14 +129,12 @@ class DevWorkflow {
     Configuration configuration,
     List<String> buildOptions,
     Map<String, int> targetPorts,
-    void Function(Level level, String message) logHandler,
   ) async {
     var workingDirectory = Directory.current.path;
-    var client =
-        await _startBuildDaemon(workingDirectory, buildOptions, logHandler);
-    var devTools = await _startDevTools(configuration, logHandler);
-    var serverManager = await _startServerManager(configuration, targetPorts,
-        workingDirectory, client, devTools, logHandler);
+    var client = await _startBuildDaemon(workingDirectory, buildOptions);
+    var devTools = await _startDevTools(configuration);
+    var serverManager = await _startServerManager(
+        configuration, targetPorts, workingDirectory, client, devTools);
     var chrome = await _startChrome(configuration, serverManager, client);
     logHandler(Level.INFO, 'Registering build targets...');
     for (var target in targetPorts.keys) {

--- a/webdev/lib/src/serve/handlers/dev_handler.dart
+++ b/webdev/lib/src/serve/handlers/dev_handler.dart
@@ -15,7 +15,7 @@ import 'package:sse/server/sse_handler.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../../serve/chrome.dart';
-import '../../serve/utils.dart';
+import '../../serve/logging.dart';
 import '../data/connect_request.dart';
 import '../data/devtools_request.dart';
 import '../data/serializers.dart' as webdev;

--- a/webdev/lib/src/serve/handlers/dev_handler.dart
+++ b/webdev/lib/src/serve/handlers/dev_handler.dart
@@ -35,11 +35,12 @@ class DevHandler {
   final String _hostname;
   final _connectedApps = StreamController<ConnectRequest>.broadcast();
   final _servicesByAppId = <String, Future<AppDebugServices>>{};
+  final Stream<BuildResult> buildResults;
 
   Stream<ConnectRequest> get connectedApps => _connectedApps.stream;
 
-  DevHandler(Stream<BuildResult> buildResults, this._devTools,
-      this._assetHandler, this._hostname) {
+  DevHandler(
+      this.buildResults, this._devTools, this._assetHandler, this._hostname) {
     _sub = buildResults.listen(_emitBuildResults);
     _listen();
   }
@@ -166,7 +167,7 @@ class DevHandler {
     var chrome = await Chrome.connectedInstance;
     var debugService =
         await startDebugService(chrome.chromeConnection, instanceId);
-    colorLog(
+    logHandler(
         Level.INFO,
         'Debug service listening on '
         'ws://${debugService.hostname}:${debugService.port}\n');
@@ -178,7 +179,7 @@ class DevHandler {
         debugService.chromeProxyService.tabConnection.onClose.first.then((_) {
       appServices.close();
       _servicesByAppId.remove(appId);
-      colorLog(
+      logHandler(
           Level.INFO,
           'Stopped debug service on '
           'ws://${debugService.hostname}:${debugService.port}\n');

--- a/webdev/lib/src/serve/logging.dart
+++ b/webdev/lib/src/serve/logging.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:io/ansi.dart';
+import 'package:logging/logging.dart';
+
+var _verbose = false;
+
+/// Sets the verbosity of the current [logHandler].
+void setVerbosity(bool verbose) => _verbose = verbose;
+
+void Function(Level, String) _logHandler =
+    (level, message) => _colorLog(level, message, verbose: _verbose);
+
+void Function(Level level, String message) get logHandler => _logHandler;
+
+void setLogHandler(void Function(Level, String, {bool verbose}) newHandler) {
+  _logHandler =
+      (level, message) => newHandler(level, message, verbose: _verbose);
+}
+
+/// Colors the message and writes it to stdout.
+///
+/// If the [level] is not contained in the message, one will be inserted.
+void _colorLog(Level level, String message, {bool verbose}) {
+  verbose ??= false;
+  AnsiCode color;
+  if (level < Level.WARNING) {
+    color = cyan;
+  } else if (level < Level.SEVERE) {
+    color = yellow;
+  } else {
+    color = red;
+  }
+  var multiline = message.contains('\n') && !message.endsWith('\n');
+  var eraseLine = _verbose ? '' : '\x1b[2K\r';
+  var colorLevel = color.wrap('[$level]');
+
+  stdout.write('$eraseLine$colorLevel $message');
+
+  // Prevent multilines and severe messages from being erased.
+  if (level > Level.INFO || verbose || multiline) {
+    stdout.writeln('');
+  }
+}

--- a/webdev/lib/src/serve/utils.dart
+++ b/webdev/lib/src/serve/utils.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:build_daemon/data/server_log.dart';
-import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
 
 /// Returns a port that is probably, but not definitely, not in use.
@@ -26,34 +25,6 @@ Future<int> findUnusedPort() async {
   await socket.close();
   return port;
 }
-
-var verboseLogs = false;
-
-/// Colors the message and writes it to stdout.
-///
-/// If the [level] is not contained in the message, one will be inserted.
-void colorLog(Level level, String message) {
-  AnsiCode color;
-  if (level < Level.WARNING) {
-    color = cyan;
-  } else if (level < Level.SEVERE) {
-    color = yellow;
-  } else {
-    color = red;
-  }
-  var multiline = message.contains('\n') && !message.endsWith('\n');
-  var eraseLine = verboseLogs ? '' : '\x1b[2K\r';
-  var colorLevel = color.wrap('[$level]');
-
-  stdout.write('$eraseLine$colorLevel $message');
-
-  // Prevent multilines and severe messages from being erased.
-  if (level > Level.INFO || verboseLogs || multiline) {
-    stdout.writeln('');
-  }
-}
-
-void Function(Level level, String message) logHandler = colorLog;
 
 String trimLevel(Level level, String message) => message.startsWith('[$level]')
     ? message.replaceFirst('[$level]', '').trimLeft()

--- a/webdev/lib/src/serve/utils.dart
+++ b/webdev/lib/src/serve/utils.dart
@@ -27,11 +27,12 @@ Future<int> findUnusedPort() async {
   return port;
 }
 
+var verboseLogs = false;
+
 /// Colors the message and writes it to stdout.
 ///
 /// If the [level] is not contained in the message, one will be inserted.
-void colorLog(Level level, String message, {bool verbose}) {
-  verbose ??= false;
+void colorLog(Level level, String message) {
   AnsiCode color;
   if (level < Level.WARNING) {
     color = cyan;
@@ -41,13 +42,13 @@ void colorLog(Level level, String message, {bool verbose}) {
     color = red;
   }
   var multiline = message.contains('\n') && !message.endsWith('\n');
-  var eraseLine = verbose ? '' : '\x1b[2K\r';
+  var eraseLine = verboseLogs ? '' : '\x1b[2K\r';
   var colorLevel = color.wrap('[$level]');
 
   stdout.write('$eraseLine$colorLevel $message');
 
   // Prevent multilines and severe messages from being erased.
-  if (level > Level.INFO || verbose || multiline) {
+  if (level > Level.INFO || verboseLogs || multiline) {
     stdout.writeln('');
   }
 }

--- a/webdev/lib/src/serve/utils.dart
+++ b/webdev/lib/src/serve/utils.dart
@@ -52,6 +52,8 @@ void colorLog(Level level, String message, {bool verbose}) {
   }
 }
 
+void Function(Level level, String message) logHandler = colorLog;
+
 String trimLevel(Level level, String message) => message.startsWith('[$level]')
     ? message.replaceFirst('[$level]', '').trimLeft()
     : message;

--- a/webdev/test/daemon/app_domain_test.dart
+++ b/webdev/test/daemon/app_domain_test.dart
@@ -96,7 +96,7 @@ void main() {
                   '"message":"Performing hot restart..."'),
               startsWith(
                   '[{"event":"app.progress","params":{"appId":"$appId","id":"1",'
-                  '"finished":true')
+                  '"finished":true'),
             ])));
         await exitWebdev(webdev);
       });

--- a/webdev/test/daemon/app_domain_test.dart
+++ b/webdev/test/daemon/app_domain_test.dart
@@ -96,7 +96,7 @@ void main() {
                   '"message":"Performing hot restart..."'),
               startsWith(
                   '[{"event":"app.progress","params":{"appId":"$appId","id":"1",'
-                  '"finished":true'),
+                  '"finished":true')
             ])));
         await exitWebdev(webdev);
       });


### PR DESCRIPTION
- No longer plumb the `logHandler` throughout `DevWorkflow` simply make it globally available.
- Override the `logHandler` in the `Daemon` command.
  - This fixes an issue where some logs were not captured from the `DevHandler`.
- Actually enable verbose logs in `webdev serve`
- Add additional progress logs for the daemon command

Closes https://github.com/dart-lang/webdev/issues/219 
Closes https://github.com/dart-lang/webdev/issues/220