### PR TITLE
update vm_service_lib, prep for release

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.2
+## 0.3.0
 
 - Change the exposed type on DebugService to VmServiceInterface
 

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.2.2-dev
+version: 0.3.0
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
@@ -18,7 +18,7 @@ dependencies:
   shelf: ^0.7.0
   shelf_web_socket: ^0.2.0
   source_maps: ^0.10.0
-  vm_service_lib: 3.14.3-dev.4
+  vm_service_lib: 3.15.1+1
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: ^0.4.0
 


### PR DESCRIPTION
Related to https://github.com/flutter/devtools/issues/562

Will follow up with a webdev update to allow this version and update for the breaking change.