### PR TITLE
Initial support of getStack

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3
+
+- Add support for `getScript` for paused isolates.
+
 ## 0.3.2
 
 - Add support for `scope` in `evaluate` calls.

--- a/dwds/example/hello_world/main.dart
+++ b/dwds/example/hello_world/main.dart
@@ -41,11 +41,22 @@ void main() async {
     });
   };
 
+  Timer.periodic(Duration(seconds: 1), (_) {
+    printCount();
+  });
+
   // Register one up front before the proxy connects, the isolate should still
   // recognize this as an available extension.
   registerExtension('ext.hello_world.existing', (_, __) => null);
 
   window.console.debug('Page Ready');
+}
+
+var count = 0;
+
+// An easy location to add a breakpoint.
+void printCount() {
+  print('The count is ${++count}');
 }
 
 String helloString(String response) => response;

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'location.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:vm_service_lib/vm_service_lib.dart';
@@ -43,11 +44,17 @@ class ChromeProxyService implements VmServiceInterface {
   /// Provides debugger-related functionality.
   Debugger debugger;
 
+  /// The current Dart stack for the paused [_isolate].
+  ///
+  /// This is null if the [_isolate] is not paused.
+  Stack _pausedStack;
+
   /// Fields that are specific to the current [_isolate].
   ///
   /// These need to get cleared whenever [destroyIsolate] is called.
   final _classes = <String, Class>{};
   final _scriptRefs = <String, ScriptRef>{};
+  final _serverPathToScriptRef = <String, ScriptRef>{};
   final _libraries = <String, Library>{};
   final _libraryRefs = <String, LibraryRef>{};
   StreamSubscription<ConsoleAPIEvent> _consoleSubscription;
@@ -183,8 +190,10 @@ class ChromeProxyService implements VmServiceInterface {
     _vm.isolates.removeWhere((ref) => ref.id == _isolate.id);
 
     _isolate = null;
+    _pausedStack = null;
     _classes.clear();
     _scriptRefs.clear();
+    _serverPathToScriptRef.clear();
     _libraries.clear();
     _libraryRefs.clear();
     _consoleSubscription.cancel();
@@ -474,6 +483,8 @@ function($argsString) {
       ..id = createId();
 
     _scriptRefs[scriptRef.id] = scriptRef;
+    _serverPathToScriptRef[DartUri(libraryRef.id, scriptRef.uri).serverPath] =
+        scriptRef;
 
     return Library()
       ..id = libraryRef.id
@@ -523,6 +534,9 @@ function($argsString) {
     return ScriptList()..scripts = scripts;
   }
 
+  /// Returns the corresponding [ScriptRef] for the provided Dart server path.
+  ScriptRef scriptRefFor(String uri) => _serverPathToScriptRef[uri];
+
   Future<Script> _getScript(String isolateId, ScriptRef scriptRef) async {
     var libraryId = scriptRef.uri;
     // TODO(401): Remove uri parameter.
@@ -560,10 +574,12 @@ function($argsString) {
     throw UnimplementedError();
   }
 
+  /// Returns the current stack.
+  ///
+  /// Returns null if the corresponding isolate is not paused.
   @override
-  Future<Stack> getStack(String isolateId) {
-    throw UnimplementedError();
-  }
+  Future<Stack> getStack(String isolateId) async =>
+      isolateId == _isolate?.id ? _pausedStack : null;
 
   @override
   Future<VM> getVM() => Future.value(_vm);
@@ -771,6 +787,30 @@ function($argsString) {
     return controller;
   }
 
+  List<Frame> _translateJsFrames(DebuggerPausedEvent e) {
+    var dartFrames = <Frame>[];
+    var index = 0;
+    for (var frame in e.params['callFrames']) {
+      var location = frame['location'];
+      // TODO(grouma) - This function name is JS based. Add logic to
+      // translate this to a Dart function name.
+      var functionName = frame['functionName'] as String ?? '';
+      // Chrome is 0 based. Account for this.
+      var jsLocation = JsLocation(
+          location['scriptId'] as String,
+          location['lineNumber'] + 1 as int,
+          location['columnNumber'] + 1 as int);
+      var dartFrame = debugger.frameFor(jsLocation);
+      if (dartFrame != null) {
+        dartFrame.code.name =
+            functionName.isEmpty ? '(anonymous)' : functionName;
+        dartFrame.index = index++;
+        dartFrames.add(dartFrame);
+      }
+    }
+    return dartFrames;
+  }
+
   /// Listens to the `debugger` events from chrome and translates those to
   /// the `Debug` stream events for the vm service protocol.
   ///
@@ -792,10 +832,14 @@ function($argsString) {
         } else {
           event.kind = EventKind.kPauseInterrupted;
         }
+        _pausedStack = Stack()
+          ..frames = _translateJsFrames(e)
+          ..messages = [];
         streamNotify('Debug', event);
       });
       resumeSubscription = tabConnection.debugger.onResumed.listen((e) {
         if (_isolate == null) return;
+        _pausedStack = null;
         streamNotify(
             'Debug',
             Event()

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -134,7 +134,7 @@ class Debugger {
 
   /// Returns the closest [Location] for the given Dart source position.
   ///
-  /// The [line] and [column] are  1-based.
+  /// The [line] and [column] are 1-based.
   ///
   /// Can return null if no suitable [Location] is found.
   Location _bestLocationForJs(String scriptId, int line, int column) {

--- a/dwds/lib/src/location.dart
+++ b/dwds/lib/src/location.dart
@@ -4,6 +4,8 @@
 
 import 'package:source_maps/parser.dart';
 
+import 'dart_uri.dart';
+
 var _startTokenId = 1337;
 
 /// A source location, with both Dart and JS information.
@@ -12,39 +14,23 @@ var _startTokenId = 1337;
 /// Service protocol line/column numbers are one-based, but in JS source maps and
 /// the Chrome protocol are zero-based, so they require translation.
 class Location {
-  final String jsScriptId;
+  final JsLocation jsLocation;
 
-  /// 1 based row offset within the JS source code.
-  final int jsLine;
-
-  /// 1 based column offset within the JS source code.
-  final int jsColumn;
-
-  final String dartUri;
-
-  /// 1 based row offset within the Dart source code.
-  final int dartLine;
-
-  /// 1 based column offset within the Dart source code.
-  final int dartColumn;
+  final DartLocation dartLocation;
 
   /// An arbitrary integer value used to represent this location.
   final int tokenPos;
 
   Location._(
-    this.jsScriptId,
-    this.jsLine,
-    this.jsColumn,
-    this.dartUri,
-    this.dartLine,
-    this.dartColumn,
+    this.jsLocation,
+    this.dartLocation,
   ) : tokenPos = _startTokenId++;
 
   static Location from(
     String scriptId,
     TargetLineEntry lineEntry,
     TargetEntry entry,
-    String dartUrl,
+    DartUri dartUri,
   ) {
     var dartLine = entry.sourceLine;
     var dartColumn = entry.sourceColumn;
@@ -52,7 +38,42 @@ class Location {
     var jsColumn = entry.column;
     // lineEntry data is 0 based according to:
     // https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k
-    return Location._(scriptId, jsLine + 1, jsColumn + 1, dartUrl, dartLine + 1,
-        dartColumn + 1);
+    return Location._(JsLocation(scriptId, jsLine + 1, jsColumn + 1),
+        DartLocation(dartUri, dartLine + 1, dartColumn + 1));
   }
+}
+
+/// Location information for a Dart source.
+class DartLocation {
+  final DartUri uri;
+
+  /// 1 based row offset within the Dart source code.
+  final int line;
+
+  /// 1 based column offset within the Dart source code.
+  final int column;
+
+  DartLocation(
+    this.uri,
+    this.line,
+    this.column,
+  );
+}
+
+/// Location information for a JS source.
+class JsLocation {
+  /// The script ID as provided by Chrome.
+  final String scriptId;
+
+  /// 1 based row offset within the JS source code.
+  final int line;
+
+  /// 1 based column offset within the JS source code.
+  final int column;
+
+  JsLocation(
+    this.scriptId,
+    this.line,
+    this.column,
+  );
 }

--- a/dwds/lib/src/location.dart
+++ b/dwds/lib/src/location.dart
@@ -9,10 +9,6 @@ import 'dart_uri.dart';
 var _startTokenId = 1337;
 
 /// A source location, with both Dart and JS information.
-///
-/// Note that line and column numbers here are always 1-based. The  Dart VM
-/// Service protocol line/column numbers are one-based, but in JS source maps and
-/// the Chrome protocol are zero-based, so they require translation.
 class Location {
   final JsLocation jsLocation;
 
@@ -38,8 +34,8 @@ class Location {
     var jsColumn = entry.column;
     // lineEntry data is 0 based according to:
     // https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k
-    return Location._(JsLocation(scriptId, jsLine + 1, jsColumn + 1),
-        DartLocation(dartUri, dartLine + 1, dartColumn + 1));
+    return Location._(JsLocation.fromZeroBased(scriptId, jsLine, jsColumn),
+        DartLocation.fromZeroBased(dartUri, dartLine, dartColumn));
   }
 }
 
@@ -53,11 +49,17 @@ class DartLocation {
   /// 1 based column offset within the Dart source code.
   final int column;
 
-  DartLocation(
+  DartLocation._(
     this.uri,
     this.line,
     this.column,
   );
+
+  static DartLocation fromZeroBased(DartUri uri, int line, int column) =>
+      DartLocation._(uri, line + 1, column + 1);
+
+  static DartLocation fromOneBased(DartUri uri, int line, int column) =>
+      DartLocation._(uri, line, column);
 }
 
 /// Location information for a JS source.
@@ -71,9 +73,15 @@ class JsLocation {
   /// 1 based column offset within the JS source code.
   final int column;
 
-  JsLocation(
+  JsLocation._(
     this.scriptId,
     this.line,
     this.column,
   );
+
+  static JsLocation fromZeroBased(String scriptId, int line, int column) =>
+      JsLocation._(scriptId, line + 1, column + 1);
+
+  static JsLocation fromOneBased(String scriptId, int line, int column) =>
+      JsLocation._(scriptId, line, column);
 }

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.3.2
+version: 0.3.3-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-


### PR DESCRIPTION
- Update `Location` to group JS fields into `JsLocation` and Dart fields into `DartLocation`
- Add logic to translate JS frame information into Dart frame
- Listen for pause events to cache the current Dart frame

Closes https://github.com/dart-lang/webdev/issues/348
Towards https://github.com/dart-lang/webdev/issues/352