### PR TITLE
Remove logger name when not verbose

### DIFF
--- a/webdev/lib/src/logging.dart
+++ b/webdev/lib/src/logging.dart
@@ -10,7 +10,7 @@ import 'package:logging/logging.dart';
 
 var _verbose = false;
 
-var _loggerName = RegExp(r'^(\w)+: ');
+var _loggerName = RegExp(r'^\w+: ');
 
 /// Sets the verbosity of the current [logHandler].
 void setVerbosity(bool verbose) => _verbose = verbose;

--- a/webdev/lib/src/logging.dart
+++ b/webdev/lib/src/logging.dart
@@ -41,11 +41,8 @@ void _colorLog(Level level, String message, {bool verbose}) {
   var multiline = message.contains('\n') && !message.endsWith('\n');
   var eraseLine = _verbose ? '' : '\x1b[2K\r';
   var colorLevel = color.wrap('[$level]');
-  if (!verbose) {
-    var match = _loggerName.firstMatch(message);
-    // Remove the logger name.
-    if (match != null) message = message.substring(match.end);
-  }
+  if (!verbose) message = trimLoggerName(message);
+
   stdout.write('$eraseLine$colorLevel $message');
 
   // Prevent multilines and severe messages from being erased.
@@ -58,6 +55,14 @@ void _colorLog(Level level, String message, {bool verbose}) {
 String trimLevel(Level level, String message) => message.startsWith('[$level]')
     ? message.replaceFirst('[$level]', '').trimLeft()
     : message;
+
+/// Removes the logger name from the [message] if one is present.
+String trimLoggerName(String message) {
+  var match = _loggerName.firstMatch(message);
+  // Remove the logger name.
+  if (match != null) message = message.substring(match.end);
+  return message;
+}
 
 /// Detects if the [ServerLog] contains a [Level] and returns the
 /// resulting value.

--- a/webdev/lib/src/serve/logging.dart
+++ b/webdev/lib/src/serve/logging.dart
@@ -9,6 +9,8 @@ import 'package:logging/logging.dart';
 
 var _verbose = false;
 
+var _loggerName = RegExp(r'^(\w)+: ');
+
 /// Sets the verbosity of the current [logHandler].
 void setVerbosity(bool verbose) => _verbose = verbose;
 
@@ -38,7 +40,11 @@ void _colorLog(Level level, String message, {bool verbose}) {
   var multiline = message.contains('\n') && !message.endsWith('\n');
   var eraseLine = _verbose ? '' : '\x1b[2K\r';
   var colorLevel = color.wrap('[$level]');
-
+  if (!verbose) {
+    var match = _loggerName.firstMatch(message);
+    // Remove the logger name.
+    if (match != null) message = message.substring(match.end);
+  }
   stdout.write('$eraseLine$colorLevel $message');
 
   // Prevent multilines and severe messages from being erased.

--- a/webdev/test/logging_test.dart
+++ b/webdev/test/logging_test.dart
@@ -1,0 +1,61 @@
+import 'package:build_daemon/data/server_log.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+import 'package:webdev/src/logging.dart';
+
+void main() {
+  group('trimLoggerName', () {
+    test('properly removes logger names', () {
+      expect(trimLoggerName('SomeLogName: foo bar'), equals('foo bar'));
+    });
+
+    test('leaves messages untouched if no logger name is present', () {
+      expect(trimLoggerName('foo bar looksLikeALoggerName: '),
+          equals('foo bar looksLikeALoggerName: '));
+    });
+
+    test('works with empty messages', () {
+      expect(trimLoggerName(''), equals(''));
+    });
+
+    test('assumes logger names is one word', () {
+      expect(trimLoggerName('not a logger: foo bar'),
+          equals('not a logger: foo bar'));
+      expect(trimLoggerName('foo baz: foo bar'), equals('foo baz: foo bar'));
+    });
+
+    test('assumes loggers are directly at the front of a message', () {
+      expect(
+          trimLoggerName(' notLogger: foo bar'), equals(' notLogger: foo bar'));
+    });
+  });
+
+  group('levelForLog', () {
+    test('correctly returns the level from the log', () {
+      expect(levelForLog(ServerLog((b) => b.log = '[INFO] foo bar')),
+          equals(Level.INFO));
+      expect(levelForLog(ServerLog((b) => b.log = '[SEVERE] foo bar')),
+          equals(Level.SEVERE));
+    });
+
+    test('returns null if no level is present', () {
+      expect(levelForLog(ServerLog((b) => b.log = 'foo bar')), isNull);
+    });
+
+    test('only looks for levels at the start of a log', () {
+      expect(levelForLog(ServerLog((b) => b.log = 'foo bar [INFO]')), isNull);
+    });
+  });
+
+  group('trimLevel', () {
+    test('correctly trims the level from the message', () {
+      expect(trimLevel(Level.INFO, '[INFO]foo bar'), equals('foo bar'));
+      expect(trimLevel(Level.INFO, '[INFO]no space'), equals('no space'));
+    });
+
+    test('leaves the message untouched if the level is not present', () {
+      expect(trimLevel(Level.INFO, '[SEVERE] foo bar'),
+          equals('[SEVERE] foo bar'));
+    });
+  });
+}

--- a/webdev/test/logging_test.dart
+++ b/webdev/test/logging_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:build_daemon/data/server_log.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
This assumes the logger names do not contain spaces. Based off of https://github.com/dart-lang/build/pull/2194 this assumption appears correct.

Closes https://github.com/dart-lang/webdev/issues/301