### PR TITLE
return an error code for hot reload

### DIFF
--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -21,7 +21,9 @@ import 'utilites.dart';
 class AppDomain extends Domain {
   String _appId;
   AppDebugServices _appDebugServices;
+
   DebugService get _debugService => _appDebugServices?.debugService;
+
   VmService get _vmService => _appDebugServices?.webdevClient?.client;
   StreamSubscription<BuildResult> _resultSub;
   StreamSubscription<Event> _stdOutSub;
@@ -144,8 +146,10 @@ class AppDomain extends Domain {
     if (_appId != appId) throw ArgumentError.value(appId, 'appId', 'Not found');
     var fullRestart = getBoolArg(args, 'fullRestart') ?? false;
     if (!fullRestart) {
-      throw ArgumentError.value(
-          fullRestart, 'fullRestart', 'We do not support hot reload yet.');
+      return {
+        'code': 1,
+        'message': 'hot reload not yet supported by package:flutter_web',
+      };
     }
     // TODO(grouma) - Support pauseAfterRestart.
     // var pauseAfterRestart = getBoolArg(args, 'pause') ?? false;

--- a/webdev/test/daemon/app_domain_test.dart
+++ b/webdev/test/daemon/app_domain_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Timeout(Duration(minutes: 2))
-
 import 'dart:async';
 import 'dart:convert';
 
@@ -89,6 +88,22 @@ void main() {
             emitsThrough(
                 startsWith('[{"event":"app.log","params":{"appId":"$appId",'
                     '"log":"Hello World\\n"}}')));
+        await exitWebdev(webdev);
+      });
+
+      test('.reload', () async {
+        var webdev =
+            await runWebDev(['daemon'], workingDirectory: exampleDirectory);
+        var appId = await _getAppId(webdev);
+        var extensionCall = '[{"method":"app.restart","id":0,'
+            '"params" : { "appId" : "$appId", "fullRestart" : false}}]';
+        webdev.stdin.add(utf8.encode('$extensionCall\n'));
+        await expectLater(
+          webdev.stdout,
+          emitsThrough(startsWith(
+            '[{"id":0,"result":{"code": 1, "message": "hot reload not yet supported',
+          )),
+        );
         await exitWebdev(webdev);
       });
 

--- a/webdev/test/daemon/app_domain_test.dart
+++ b/webdev/test/daemon/app_domain_test.dart
@@ -101,7 +101,7 @@ void main() {
         await expectLater(
           webdev.stdout,
           emitsThrough(startsWith(
-            '[{"id":0,"result":{"code": 1, "message": "hot reload not yet supported',
+            '[{"id":0,"result":{"code":1,"message":"hot reload not yet supported',
           )),
         );
         await exitWebdev(webdev);


### PR DESCRIPTION
- return an error code for hot reload instead of an exception result

In IDEs, we can show:

<img width="394" alt="Screen Shot 2019-04-18 at 9 12 13 AM" src="https://user-images.githubusercontent.com/1269969/56377322-07dbbd80-61bf-11e9-9698-b99ab3c2c70e.png">

instead of:

<img width="1179" alt="Screen Shot 2019-04-14 at 12 12 25 AM" src="https://user-images.githubusercontent.com/1269969/56377341-10cc8f00-61bf-11e9-914b-6c3ec7f848b0.png">

I'm going to let this build through in the bots - I'm having trouble running the tests locally.