### PR TITLE
Start build before launching Chrome

### DIFF
--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -163,14 +163,14 @@ class DevWorkflow {
   ) async {
     var workingDirectory = Directory.current.path;
     var client = await _startBuildDaemon(workingDirectory, buildOptions);
-    var devTools = await _startDevTools(configuration);
-    var serverManager = await _startServerManager(
-        configuration, targetPorts, workingDirectory, client, devTools);
-    var chrome = await _startChrome(configuration, serverManager, client);
     logHandler(Level.INFO, 'Registering build targets...');
     _registerBuildTargets(client, configuration, targetPorts);
     logHandler(Level.INFO, 'Starting initial build...');
     client.startBuild();
+    var devTools = await _startDevTools(configuration);
+    var serverManager = await _startServerManager(
+        configuration, targetPorts, workingDirectory, client, devTools);
+    var chrome = await _startChrome(configuration, serverManager, client);
     return DevWorkflow._(client, chrome, devTools, serverManager);
   }
 


### PR DESCRIPTION
Possibly towards https://github.com/dart-lang/webdev/issues/319

There is a race condition where assets can be requested prior to starting a build which would cause read errors. Change the logic to register and start a build before starting the proxy asset server and launching chrome.