### PR TITLE
Chrome fixes for VS code

### DIFF
--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
 
 dev_dependencies:
   args: ^1.0.0
+  build_daemon: ^0.5.0
   build_runner: ^1.0.0
   build_web_compilers: '>=1.0.0 <3.0.0'
   test: ^1.6.0

--- a/dwds/test/test_context.dart
+++ b/dwds/test/test_context.dart
@@ -48,7 +48,7 @@ class TestContext {
       }
       printOnFailure(line);
     });
-    await assetReadyCompleter.future;
+    await assetReadyCompleter.future.timeout(Duration(seconds: 60));
     appUrl = 'http://localhost:$port/hello_world/';
     var debugPort = await findUnusedPort();
     webDriver = await createDriver(desired: {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,3 +7,4 @@ environment:
 dev_dependencies:
   build_runner: '>=1.3.0 <2.0.0'
   build_web_compilers: '>=1.0.0 <3.0.0'
+  build_daemon: ^0.5.0

--- a/webdev/lib/src/serve/chrome.dart
+++ b/webdev/lib/src/serve/chrome.dart
@@ -61,7 +61,6 @@ class Chrome {
   Future<void> close() async {
     if (_currentCompleter.isCompleted) _currentCompleter = Completer<Chrome>();
     chromeConnection.close();
-    print("ABOUT TO CLOSE CHROME");
     _process?.kill(ProcessSignal.sigkill);
     await _process?.exitCode;
     await _dataDir?.delete(recursive: true);

--- a/webdev/lib/src/serve/chrome.dart
+++ b/webdev/lib/src/serve/chrome.dart
@@ -63,7 +63,16 @@ class Chrome {
     chromeConnection.close();
     _process?.kill(ProcessSignal.sigkill);
     await _process?.exitCode;
-    await _dataDir?.delete(recursive: true);
+    try {
+      // Chrome starts another process as soon as it dies that modifies the
+      // profile information. Give it some time before attempting to delete
+      // the directory.
+      await Future.delayed(Duration(milliseconds: 500));
+      await _dataDir?.delete(recursive: true);
+    } catch (_) {
+      // Silently fail if we can't clean up the profile information.
+      // It is a system tmp directory so it should get cleaned up eventually.
+    }
   }
 
   /// Connects to an instance of Chrome with an open debug port.

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -175,7 +175,6 @@ class DevWorkflow {
   }
 
   Future<void> shutDown() async {
-    print("SHUTTING DOWN");
     await _chrome?.close();
     await _client?.close();
     await _devTools?.close();

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -175,6 +175,7 @@ class DevWorkflow {
   }
 
   Future<void> shutDown() async {
+    print("SHUTTING DOWN");
     await _chrome?.close();
     await _client?.close();
     await _devTools?.close();

--- a/webdev/lib/src/serve/handlers/dev_handler.dart
+++ b/webdev/lib/src/serve/handlers/dev_handler.dart
@@ -50,9 +50,11 @@ class DevHandler {
 
   Future<void> close() async {
     await _sub.cancel();
-    for (var connection in _connections) {
-      await connection.sink.close();
-    }
+    // We listen for connections to close and remove them from the connections
+    // set. Therefore we shouldn't asynchronously iterate through the
+    // connections.
+    await Future.wait(
+        _connections.map((connection) => connection.sink.close()));
     await Future.wait(_servicesByAppId.values.map((futureServices) async {
       await (await futureServices).close();
     }));


### PR DESCRIPTION
- As suggested by the Chrome docs, always use a tmp dir when passing `--remote-debugging-port`
- Add graceful exit handler for daemon command
  - This ensures that Chrome is properly closed
- Temporary pin build_daemon version to fix integration tests
- Fix concurrent modification issue

Closes https://github.com/dart-lang/webdev/issues/319
Closes https://github.com/dart-lang/webdev/issues/300

This reverts https://github.com/dart-lang/webdev/pull/322 & https://github.com/dart-lang/webdev/pull/316
