### PR TITLE
handle org-dartlang-app library uris in dwds

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.3-dev
+
+- Handle `org-dartlang-app` scheme library uris and convert them to match the
+  dart uris that we will see in the sourcemaps.
+
 ## 0.3.2
 
 - Add support for `scope` in `evaluate` calls.

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -129,7 +129,7 @@ class ChromeProxyService implements VmServiceInterface {
       // relative to a top level directory in the package (such as `web` or
       // `test`), so we strip the scheme and skip the first path segment.
       var sourceMapUri = uri.scheme == 'org-dartlang-app'
-          ? p.url.joinAll(uri.pathSegments.skip(1))
+          ? p.url.joinAll(['/'].followedBy(uri.pathSegments.skip(1)))
           : '$uri';
       isolate.libraries.add(LibraryRef()
         ..id = sourceMapUri

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.3.2
+version: 0.3.3-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -242,8 +242,7 @@ void main() {
       expect(result, const TypeMatcher<Isolate>());
       var isolate = result as Isolate;
       expect(isolate.name, contains(context.appUrl));
-      // TODO: library names change with kernel dart-lang/sdk#36736
-      expect(isolate.rootLib.uri, endsWith('main.dart'));
+      expect(isolate.rootLib.uri, equals('hello_world/main.dart'));
 
       expect(
           isolate.libraries,

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -242,7 +242,9 @@ void main() {
       expect(result, const TypeMatcher<Isolate>());
       var isolate = result as Isolate;
       expect(isolate.name, contains(context.appUrl));
-      expect(isolate.rootLib.uri, equals('hello_world/main.dart'));
+      // TODO(jakemac): Update to the full expected uri `/hello_world/main.dart`
+      // once the next dev sdk comes out.
+      expect(isolate.rootLib.uri, endsWith('main.dart'));
 
       expect(
           isolate.libraries,

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -49,5 +49,9 @@ dev_dependencies:
   uuid: ^2.0.0
   webdriver: ^2.0.0
 
+dependency_overrides:
+  dwds:
+    path: ../dwds
+
 executables:
   webdev:


### PR DESCRIPTION
This will only work with the latest edge sdk which returns the original `org-dartlang-app` uris for libraries, and it will modify those uris to match up with the source map uris.

Existing uris (which are just the basename of the file) are left untouched.