### PR TITLE
allow build_runner args to the build command

### DIFF
--- a/webdev/lib/src/command/build_command.dart
+++ b/webdev/lib/src/command/build_command.dart
@@ -34,17 +34,22 @@ class BuildCommand extends Command<int> {
 
   @override
   Future<int> run() async {
-    if (argResults.rest.isNotEmpty) {
+    var unsupported =
+        argResults.rest.where((arg) => !arg.startsWith('-')).toList();
+    if (unsupported.isNotEmpty) {
       throw UsageException(
           'Arguments were provided that are not supported: '
-          '"${argResults.rest.join(' ')}".',
+          '"${unsupported.join(' ')}".',
           argParser.usage);
     }
+    var extraArgs =
+        argResults.rest.where((arg) => arg.startsWith('-')).toList();
 
     var configuration = Configuration.fromArgs(argResults);
     setVerbosity(configuration.verbose);
     var pubspecLock = await readPubspecLock(configuration);
-    final arguments = buildRunnerArgs(pubspecLock, configuration);
+    final arguments = buildRunnerArgs(pubspecLock, configuration)
+      ..addAll(extraArgs);
 
     try {
       logHandler(Level.INFO, 'Connecting to the build daemon...');

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -62,6 +62,21 @@ void main() {
     await process.shouldExit(isNot(0));
   });
 
+  test('build should allow passing extra arguments to build_runner', () async {
+    var args = [
+      'build',
+      '-o',
+      'web:${d.sandbox}',
+      '--',
+      '--delete-conflicting-outputs'
+    ];
+
+    var process = await runWebDev(args, workingDirectory: exampleDirectory);
+
+    await checkProcessStdout(process, ['Succeeded']);
+    await process.shouldExit(0);
+  });
+
   group('should build with valid configuration', () {
     for (var withDDC in [true, false]) {
       test(withDDC ? 'DDC' : 'dart2js', () async {


### PR DESCRIPTION
This is necessary for providing `--delete-conflicting-outputs` at a minimum.