### PR TITLE
Work around Windows limitations

### DIFF
--- a/webdev/lib/src/command/daemon_command.dart
+++ b/webdev/lib/src/command/daemon_command.dart
@@ -53,9 +53,11 @@ class DaemonCommand extends Command<int> {
     Daemon daemon;
     DevWorkflow workflow;
     var cancelCount = 0;
-    var cancelSub = StreamGroup.merge(
-            [ProcessSignal.sigint.watch(), ProcessSignal.sigterm.watch()])
-        .listen((signal) async {
+    var cancelSub = StreamGroup.merge([
+      ProcessSignal.sigint.watch(),
+      // SIGTERM is not supported on Windows.
+      Platform.isWindows ? const Stream.empty() : ProcessSignal.sigterm.watch()
+    ]).listen((signal) async {
       cancelCount++;
       daemon?.shutdown();
       if (cancelCount > 1) exit(1);


### PR DESCRIPTION
`SIGTERM` is not supported on Windows. Flutter works around it like this: https://github.com/flutter/flutter/blob/8e7c7fcbd48abf2ded5ec876759375453ac18cff/packages/flutter_tools/lib/src/base/io.dart#L116