### PR TITLE
Use createTarget API for DevTools

### DIFF
--- a/webdev/lib/src/serve/handlers/dev_handler.dart
+++ b/webdev/lib/src/serve/handlers/dev_handler.dart
@@ -152,13 +152,12 @@ class DevHandler {
             .serialize(DevToolsResponse((b) => b..success = true))));
 
         appServices.connectedInstanceId = message.instanceId;
-        var chrome = await Chrome.connectedInstance;
-        // We can't use `window.open` here as DevTools is on the same hostname
-        // as the application. This makes it such that pausing execution in one
-        // will pause execution in the other.
-        await chrome.chromeConnection
-            .getUrl('json/new/?http://${_devTools.hostname}:${_devTools.port}'
-                '/?uri=${appServices.debugService.wsUri}');
+        await appServices.chromeProxyService.tabConnection
+            .sendCommand('Target.createTarget', {
+          'newWindow': true,
+          'url': 'http://${_devTools.hostname}:${_devTools.port}'
+              '/?uri=${appServices.debugService.wsUri}',
+        });
       } else if (message is ConnectRequest) {
         if (appId != null) {
           throw StateError('Duplicate connection request from the same app. '


### PR DESCRIPTION
For some reason the `newWindow` parameter doesn't work. Nonetheless this is a preferred API.

See:
https://chromedevtools.github.io/devtools-protocol/tot/Target#method-createTarget