### PR TITLE
Update minimum build_runner version to 1.5.0

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.7
+
+- Update minimum `package:build_runner` version to `1.5.0`.
+
 ## 2.0.6
 
 - Use latest `package:build_daemon`.

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -180,7 +180,7 @@ Future<void> checkPubspecLock(PubspecLock pubspecLock,
   var issues = <PackageExceptionDetails>[];
 
   var buildRunnerIssues = pubspecLock.checkPackage(
-      'build_runner', VersionConstraint.parse('>=1.3.0 <2.0.0'));
+      'build_runner', VersionConstraint.parse('>=1.5.0 <2.0.0'));
 
   issues.addAll(buildRunnerIssues);
 

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.0.6';
+const packageVersion = '2.0.7-dev';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdev
-version: 2.0.6
+version: 2.0.7-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -140,7 +140,7 @@ name: sample
               switch (entry.key) {
                 case 'build_runner':
                   buildRunnerVersion = version;
-                  supportedRange = '>=1.3.0 <2.0.0';
+                  supportedRange = '>=1.5.0 <2.0.0';
                   break;
                 case 'build_web_compilers':
                   webCompilersVersion = version;
@@ -285,7 +285,7 @@ dependencies:
   }
 }
 
-const _supportedBuildRunnerVersion = '1.3.0';
+const _supportedBuildRunnerVersion = '1.5.0';
 const _supportedWebCompilersVersion = '1.2.0';
 const _supportedBuildDaemonVersion = '1.0.0';
 


### PR DESCRIPTION
We actually require this version today due to requiring version `1.0.0` of `package:build_daemon`. Updating this minimum provides better error messages.

Related to https://github.com/dart-lang/webdev/issues/408