### PR TITLE
tweak how we send progress events

### DIFF
--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -38,16 +38,13 @@ class AppDomain extends Domain {
         sendEvent('app.progress', {
           'appId': _appId,
           'id': '$_buildProgressEventId',
-          'message': 'Building',
-          'progressId': 'build',
+          'message': 'Building...',
         });
         break;
       case BuildStatus.failed:
         sendEvent('app.progress', {
           'appId': _appId,
           'id': '$_buildProgressEventId',
-          'message': 'Build Failed',
-          'progressId': 'build',
           'finished': true,
         });
         break;
@@ -55,8 +52,6 @@ class AppDomain extends Domain {
         sendEvent('app.progress', {
           'appId': _appId,
           'id': '$_buildProgressEventId',
-          'message': 'Build Succeeded',
-          'progressId': 'build',
           'finished': true,
         });
         break;


### PR DESCRIPTION
tweak how we send progress events:
- messages generally end in ellipses, in order to indicate that a task is ongoing
- `finished` events don't send messages
- `progressId` fields generally aren't needed. This is only used by flutter_tools to help clients call out hot reload and hot restart progress event

@grouma 