### PR TITLE
Use correct ChromeDriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ before_install:
   - "export CHROMEDRIVER_BINARY=/usr/bin/google-chrome"
   - "export CHROMEDRIVER_ARGS=--no-sandbox"
   - "/usr/bin/google-chrome --version"
+  - "export CHROME_LATEST_VERSION=$(/usr/bin/google-chrome --version | cut -d' ' -f3 | cut -d'.' -f1)"
+  - "export CHROME_DRIVER_VERSION=$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_LATEST_VERSION)"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - "wget http://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip"
-  - unzip chromedriver_linux64.zip
+  - "wget https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip"
+  - "unzip chromedriver_linux64.zip"
   - "export PATH=$PATH:$PWD"
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,5 @@ branches:
 cache:
   directories:
     - "$HOME/.pub-cache"
-    - example/.dart_tool
+    - example/.dart_tool/build
+    - example/.dart_tool/pub

--- a/webdev/lib/src/serve/chrome.dart
+++ b/webdev/lib/src/serve/chrome.dart
@@ -87,7 +87,10 @@ class Chrome {
     await process.stderr
         .transform(utf8.decoder)
         .transform(const LineSplitter())
-        .firstWhere((line) => line.startsWith('DevTools listening'));
+        .firstWhere((line) => line.startsWith('DevTools listening'))
+        .timeout(Duration(seconds: 60),
+            onTimeout: () =>
+                throw Exception('Unable to connect to Chrome DevTools.'));
 
     return _connect(Chrome._(
       port,


### PR DESCRIPTION
ChromeDriver no longer supports a range of Chrome versions :(

Figure out the correct version of ChromeDriver to download and use that one.

Fix an issue where we were reusing the chrome profile from the Travis cache. Also add a timeout for waiting for the Chrome DevTools connection.