### PR TITLE
Support latest build_daemon and build_runner

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,5 +5,13 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dev_dependencies:
-  build_runner: '>=1.2.8 <2.0.0'
+  build_runner: '>=1.3.0 <2.0.0'
   build_web_compilers: ^1.0.0
+
+dependency_overrides:
+  build_runner:
+    path: /usr/local/google/home/grouma/Projects/build/build_runner
+  build_runner_core:
+    path: /usr/local/google/home/grouma/Projects/build/build_runner_core
+  build_daemon:
+    path: /usr/local/google/home/grouma/Projects/build/build_daemon

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,11 +7,3 @@ environment:
 dev_dependencies:
   build_runner: '>=1.3.0 <2.0.0'
   build_web_compilers: ^1.0.0
-
-dependency_overrides:
-  build_runner:
-    path: /usr/local/google/home/grouma/Projects/build/build_runner
-  build_runner_core:
-    path: /usr/local/google/home/grouma/Projects/build/build_runner_core
-  build_daemon:
-    path: /usr/local/google/home/grouma/Projects/build/build_daemon

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -48,6 +48,8 @@ class Configuration {
   final bool _launchInChrome;
   final bool _logRequests;
   final String _output;
+  final String _outputInput;
+  final String _outputPath;
   final bool _release;
   final ReloadConfiguration _reload;
   final bool _requireBuildWebCompilers;
@@ -60,6 +62,8 @@ class Configuration {
     bool launchInChrome,
     bool logRequests,
     String output,
+    String outputInput,
+    String outputPath,
     ReloadConfiguration reload,
     bool release,
     bool requireBuildWebCompilers,
@@ -70,6 +74,8 @@ class Configuration {
         _launchInChrome = launchInChrome,
         _logRequests = logRequests,
         _output = output,
+        _outputInput = outputInput,
+        _outputPath = outputPath,
         _release = release,
         _reload = reload,
         _requireBuildWebCompilers = requireBuildWebCompilers,
@@ -86,6 +92,10 @@ class Configuration {
   bool get logRequests => _logRequests ?? false;
 
   String get output => _output ?? outputNone;
+
+  String get outputInput => _outputInput;
+
+  String get outputPath => _outputPath;
 
   bool get release => _release ?? false;
 
@@ -124,6 +134,19 @@ class Configuration {
         ? argResults[outputFlag] as String
         : defaultConfiguration.output;
 
+    String outputPath;
+    String outputInput;
+    if (output != 'NONE') {
+      var splitOutput = output.split(':');
+      if (splitOutput.length == 2) {
+        outputInput = splitOutput.first;
+        outputPath = splitOutput.last;
+      } else {
+        outputInput = '';
+        outputPath = output;
+      }
+    }
+
     var release = argResults.options.contains(releaseFlag)
         ? argResults[releaseFlag] as bool
         : defaultConfiguration.release;
@@ -150,6 +173,8 @@ class Configuration {
         launchInChrome: launchInChrome,
         logRequests: logRequests,
         output: output,
+        outputInput: outputInput,
+        outputPath: outputPath,
         release: release,
         reload: _parseReloadConfiguration(argResults),
         requireBuildWebCompilers: requireBuildWebCompilers,

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -74,8 +74,8 @@ class Configuration {
   final bool _launchInChrome;
   final bool _logRequests;
   final String _output;
-  final String _outputInput;
-  final String _outputPath;
+  final String outputInput;
+  final String outputPath;
   final bool _release;
   final ReloadConfiguration _reload;
   final bool _requireBuildWebCompilers;
@@ -88,8 +88,8 @@ class Configuration {
     bool launchInChrome,
     bool logRequests,
     String output,
-    String outputInput,
-    String outputPath,
+    this.outputInput,
+    this.outputPath,
     ReloadConfiguration reload,
     bool release,
     bool requireBuildWebCompilers,
@@ -100,8 +100,6 @@ class Configuration {
         _launchInChrome = launchInChrome,
         _logRequests = logRequests,
         _output = output,
-        _outputInput = outputInput,
-        _outputPath = outputPath,
         _release = release,
         _reload = reload,
         _requireBuildWebCompilers = requireBuildWebCompilers,
@@ -118,10 +116,6 @@ class Configuration {
   bool get logRequests => _logRequests ?? false;
 
   String get output => _output ?? outputNone;
-
-  String get outputInput => _outputInput;
-
-  String get outputPath => _outputPath;
 
   bool get release => _release ?? false;
 

--- a/webdev/lib/src/command/daemon_command.dart
+++ b/webdev/lib/src/command/daemon_command.dart
@@ -53,7 +53,8 @@ class DaemonCommand extends Command<int> {
     daemon.registerDomain(daemonDomain);
     var configuration = Configuration(launchInChrome: true, debug: true);
     var pubspecLock = await readPubspecLock(configuration);
-    var buildOptions = buildRunnerArgs(pubspecLock, configuration);
+    var buildOptions =
+        buildRunnerArgs(pubspecLock, configuration, includeOutput: false);
     var port = await findUnusedPort();
     var workflow = await DevWorkflow.start(
         configuration, buildOptions, {'web': port}, (level, message) {

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -93,10 +93,11 @@ class ServeCommand extends Command<int> {
     var pubspecLock = await readPubspecLock(configuration);
     // Forward remaining arguments as Build Options to the Daemon.
     // This isn't documented. Should it be advertised?
-    var buildOptions = buildRunnerArgs(pubspecLock, configuration)
-      ..addAll(argResults.rest
-          .where((arg) => !arg.contains(':') || arg.startsWith('--'))
-          .toList());
+    var buildOptions =
+        buildRunnerArgs(pubspecLock, configuration, includeOutput: false)
+          ..addAll(argResults.rest
+              .where((arg) => !arg.contains(':') || arg.startsWith('--'))
+              .toList());
     var directoryArgs = argResults.rest
         .where((arg) => arg.contains(':') || !arg.startsWith('--'))
         .toList();

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -44,13 +44,17 @@ void addSharedArgs(ArgParser argParser,
 }
 
 List<String> buildRunnerArgs(
-    PubspecLock pubspecLock, Configuration configuration) {
+    PubspecLock pubspecLock, Configuration configuration,
+    {bool includeOutput}) {
+  includeOutput ??= true;
   var arguments = <String>[];
   if (configuration.release) {
     arguments.add('--$releaseFlag');
   }
 
-  if (configuration.output != null && configuration.output != outputNone) {
+  if (includeOutput &&
+      configuration.output != null &&
+      configuration.output != outputNone) {
     arguments.addAll(['--$outputFlag', configuration.output]);
   }
 

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -43,6 +43,8 @@ void addSharedArgs(ArgParser argParser,
         help: 'Enables verbose logging.');
 }
 
+/// Parses the provided [Configuration] to return a list of
+/// `package:build_runner` appropriate arguments.
 List<String> buildRunnerArgs(
     PubspecLock pubspecLock, Configuration configuration,
     {bool includeOutput}) {

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -118,7 +118,7 @@ Future<void> checkPubspecLock(PubspecLock pubspecLock,
   var issues = <PackageExceptionDetails>[];
 
   issues.addAll(pubspecLock.checkPackage(
-      'build_runner', VersionConstraint.parse('>=1.2.2 <2.0.0')));
+      'build_runner', VersionConstraint.parse('>=1.3.0 <2.0.0')));
 
   if (requireBuildWebCompilers) {
     issues.addAll(pubspecLock.checkPackage(

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -107,6 +107,39 @@ Future<DevTools> _startDevTools(
   return null;
 }
 
+void _registerBuildTargets(
+  BuildDaemonClient client,
+  Configuration configuration,
+  Map<String, int> targetPorts,
+) {
+  // Register a target for each serve target.
+  for (var target in targetPorts.keys) {
+    OutputLocation outputLocation;
+    if (configuration.outputPath != null &&
+        (configuration.outputInput == null ||
+            target == configuration.outputInput)) {
+      outputLocation = OutputLocation((b) => b
+        ..output = configuration.outputPath
+        ..useSymlinks = true
+        ..hoist = true);
+    }
+    client.registerBuildTarget(DefaultBuildTarget((b) => b
+      ..target = target
+      ..outputLocation = outputLocation?.toBuilder()));
+  }
+  // Empty string indicates we should build everything, register a corresponding
+  // target.
+  if (configuration.outputInput == '') {
+    var outputLocation = OutputLocation((b) => b
+      ..output = configuration.outputPath
+      ..useSymlinks = true
+      ..hoist = false);
+    client.registerBuildTarget(DefaultBuildTarget((b) => b
+      ..target = ''
+      ..outputLocation = outputLocation?.toBuilder()));
+  }
+}
+
 /// Controls the web development workflow.
 ///
 /// Connects to the Build Daemon, creates servers, launches Chrome and wires up
@@ -142,9 +175,7 @@ class DevWorkflow {
         workingDirectory, client, devTools, logHandler);
     var chrome = await _startChrome(configuration, serverManager, client);
     logHandler(Level.INFO, 'Registering build targets...');
-    for (var target in targetPorts.keys) {
-      client.registerBuildTarget(DefaultBuildTarget((b) => b.target = target));
-    }
+    _registerBuildTargets(client, configuration, targetPorts);
     logHandler(Level.INFO, 'Starting initial build...');
     client.startBuild();
     return DevWorkflow._(client, chrome, devTools, serverManager);

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   args: ^1.5.0
-  build_daemon: ^0.4.1
+  build_daemon: ^0.5.0
   built_value: ^6.3.0
   crypto: ^2.0.6
   dwds: ^0.1.0-dev
@@ -41,6 +41,8 @@ dev_dependencies:
 dependency_overrides:
   dwds:
     path: ../dwds
+  build_daemon:
+    path: /usr/local/google/home/grouma/Projects/build/build_daemon
 
 executables:
   webdev:

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -41,8 +41,6 @@ dev_dependencies:
 dependency_overrides:
   dwds:
     path: ../dwds
-  build_daemon:
-    path: /usr/local/google/home/grouma/Projects/build/build_daemon
 
 executables:
   webdev:

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -110,7 +110,7 @@ name: sample
               String supportedRange;
               if (entry.key == 'build_runner') {
                 buildRunnerVersion = version;
-                supportedRange = '>=1.2.2 <2.0.0';
+                supportedRange = '>=1.3.0 <2.0.0';
               } else {
                 assert(entry.key == 'build_web_compilers');
                 webCompilersVersion = version;
@@ -217,7 +217,7 @@ dependencies:
   }
 }
 
-const _supportedBuildRunnerVersion = '1.2.2';
+const _supportedBuildRunnerVersion = '1.3.0';
 const _supportedWebCompilersVersion = '1.2.0';
 
 String _pubspecLock(


### PR DESCRIPTION
- Add `outputInput` and `outputPath` to `Configuration` where `-o outputInput:outputPath`
  - Shitty names so open to suggestions
- Update to `build_daemon` `0.5.0` which supports output paths
- Use parsed output in the new daemon protocol
- Now require a minimum of `build_runner` `1.3.0`
