### PR TITLE
Fix pausing within DevTools

### DIFF
--- a/example/web/main.dart
+++ b/example/web/main.dart
@@ -17,7 +17,7 @@ void main() {
   document.body.append(SpanElement()..text = 'Hello World!!');
 
   var count = 0;
-  Timer.periodic(Duration(seconds: 1), (_){
+  Timer.periodic(Duration(seconds: 1), (_) {
     print('Counter is: ${++count}');
   });
 }

--- a/example/web/main.dart
+++ b/example/web/main.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 import 'dart:html';
@@ -14,4 +15,9 @@ void main() {
     return ServiceExtensionResponse.result(json.encode({'success': true}));
   });
   document.body.append(SpanElement()..text = 'Hello World!!');
+
+  var count = 0;
+  Timer.periodic(Duration(seconds: 1), (_){
+    print('Counter is: ${++count}');
+  });
 }

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Add an explicit error if there are no directories to serve. Typically this
   would happen if the user doesn't have a `web` directory.
 - Add support for specifying `--hostname any`.
+- DevTools no longer launches in a new window. This prevents an issue where
+  pausing your application also pauses DevTools.
 
 ## 2.0.7
 

--- a/webdev/lib/src/serve/handlers/dev_handler.dart
+++ b/webdev/lib/src/serve/handlers/dev_handler.dart
@@ -152,9 +152,13 @@ class DevHandler {
             .serialize(DevToolsResponse((b) => b..success = true))));
 
         appServices.connectedInstanceId = message.instanceId;
-        await appServices.chromeProxyService.tabConnection.runtime.evaluate(
-            'window.open("http://${_devTools.hostname}:${_devTools.port}'
-            '/?uri=${appServices.debugService.wsUri}", "", "_blank")');
+        var chrome = await Chrome.connectedInstance;
+        // We can't use `window.open` here as DevTools is on the same hostname
+        // as the application. This makes it such that pausing execution in one
+        // will pause execution in the other.
+        await chrome.chromeConnection
+            .getUrl('json/new/?http://${_devTools.hostname}:${_devTools.port}'
+                '/?uri=${appServices.debugService.wsUri}');
       } else if (message is ConnectRequest) {
         if (appId != null) {
           throw StateError('Duplicate connection request from the same app. '

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -52,3 +52,7 @@ dev_dependencies:
 
 executables:
   webdev:
+
+# dependency_overrides:
+#  dwds:
+#    path: ../dwds


### PR DESCRIPTION
- No longer use the `window.open` API as it has unintended consequences for debugging
- Update the example to have a counting logger
  - This is useful as we build out the debugging support
- Add dependency_override comment to ease development

Unfortunately this regresses https://github.com/dart-lang/webdev/issues/287. The other option is to launch a new instance of Chrome but that's less than ideal.