### PR TITLE
Remove unused path are to PubspecLock.read

### DIFF
--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -58,9 +58,8 @@ List<String> buildRunnerArgs(
   return arguments;
 }
 
-Future<PubspecLock> readPubspecLock(Configuration configuration,
-    [String path]) async {
-  var pubspecLock = await PubspecLock.read(path);
+Future<PubspecLock> readPubspecLock(Configuration configuration) async {
+  var pubspecLock = await PubspecLock.read();
   await checkPubspecLock(pubspecLock,
       requireBuildWebCompilers: configuration.requireBuildWebCompilers);
   return pubspecLock;

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -74,11 +74,11 @@ class PubspecLock {
 
   PubspecLock(this._packages);
 
-  static Future<PubspecLock> read([String path]) async {
-    path ??= 'pubspec.lock';
+  static Future<PubspecLock> read() async {
     await _runPubDeps();
 
-    var pubspecLock = loadYaml(await File(path).readAsString()) as YamlMap;
+    var pubspecLock =
+        loadYaml(await File('pubspec.lock').readAsString()) as YamlMap;
 
     var packages = pubspecLock['packages'] as YamlMap;
     return PubspecLock(packages);


### PR DESCRIPTION
It'll just cause problems since the call to `pub deps` is not updated
to correspond to the file location