### PR TITLE
Tweak daemon app.progress events

### DIFF
--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -36,8 +36,8 @@ class AppDomain extends Domain {
         sendEvent('app.progress', {
           'appId': _appId,
           'id': '$_buildProgressEventId',
-          'message': 'Starting Build',
-          'progressId': 'build.started',
+          'message': 'Building',
+          'progressId': 'build',
         });
         break;
       case BuildStatus.failed:
@@ -45,7 +45,8 @@ class AppDomain extends Domain {
           'appId': _appId,
           'id': '$_buildProgressEventId',
           'message': 'Build Failed',
-          'progressId': 'build.failed',
+          'progressId': 'build',
+          'finished': true,
         });
         break;
       case BuildStatus.succeeded:
@@ -53,7 +54,8 @@ class AppDomain extends Domain {
           'appId': _appId,
           'id': '$_buildProgressEventId',
           'message': 'Build Succeeded',
-          'progressId': 'build.succeeded',
+          'progressId': 'build',
+          'finished': true,
         });
         break;
     }


### PR DESCRIPTION
1. Set the IDs to match for the start/end events so that the editor knows there are related
2. Set finished: true for the end events so the editor knows the progress finished (and can remove the progress indicator) (see https://github.com/dart-lang/webdev/issues/219#issuecomment-480794461)
3. Changed the start text to "Building" so that it makes sense when shown as a progress indicator