### PR TITLE
Add support for --hostname any

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 2.0.8-dev
+## 2.1.0-dev
 
 - Add an explicit error if there are no directories to serve. Typically this
   would happen if the user doesn't have a `web` directory.
+- Add support for specifying `--hostname any`.
 
 ## 2.0.7
 

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -79,9 +79,7 @@ class WebDevServer {
     cascade = cascade.add(devHandler.handler).add(assetHandler.handler);
 
     var hostname = options.configuration.hostname;
-    var server = hostname == 'localhost'
-        ? await HttpMultiServer.loopback(options.port)
-        : await HttpServer.bind(hostname, options.port);
+    var server = await HttpMultiServer.bind(hostname, options.port);
     shelf_io.serveRequests(server, pipeline.addHandler(cascade.handler));
     return WebDevServer._(
         options.target, server, devHandler, options.configuration.autoRun);

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.0.8-dev';
+const packageVersion = '2.1.0-dev';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdev
-version: 2.0.8-dev
+version: 2.1.0-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-
@@ -18,7 +18,7 @@ dependencies:
   dwds: ^0.3.0
   devtools: ^0.0.15-dev.1
   http: ^0.12.0
-  http_multi_server: ^2.0.0
+  http_multi_server: ^2.1.0
   io: ^0.3.2+1
   logging: ^0.11.0
   pedantic: ^1.5.0


### PR DESCRIPTION
Bump to latest `http_multi_server` which encapsulates the logic for
special hostnames 'localhost' and 'any'.