### PR TITLE
add angular deps to the example app as a smoke test

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,6 +4,12 @@ description: A web app example for webdev CLI.
 environment:
   sdk: ">=2.2.1-dev.2.0 <3.0.0"
 
+dependencies:
+  # These ensure the latest angular packages can get a valid version solve
+  # with the latest webdev.
+  angular: ^5.0.0
+  angular_components: ^0.13.0
+
 dev_dependencies:
   build_runner: '>=1.3.0 <2.0.0'
   build_web_compilers: '>=1.0.0 <3.0.0'


### PR DESCRIPTION
This should prevent issues like https://github.com/dart-lang/webdev/issues/408 in the future. 

This will involve a bit of followup work but it should be minimal, just bumping the versions when there are breaking changes.

Closes https://github.com/dart-lang/webdev/issues/429