### PR TITLE
don't collapse version.dart in github code reviews

### DIFF
--- a/webdev/.gitattributes
+++ b/webdev/.gitattributes
@@ -1,0 +1,4 @@
+*.dart eol=lf
+
+# Don't collapse in github code reviews by default.
+webdev/lib/src/version.dart linguist-generated=false


### PR DESCRIPTION
- don't collapse version.dart in github code reviews

I noticed that version.dart was collapsed by default in code reviews here; this bit of metadata should prevent that.