### PR TITLE
Fix DWDS tests with webdev 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,12 @@ jobs:
       env: PKGS="dwds example webdev"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
-      name: "SDK: 2.2.1-dev.2.0; PKG: dwds; TASKS: `pub run test`"
+      name: "SDK: 2.2.1-dev.2.0; PKG: dwds; TASKS: `pub run test -j 1`"
       dart: "2.2.1-dev.2.0"
       env: PKGS="dwds"
       script: ./tool/travis.sh test_0
     - stage: unit_test
-      name: "SDK: dev; PKG: dwds; TASKS: `pub run test`"
+      name: "SDK: dev; PKG: dwds; TASKS: `pub run test -j 1`"
       dart: dev
       env: PKGS="dwds"
       script: ./tool/travis.sh test_0

--- a/dwds/example/hello_world/index.html
+++ b/dwds/example/hello_world/index.html
@@ -2,10 +2,6 @@
 
 <head>
   <script defer src="main.dart.js"></script>
-  <script>
-    window.$dartAppId = 'id-for-testing';
-    window.$dartAppInstanceId = 'instance-id-for-testing';
-  </script>
 </head>
 
 </html>

--- a/dwds/mono_pkg.yaml
+++ b/dwds/mono_pkg.yaml
@@ -13,4 +13,4 @@ stages:
       - dartanalyzer: --fatal-warnings .
       dart: [2.2.1-dev.2.0]
   - unit_test:
-    - test:
+    - test: -j 1

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -37,8 +37,8 @@ for PKG in ${PKGS}; do
       ;;
     test_0) echo
       echo -e '\033[1mTASK: test_0\033[22m'
-      echo -e 'pub run test'
-      pub run test || EXIT_CODE=$?
+      echo -e 'pub run test -j 1'
+      pub run test -j 1 || EXIT_CODE=$?
       ;;
     test_1) echo
       echo -e '\033[1mTASK: test_1\033[22m'


### PR DESCRIPTION
DWDS tests make use of `webdev` by global activation. When `webdev 2.0.0` was released it broke the tests. Changes:

- No longer implicitly cancel the `stdout` stream as that causes issues with `webdev`
- Get `instanceId` through an evaluate instead of hard coding a fake one
  - `webdev 2.0.0` now embeds one
- Run only one test at a time due to blocking issue https://github.com/dart-lang/build/issues/2210