### PR TITLE
Wait for daemon to exit before returning success

### DIFF
--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -175,6 +175,8 @@ class AppDomain extends Domain {
   Future<bool> _stop(Map<String, dynamic> args) async {
     var appId = getStringArg(args, 'appId', required: true);
     if (_appId != appId) throw ArgumentError.value(appId, 'appId', 'Not found');
+    // Note that this triggers the daemon to shutdown as we listen for the
+    // tabConnection to close to initiate a shutdown.
     await _appDebugServices.chromeProxyService.tabConnection.close();
     // Wait for the daemon to gracefully shutdown before sending success.
     await daemon.onExit;

--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -176,6 +176,8 @@ class AppDomain extends Domain {
     var appId = getStringArg(args, 'appId', required: true);
     if (_appId != appId) throw ArgumentError.value(appId, 'appId', 'Not found');
     await _appDebugServices.chromeProxyService.tabConnection.close();
+    // Wait for the daemon to gracefully shutdown before sending success.
+    await daemon.onExit;
     return true;
   }
 


### PR DESCRIPTION
Closes https://github.com/dart-lang/webdev/issues/363

This is less than ideal in my opinion. VS code must be listening for this response and actively killing the process. On Windows we can only capture `SIGINT`. I believe any other signal kills the process.