### PR TITLE
Fix source location incompatibilities

### DIFF
--- a/dwds/lib/src/dart_uri.dart
+++ b/dwds/lib/src/dart_uri.dart
@@ -68,6 +68,8 @@ class DartUri {
 
   /// Construct from a path, relative to the directory being served.
   factory DartUri._fromServerPath(String uri) {
-    return DartUri._(uri[0] == '/' ? uri.substring(1) : uri);
+    uri = uri[0] == '.' ? uri.substring(1) : uri;
+    uri = uri[0] == '/' ? uri.substring(1) : uri;
+    return DartUri._(uri);
   }
 }

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -68,6 +68,8 @@ class Debugger {
     var dartUri = DartUri(
         dartScript.uri, '${Uri.parse(mainProxy.uri).path}/garbage.dart');
     var location = locationFor(dartUri, line);
+    // TODO: Handle cases where a breakpoint can't be set exactly at that line.
+    if (location == null) return null;
     var jsBreakpointId = await _setBreakpoint(location);
     var dartBreakpoint = _dartBreakpoint(dartScript, location, isolate);
     _breakpoints.noteBreakpoint(js: jsBreakpointId, dart: dartBreakpoint.id);

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -102,11 +102,13 @@ class Debugger {
 
   /// Call the Chrome protocol setBreakpoint and return the breakpoint ID.
   Future<String> _setBreakpoint(Location location) async {
+    // Location is 0 based according to:
+    // https://chromedevtools.github.io/devtools-protocol/tot/Debugger#type-Location
     var response =
         await chromeDebugger.sendCommand('Debugger.setBreakpoint', params: {
       'location': {
         'scriptId': location.jsScriptId,
-        'lineNumber': location.jsLine,
+        'lineNumber': location.jsLine - 1,
       }
     });
     handleErrorIfPresent(response);
@@ -123,13 +125,9 @@ class Debugger {
   /// Find the [Location] for the given Dart source position.
   ///
   /// The [line] number is 1-based.
-  Location locationFor(DartUri uri, int line) {
-    // TODO: Handle cases where a breakpoint can't be set exactly at that
-    // line and we have to find the nearest valid position.
-    return sources.locationsFor(uri.serverPath).firstWhere(
-        (location) => location.dartLine == line,
-        orElse: () => null);
-  }
+  Location locationFor(DartUri uri, int line) => sources
+      .locationsFor(uri.serverPath)
+      .firstWhere((location) => location.dartLine == line, orElse: () => null);
 }
 
 /// Keeps track of the Dart and JS breakpoint Ids that correspond.

--- a/dwds/lib/src/location.dart
+++ b/dwds/lib/src/location.dart
@@ -50,7 +50,9 @@ class Location {
     var dartColumn = entry.sourceColumn;
     var jsLine = lineEntry.line;
     var jsColumn = entry.column;
-    return Location._(
-        scriptId, jsLine + 1, jsColumn + 1, dartUrl, dartLine, dartColumn);
+    // lineEntry data is 0 based according to:
+    // https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k
+    return Location._(scriptId, jsLine + 1, jsColumn + 1, dartUrl, dartLine + 1,
+        dartColumn + 1);
   }
 }

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -55,7 +55,7 @@ void main() {
 
     test('addBreakpoint', () async {
       // TODO: Much more testing.
-      var bp = await service.addBreakpoint(isolate.id, mainScript.id, 20);
+      var bp = await service.addBreakpoint(isolate.id, mainScript.id, 21);
       breakpoints = isolate.breakpoints;
       breakpoints = [bp];
       expect(breakpoints.any((b) => b.location.tokenPos == 42), isNotNull);


### PR DESCRIPTION
- Fix issue where we were not accounting for `.` in a relative path
- Fix some off by one issues for line and column data
- Move a TODO to a better location
  - It's likely that we won't support setting breakpoints for lines that we do not have location data for
  - See https://github.com/flutter/devtools/issues/703