### PR TITLE
Refactor Chrome Proxy Service

### DIFF
--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -97,7 +97,7 @@ class ChromeProxyService implements VmServiceInterface {
   }
 
   Future<Null> _initialize() async {
-    _debugger = await Debugger.initialize(
+    _debugger = await Debugger.create(
       _assetHandler,
       tabConnection,
       _streamNotify,

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -121,15 +121,12 @@ class ChromeProxyService implements VmServiceInterface {
           'Cannot create multiple isolates for the same app');
     }
 
-    _inspector = Inspector(
-      createId(),
+    _inspector = await Inspector.initialize(
       tabConnection,
       _assetHandler,
       _debugger,
       uri,
     );
-
-    await _inspector.initialize();
 
     var isolateRef = toIsolateRef(_inspector.isolate);
 
@@ -164,7 +161,7 @@ class ChromeProxyService implements VmServiceInterface {
 
   /// Should be called when there is a hot restart or full page refresh.
   ///
-  /// Clears out [_isolate] and all related cached information.
+  /// Clears out the [_inspector] and all related cached information.
   void destroyIsolate() {
     var isolate = _inspector?.isolate;
     if (isolate == null) return;
@@ -174,7 +171,6 @@ class ChromeProxyService implements VmServiceInterface {
           ..kind = EventKind.kIsolateExit
           ..isolate = toIsolateRef(isolate));
     _vm.isolates.removeWhere((ref) => ref.id == isolate.id);
-
     _inspector = null;
     _consoleSubscription.cancel();
     _consoleSubscription = null;

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -22,10 +22,10 @@ typedef AssetHandler = Future<String> Function(String);
 /// on that stream.
 typedef StreamNotify = void Function(String streamId, Event event);
 
-/// Returns the [Inspector] for the current tab.
+/// Returns the [AppInspector] for the current tab.
 ///
 /// This may be null during a hot restart or page refresh.
-typedef CurrentInspector = Inspector Function();
+typedef AppInspectorProvider = AppInspector Function();
 
 /// A proxy from the chrome debug protocol to the dart vm service protocol.
 class ChromeProxyService implements VmServiceInterface {
@@ -50,8 +50,9 @@ class ChromeProxyService implements VmServiceInterface {
   /// Provides debugger-related functionality.
   Debugger _debugger;
 
-  Inspector _inspector;
-  Inspector _currentInspector() => _inspector;
+  AppInspector _inspector;
+  AppInspector _appInspectorProvider() =>
+      _inspector ?? (throw StateError('Null AppInspetor.'));
 
   StreamSubscription<ConsoleAPIEvent> _consoleSubscription;
 
@@ -100,7 +101,7 @@ class ChromeProxyService implements VmServiceInterface {
       _assetHandler,
       tabConnection,
       _streamNotify,
-      _currentInspector,
+      _appInspectorProvider,
       uri,
     );
   }
@@ -119,7 +120,7 @@ class ChromeProxyService implements VmServiceInterface {
           'Cannot create multiple isolates for the same app');
     }
 
-    _inspector = await Inspector.initialize(
+    _inspector = await AppInspector.initialize(
       tabConnection,
       _assetHandler,
       _debugger,

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -60,15 +60,7 @@ class ChromeProxyService implements VmServiceInterface {
     this._tab,
     this.tabConnection,
     this._assetHandler,
-  ) {
-    _debugger = Debugger(
-      _assetHandler,
-      tabConnection,
-      _streamNotify,
-      _currentInspector,
-      uri,
-    );
-  }
+  );
 
   static Future<ChromeProxyService> create(ChromeConnection chromeConnection,
       AssetHandler assetHandler, String appInstanceId) async {
@@ -104,7 +96,13 @@ class ChromeProxyService implements VmServiceInterface {
   }
 
   Future<Null> _initialize() async {
-    await _debugger.initialize();
+    _debugger = await Debugger.initialize(
+      _assetHandler,
+      tabConnection,
+      _streamNotify,
+      _currentInspector,
+      uri,
+    );
   }
 
   /// The root URI at which we're serving.

--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -11,9 +11,21 @@ import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import 'dart_uri.dart';
 import 'debugger.dart';
 import 'helpers.dart';
+import 'inspector.dart';
+
+/// A handler for application assets, e.g. Dart sources.
+typedef AssetHandler = Future<String> Function(String);
+
+/// Adds [event] to the stream with [streamId] if there is anybody listening
+/// on that stream.
+typedef StreamNotify = void Function(String streamId, Event event);
+
+/// Returns the [Inspector] for the current tab.
+///
+/// This may be null during a hot restart or page refresh.
+typedef CurrentInspector = Inspector Function();
 
 /// A proxy from the chrome debug protocol to the dart vm service protocol.
 class ChromeProxyService implements VmServiceInterface {
@@ -30,40 +42,36 @@ class ChromeProxyService implements VmServiceInterface {
   final ChromeTab _tab;
 
   /// The connection with the chrome debug service for the tab.
+  // TODO(grouma) - This should be class private.
   final WipConnection tabConnection;
 
-  /// A handler for application assets, e.g. Dart sources.
-  final Future<String> Function(String) assetHandler;
-
-  /// The isolate for the current tab.
-  ///
-  /// This may be null during a hot restart or page refresh.
-  Isolate _isolate;
-
-  Isolate get isolate => _isolate;
+  final AssetHandler _assetHandler;
 
   /// Provides debugger-related functionality.
-  Debugger debugger;
+  Debugger _debugger;
 
-  /// Fields that are specific to the current [_isolate].
-  ///
-  /// These need to get cleared whenever [destroyIsolate] is called.
-  // TODO(grouma) - Subclass Isolate to group these together. This will ensure
-  // that they are properly cleaned up and documented.
-  final _classes = <String, Class>{};
-  final _scriptRefs = <String, ScriptRef>{};
-  final _serverPathToScriptRef = <String, ScriptRef>{};
-  final _libraries = <String, Library>{};
-  final _libraryRefs = <String, LibraryRef>{};
+  Inspector _inspector;
+  Inspector _currentInspector() => _inspector;
+
   StreamSubscription<ConsoleAPIEvent> _consoleSubscription;
 
   ChromeProxyService._(
-      this._vm, this._tab, this.tabConnection, this.assetHandler);
+    this._vm,
+    this._tab,
+    this.tabConnection,
+    this._assetHandler,
+  ) {
+    _debugger = Debugger(
+      _assetHandler,
+      tabConnection,
+      _streamNotify,
+      _currentInspector,
+      uri,
+    );
+  }
 
-  static Future<ChromeProxyService> create(
-      ChromeConnection chromeConnection,
-      Future<String> Function(String) assetHandler,
-      String appInstanceId) async {
+  static Future<ChromeProxyService> create(ChromeConnection chromeConnection,
+      AssetHandler assetHandler, String appInstanceId) async {
     ChromeTab appTab;
     for (var tab in await chromeConnection.getTabs()) {
       if (tab.url.startsWith('chrome-extensions:')) continue;
@@ -96,67 +104,46 @@ class ChromeProxyService implements VmServiceInterface {
   }
 
   Future<Null> _initialize() async {
-    debugger = Debugger(this);
-    await debugger.initialize();
+    await _debugger.initialize();
   }
 
   /// The root URI at which we're serving.
   String get uri => _tab.url;
 
-  /// Creates a new [_isolate].
+  /// Creates a new isolate.
   ///
   /// Only one isolate at a time is supported, but they should be cleaned up
   /// with [destroyIsolate] and recreated with this method there is a hot
   /// restart or full page refresh.
   Future<void> createIsolate() async {
-    if (_isolate != null) {
+    if (_inspector?.isolate != null) {
       throw UnsupportedError(
           'Cannot create multiple isolates for the same app');
     }
 
-    var id = createId();
-    var isolate = Isolate()
-      ..id = id
-      ..number = id
-      ..name = '$uri:main()'
-      ..runnable = true
-      ..breakpoints = []
-      ..libraries = []
-      ..extensionRPCs = [];
-    var isolateRef = toIsolateRef(isolate);
-    isolate.pauseEvent = Event()
-      ..kind = EventKind.kResume
-      ..isolate = isolateRef;
+    _inspector = Inspector(
+      createId(),
+      tabConnection,
+      _assetHandler,
+      _debugger,
+      uri,
+    );
 
-    for (var library in await _getLibraryNames()) {
-      isolate.libraries.add(LibraryRef()
-        ..id = library
-        ..name = library
-        ..uri = library);
-    }
+    await _inspector.initialize();
 
-    // TODO: Something more robust here, right now we rely on the 2nd to last
-    // library being the root one (the last library is the bootstrap lib).
-    isolate.rootLib = isolate.libraries[isolate.libraries.length - 2];
-
-    isolate.extensionRPCs.addAll(await _getExtensionRpcs());
-
-    for (var libraryRef in isolate.libraries) {
-      _libraryRefs[libraryRef.id] = libraryRef;
-    }
+    var isolateRef = toIsolateRef(_inspector.isolate);
 
     // Listen for `registerExtension` and `postEvent` calls.
     _setUpChromeConsoleListeners(isolateRef);
 
     _vm.isolates.add(isolateRef);
-    _isolate = isolate;
 
-    streamNotify(
+    _streamNotify(
         'Isolate',
         Event()
           ..kind = EventKind.kIsolateStart
           ..isolate = isolateRef);
-    streamNotify(
+    _streamNotify(
         'Isolate',
         Event()
           ..kind = EventKind.kIsolateRunnable
@@ -165,8 +152,8 @@ class ChromeProxyService implements VmServiceInterface {
     // TODO: We shouldn't need to fire these events since they exist on the
     // isolate, but devtools doesn't recognize extensions after a page refresh
     // otherwise.
-    for (var extensionRpc in isolate.extensionRPCs) {
-      streamNotify(
+    for (var extensionRpc in _inspector.isolate.extensionRPCs) {
+      _streamNotify(
           'Isolate',
           Event()
             ..kind = EventKind.kServiceExtensionAdded
@@ -179,29 +166,24 @@ class ChromeProxyService implements VmServiceInterface {
   ///
   /// Clears out [_isolate] and all related cached information.
   void destroyIsolate() {
-    if (_isolate == null) return;
-    streamNotify(
+    var isolate = _inspector?.isolate;
+    if (isolate == null) return;
+    _streamNotify(
         'Isolate',
         Event()
           ..kind = EventKind.kIsolateExit
-          ..isolate = toIsolateRef(_isolate));
-    _vm.isolates.removeWhere((ref) => ref.id == _isolate.id);
+          ..isolate = toIsolateRef(isolate));
+    _vm.isolates.removeWhere((ref) => ref.id == isolate.id);
 
-    _isolate = null;
-    _classes.clear();
-    _scriptRefs.clear();
-    _serverPathToScriptRef.clear();
-    _libraries.clear();
-    _libraryRefs.clear();
+    _inspector = null;
     _consoleSubscription.cancel();
     _consoleSubscription = null;
   }
 
   @override
   Future<Breakpoint> addBreakpoint(String isolateId, String scriptId, int line,
-      {int column}) async {
-    return debugger.addBreakpoint(isolateId, scriptId, line, column: column);
-  }
+          {int column}) =>
+      _debugger.addBreakpoint(isolateId, scriptId, line, column: column);
 
   @override
   Future<Breakpoint> addBreakpointAtEntry(String isolateId, String functionId) {
@@ -264,82 +246,9 @@ require("dart_sdk").developer.invokeExtension(
 
   @override
   Future evaluate(String isolateId, String targetId, String expression,
-      {Map<String, String> scope, bool disableBreakpoints}) async {
-    scope ??= {};
-    disableBreakpoints ??= false;
-    var library = await _getLibrary(isolateId, targetId);
-    if (library == null) {
-      throw UnsupportedError(
-          'Evaluate is only supported when `targetId` is a library.');
-    }
-    WipResponse result;
-
-    // If there is scope, we use `callFunctionOn` because that accepts the
-    // `arguments` option.
-    //
-    // If there is no scope we run a normal evaluate call.
-    if (scope.isEmpty) {
-      var evalExpression = '''
-(function() {
-  ${_getLibrarySnippet(library.uri)};
-  return library.$expression;
-})();
-    ''';
-      result = await tabConnection.runtime.sendCommand('Runtime.evaluate',
-          params: {'expression': evalExpression});
-      handleErrorIfPresent(result,
-          evalContents: evalExpression,
-          additionalDetails: {
-            'Dart expression': expression,
-          });
-    } else {
-      var argsString = scope.keys.join(', ');
-      var arguments = scope.values.map((id) => {'objectId': id}).toList();
-      var evalExpression = '''
-function($argsString) {
-  ${_getLibrarySnippet(library.uri)};
-  return library.$expression;
-}
-    ''';
-      result = await tabConnection.runtime
-          .sendCommand('Runtime.callFunctionOn', params: {
-        'functionDeclaration': evalExpression,
-        'arguments': arguments,
-        // TODO(jakemac): Use the executionContext instead, or possibly the
-        // library object. This will get weird if people try to use `this` in
-        // their expression.
-        'objectId': scope.values.first,
-      });
-      handleErrorIfPresent(result,
-          evalContents: evalExpression,
-          additionalDetails: {
-            'Dart expression': expression,
-            'scope': scope,
-          });
-    }
-    var remoteObject =
-        RemoteObject(result.result['result'] as Map<String, dynamic>);
-
-    switch (remoteObject.type) {
-      case 'string':
-        return _primitiveInstance(InstanceKind.kString, remoteObject);
-      case 'number':
-        return _primitiveInstance(InstanceKind.kDouble, remoteObject);
-      case 'boolean':
-        return _primitiveInstance(InstanceKind.kBool, remoteObject);
-      case 'object':
-        return InstanceRef()
-          ..kind = InstanceKind.kPlainInstance
-          ..id = remoteObject.objectId
-          // TODO(jakemac): Create a real ClassRef, we need a way of looking
-          // up the library for a given instance to create it though.
-          // https://github.com/dart-lang/sdk/issues/36771.
-          ..classRef = ClassRef();
-      default:
-        throw UnsupportedError(
-            'Unsupported response type ${remoteObject.type}');
-    }
-  }
+          {Map<String, String> scope, bool disableBreakpoints}) =>
+      _inspector?.evaluate(isolateId, targetId, expression,
+          scope: scope, disableBreakpoints: disableBreakpoints);
 
   @override
   Future evaluateInFrame(String isolateId, int frameIndex, String expression,
@@ -371,140 +280,14 @@ function($argsString) {
   /// Sync version of [getIsolate] for internal use, also has stronger typing
   /// than the public one which has to be dynamic.
   Isolate _getIsolate(String isolateId) {
-    if (_isolate?.id == isolateId) return _isolate;
+    var isolate = _inspector?.isolate;
+    if (isolate?.id == isolateId) return isolate;
     throw ArgumentError.value(
         isolateId, 'isolateId', 'Unrecognized isolate id');
   }
 
   @override
   Future getIsolate(String isolateId) async => _getIsolate(isolateId);
-
-  Future<Library> _constructLibrary(LibraryRef libraryRef) async {
-    // Fetch information about all the classes in this library.
-    var expression = '''
-    (function() {
-    ${_getLibrarySnippet(libraryRef.uri)}
-      var classes = Object.values(library)
-        .filter((l) => l && sdkUtils.isType(l));
-      return classes.map(function(clazz) {
-        var descriptor = {'name': clazz.name};
-
-        // TODO(jakemac): static methods once ddc supports them
-        var methods = sdkUtils.getMethods(clazz);
-        var methodNames = methods ? Object.keys(methods) : [];
-        descriptor['methods'] = {};
-        for (var name of methodNames) {
-          var method = methods[name];
-          descriptor['methods'][name] = {
-            // TODO(jakemac): how can we get actual const info?
-            "isConst": false,
-            "isStatic": false,
-          }
-        }
-
-        // TODO(jakemac): static fields once ddc supports them
-        var fields = sdkUtils.getFields(clazz);
-        var fieldNames = fields ? Object.keys(fields) : [];
-        descriptor['fields'] = {};
-        for (var name of fieldNames) {
-          var field = fields[name];
-          descriptor['fields'][name] = {
-            // TODO(jakemac): how can we get actual const info?
-            "isConst": false,
-            "isFinal": field.isFinal,
-            "isStatic": false,
-          }
-        }
-
-        return descriptor;
-      });
-    })()
-    ''';
-    var classesResult = await tabConnection.runtime.sendCommand(
-        'Runtime.evaluate',
-        params: {'expression': expression, 'returnByValue': true});
-    handleErrorIfPresent(classesResult, evalContents: expression);
-    var classDescriptors = (classesResult.result['result']['value'] as List)
-        .cast<Map<String, Object>>();
-    var classRefs = <ClassRef>[];
-    for (var classDescriptor in classDescriptors) {
-      var name = classDescriptor['name'] as String;
-      var classId = '${libraryRef.id}:$name';
-      var classRef = ClassRef()
-        ..name = name
-        ..id = classId;
-      classRefs.add(classRef);
-
-      var methodRefs = <FuncRef>[];
-      var methodDescriptors =
-          classDescriptor['methods'] as Map<String, dynamic>;
-      methodDescriptors.forEach((name, descriptor) {
-        var methodId = '$classId:$name';
-        methodRefs.add(FuncRef()
-          ..id = methodId
-          ..name = name
-          ..owner = classRef
-          ..isConst = descriptor['isConst'] as bool
-          ..isStatic = descriptor['isStatic'] as bool);
-      });
-
-      var fieldRefs = <FieldRef>[];
-      var fieldDescriptors = classDescriptor['fields'] as Map<String, dynamic>;
-      fieldDescriptors.forEach((name, descriptor) {
-        fieldRefs.add(FieldRef()
-          ..name = name
-          ..declaredType = (InstanceRef()..classRef = ClassRef())
-          ..owner = classRef
-          ..isConst = descriptor['isConst'] as bool
-          ..isFinal = descriptor['isFinal'] as bool
-          ..isStatic = descriptor['isStatic'] as bool);
-      });
-
-      // TODO: Implement the rest of these
-      // https://github.com/dart-lang/webdev/issues/176.
-      _classes[classId] = Class()
-        ..classRef = classRef
-        ..fields = fieldRefs
-        ..functions = methodRefs
-        ..id = classId
-        ..library = libraryRef
-        ..name = name
-        ..interfaces = []
-        ..subclasses = [];
-    }
-
-    // TODO(grouma) - This currently does not support part files.
-    // Figure out how to support them.
-    var scriptRef = ScriptRef()
-      ..uri = libraryRef.uri
-      ..id = createId();
-
-    _scriptRefs[scriptRef.id] = scriptRef;
-    _serverPathToScriptRef[DartUri(libraryRef.id, scriptRef.uri).serverPath] =
-        scriptRef;
-
-    return Library()
-      ..id = libraryRef.id
-      ..name = libraryRef.name
-      ..uri = libraryRef.uri
-      ..classes = classRefs
-      ..debuggable = true
-      ..dependencies = []
-      ..functions = []
-      ..scripts = [scriptRef]
-      ..variables = [];
-  }
-
-  Future<Library> _getLibrary(String isolateId, String objectId) async {
-    if (isolateId != _isolate?.id) return null;
-    var libraryRef = _libraryRefs[objectId];
-    if (libraryRef == null) return null;
-    var library = _libraries[objectId];
-    if (library != null) return library;
-    library = await _constructLibrary(libraryRef);
-    _libraries[objectId] = library;
-    return library;
-  }
 
   @override
   Future<dynamic> getMemoryUsage(String isolateId) async {
@@ -513,57 +296,12 @@ function($argsString) {
 
   @override
   Future getObject(String isolateId, String objectId,
-      {int offset, int count}) async {
-    var library = await _getLibrary(isolateId, objectId);
-    if (library != null) return library;
-    var clazz = _classes[objectId];
-    if (clazz != null) return clazz;
-    var scriptRef = _scriptRefs[objectId];
-    if (scriptRef != null) return await _getScript(isolateId, scriptRef);
-
-    throw UnsupportedError(
-        'Only libraries and classes are supported for getObject');
-  }
+          {int offset, int count}) =>
+      _inspector?.getObject(isolateId, objectId, offset: offset, count: count);
 
   @override
-  Future<ScriptList> getScripts(String isolateId) async {
-    var scripts = await scriptRefs(isolateId);
-    return ScriptList()..scripts = scripts;
-  }
-
-  /// Returns the [ScriptRef] for the provided Dart server path [uri].
-  ScriptRef scriptRefFor(String uri) => _serverPathToScriptRef[uri];
-
-  Future<Script> _getScript(String isolateId, ScriptRef scriptRef) async {
-    var libraryId = scriptRef.uri;
-    // TODO(401): Remove uri parameter.
-    var serverPath = DartUri(libraryId, uri).serverPath;
-    var script = await assetHandler(serverPath);
-    return Script()
-      ..library = _libraryRefs[libraryId]
-      ..id = scriptRef.id
-      ..uri = libraryId
-      ..tokenPosTable = debugger.sources.tokenPosTableFor(serverPath)
-      ..source = script;
-  }
-
-  /// Internal method to list all scripts in the isolate.
-  ///
-  /// This is used as the underlying mechanism
-  /// for [getScripts].
-  Future<List<ScriptRef>> scriptRefs(String isolateId) async {
-    var isolate = _getIsolate(isolateId);
-    var scripts = <ScriptRef>[];
-    for (var lib in isolate.libraries) {
-      // We can't provide the source for `dart:` imports so ignore for now.
-      // Also `main.dart.bootstrap` does not have a corresponding script.
-      if (lib.id.startsWith('dart:') || lib.id.endsWith('.bootstrap')) continue;
-      scripts.addAll((await _getLibrary(isolateId, lib.id)).scripts);
-    }
-    // TODO(alanknight): Is this the same as the values in _scriptRefs after
-    // constructing all the libraries? Make that clearer.
-    return scripts;
-  }
+  Future<ScriptList> getScripts(String isolateId) =>
+      _inspector?.getScripts(isolateId);
 
   @override
   Future<SourceReport> getSourceReport(String isolateId, List<String> reports,
@@ -575,7 +313,7 @@ function($argsString) {
   ///
   /// Returns null if the corresponding isolate is not paused.
   @override
-  Future<Stack> getStack(String isolateId) => debugger.getStack(isolateId);
+  Future<Stack> getStack(String isolateId) => _debugger.getStack(isolateId);
 
   @override
   Future<VM> getVM() => Future.value(_vm);
@@ -636,7 +374,7 @@ function($argsString) {
   }
 
   @override
-  Future<Success> pause(String isolateId) => debugger.pause();
+  Future<Success> pause(String isolateId) => _debugger.pause();
 
   @override
   Future<Success> registerService(String service, String alias) async {
@@ -650,11 +388,8 @@ function($argsString) {
   }
 
   @override
-  Future<Success> removeBreakpoint(
-      String isolateId, String breakpointId) async {
-    await debugger.removeBreakpoint(isolateId, breakpointId);
-    return Success();
-  }
+  Future<Success> removeBreakpoint(String isolateId, String breakpointId) =>
+      _debugger.removeBreakpoint(isolateId, breakpointId);
 
   @override
   Future<Success> requestHeapSnapshot(
@@ -665,20 +400,11 @@ function($argsString) {
   @override
   Future<Success> resume(String isolateId,
           {String step, int frameIndex}) async =>
-      debugger.resume(isolateId, step: step, frameIndex: frameIndex);
+      _debugger.resume(isolateId, step: step, frameIndex: frameIndex);
 
   @override
-  Future<Success> setExceptionPauseMode(String isolateId, String mode) async {
-    // Validates that the ID is correct.
-    _getIsolate(isolateId);
-
-    var pauseState = _pauseModePauseStates[mode.toLowerCase()] ??
-        // ignore: only_throw_errors
-        (throw RPCError(
-            'setExceptionPauseMode', -32602, 'Unsupported mode `$mode`'));
-    await tabConnection.debugger.setPauseOnExceptions(pauseState);
-    return Success();
-  }
+  Future<Success> setExceptionPauseMode(String isolateId, String mode) =>
+      _debugger.setExceptionPauseMode(isolateId, mode);
 
   @override
   Future<Success> setFlag(String name, String value) {
@@ -701,7 +427,7 @@ function($argsString) {
   @override
   Future<Success> setVMName(String name) async {
     _vm.name = name;
-    streamNotify(
+    _streamNotify(
         'VM',
         Event()
           ..kind = EventKind.kVMUpdate
@@ -742,24 +468,26 @@ function($argsString) {
     }, onListen: () {
       chromeConsoleSubscription =
           tabConnection.runtime.onConsoleAPICalled.listen((e) {
-        if (_isolate == null) return;
+        var isolate = _inspector?.isolate;
+        if (isolate == null) return;
         if (!filter(e)) return;
         var args = e.params['args'] as List;
         var item = args[0] as Map;
         var value = '${item["value"]}\n';
         controller.add(Event()
           ..kind = EventKind.kWriteEvent
-          ..isolate = toIsolateRef(_isolate)
+          ..isolate = toIsolateRef(isolate)
           ..bytes = base64.encode(utf8.encode(value))
           ..timestamp = e.timestamp.toInt());
       });
       if (includeExceptions) {
         exceptionsSubscription =
             tabConnection.runtime.onExceptionThrown.listen((e) {
-          if (_isolate == null) return;
+          var isolate = _inspector?.isolate;
+          if (isolate == null) return;
           controller.add(Event()
             ..kind = EventKind.kWriteEvent
-            ..isolate = toIsolateRef(_isolate)
+            ..isolate = toIsolateRef(isolate)
             ..bytes = base64
                 .encode(utf8.encode(e.exceptionDetails.exception.description)));
         });
@@ -768,38 +496,19 @@ function($argsString) {
     return controller;
   }
 
-  /// Runs an eval on the page to compute all existing registered extensions.
-  Future<List<String>> _getExtensionRpcs() async {
-    var expression = "require('dart_sdk').developer._extensions.keys.toList();";
-    var extensionsResult = await tabConnection.runtime.sendCommand(
-        'Runtime.evaluate',
-        params: {'expression': expression, 'returnByValue': true});
-    handleErrorIfPresent(extensionsResult, evalContents: expression);
-    return List.from(extensionsResult.result['result']['value'] as List);
-  }
-
-  /// Runs an eval on the page to compute all the library names in the app.
-  Future<List<String>> _getLibraryNames() async {
-    var expression = "require('dart_sdk').dart.getLibraries();";
-    var librariesResult = await tabConnection.runtime.sendCommand(
-        'Runtime.evaluate',
-        params: {'expression': expression, 'returnByValue': true});
-    handleErrorIfPresent(librariesResult, evalContents: expression);
-    return List.from(librariesResult.result['result']['value'] as List);
-  }
-
   /// Listens for chrome console events and handles the ones we care about.
   void _setUpChromeConsoleListeners(IsolateRef isolateRef) {
     _consoleSubscription = tabConnection.runtime.onConsoleAPICalled
         .listen((ConsoleAPIEvent event) {
-      if (_isolate == null) return;
+      var isolate = _inspector?.isolate;
+      if (isolate == null) return;
       if (event.type != 'debug') return;
       var firstArgValue = event.args[0].value as String;
       switch (firstArgValue) {
         case 'dart.developer.registerExtension':
           var service = event.args[1].value as String;
-          _isolate.extensionRPCs.add(service);
-          streamNotify(
+          isolate.extensionRPCs.add(service);
+          _streamNotify(
               'Isolate',
               Event()
                 ..kind = EventKind.kServiceExtensionAdded
@@ -807,7 +516,7 @@ function($argsString) {
                 ..isolate = isolateRef);
           break;
         case 'dart.developer.postEvent':
-          streamNotify(
+          _streamNotify(
               'Extension',
               Event()
                 ..kind = EventKind.kExtension
@@ -827,7 +536,7 @@ function($argsString) {
             // up the library for a given instance to create it though.
             // https://github.com/dart-lang/sdk/issues/36771.
             ..classRef = ClassRef();
-          streamNotify(
+          _streamNotify(
               'Debug',
               Event()
                 ..kind = EventKind.kInspect
@@ -841,9 +550,7 @@ function($argsString) {
     });
   }
 
-  /// Adds [event] to the stream with [streamId] if there is anybody listening
-  /// on that stream.
-  void streamNotify(String streamId, Event event) {
+  void _streamNotify(String streamId, Event event) {
     var controller = _streamControllers[streamId];
     if (controller == null) return;
     controller.add(event);
@@ -867,25 +574,6 @@ void handleErrorIfPresent(WipResponse response,
         additionalDetails: additionalDetails);
   }
 }
-
-/// Creates a snippet of JS code that initializes a `library` variable that has
-/// the actual library object in DDC for [libraryUri].
-///
-/// In DDC we have module libraries indexed by names of the form
-/// 'packages/package/mainFile' with no .dart suffix on the file, or
-/// 'directory/packageName/mainFile', also with no .dart suffix, and relative to
-/// the serving root, normally /web within the package. These modules have a map
-/// from the URI with a Dart-specific scheme (package: or org-dartlang-app:) to
-/// the library objects. The [libraryUri] parameter should be one of these
-/// Dart-specific scheme URIs, and we set `library` the corresponding library.
-String _getLibrarySnippet(String libraryUri) => '''
-  var libraryName = '$libraryUri';
-  var sdkUtils = require('dart_sdk').dart;
-  var moduleName = sdkUtils.getModuleNames().find(
-    (name) => sdkUtils.getModuleLibraries(name)[libraryName]);
-  var library = sdkUtils.getModuleLibraries(moduleName)[libraryName];
-  if (!library) throw 'cannot find library for ' + libraryName + ' under ' + moduleName;
-''';
 
 class ChromeDebugException extends ExceptionDetails implements Exception {
   /// Optional, additional information about the exception.
@@ -919,22 +607,4 @@ class ChromeDebugException extends ExceptionDetails implements Exception {
     }
     return description.toString();
   }
-}
-
-/// Converts from ExceptionPauseMode strings to [PauseState] enums.
-const _pauseModePauseStates = {
-  'none': PauseState.none,
-  'all': PauseState.all,
-  'unhandled': PauseState.uncaught,
-};
-
-/// Creates an [InstanceRef] for a primitive [RemoteObject].
-InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
-  var classRef = ClassRef()
-    ..id = 'dart:core:${remoteObject.type}'
-    ..name = kind;
-  return InstanceRef()
-    ..valueAsString = '${remoteObject.value}'
-    ..classRef = classRef
-    ..kind = kind;
 }

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -28,7 +28,7 @@ class Debugger {
   final CurrentInspector _currentInspector;
   final String _root;
 
-  Debugger(
+  Debugger._(
     this._assetHandler,
     this._tabConnection,
     this._streamNotify,
@@ -131,7 +131,25 @@ class Debugger {
     return _pausedStack;
   }
 
-  Future<Null> initialize() async {
+  static Future<Debugger> initialize(
+      AssetHandler assetHandler,
+      WipConnection tabConnection,
+      StreamNotify streamNotify,
+      CurrentInspector currentInspector,
+      String root) async {
+    var debugger = Debugger._(
+      assetHandler,
+      tabConnection,
+      streamNotify,
+      currentInspector,
+      // TODO(401) - Remove.
+      root,
+    );
+    await debugger._initialize();
+    return debugger;
+  }
+
+  Future<Null> _initialize() async {
     sources = Sources(_assetHandler);
     // We must add a listener before enabling the debugger otherwise we will
     // miss events.

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -14,6 +14,9 @@ import 'location.dart';
 import 'sources.dart';
 
 /// Converts from ExceptionPauseMode strings to [PauseState] enums.
+///
+/// Values defined in:
+/// https://chromedevtools.github.io/devtools-protocol/tot/Debugger#method-setPauseOnExceptions
 const _pauseModePauseStates = {
   'none': PauseState.none,
   'all': PauseState.all,
@@ -133,7 +136,7 @@ class Debugger {
     return _pausedStack;
   }
 
-  static Future<Debugger> initialize(
+  static Future<Debugger> create(
       AssetHandler assetHandler,
       WipConnection tabConnection,
       StreamNotify streamNotify,

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -13,12 +13,31 @@ import 'helpers.dart';
 import 'location.dart';
 import 'sources.dart';
 
+/// Converts from ExceptionPauseMode strings to [PauseState] enums.
+const _pauseModePauseStates = {
+  'none': PauseState.none,
+  'all': PauseState.all,
+  'unhandled': PauseState.uncaught,
+};
+
 class Debugger {
-  Debugger(this._mainProxy) : _breakpoints = _Breakpoints(_mainProxy);
+  WipConnection _tabConnection;
 
-  final ChromeProxyService _mainProxy;
+  final AssetHandler _assetHandler;
+  final StreamNotify _streamNotify;
+  final CurrentInspector _currentInspector;
+  final String _root;
 
-  WipDebugger get chromeDebugger => _mainProxy.tabConnection.debugger;
+  Debugger(
+    this._assetHandler,
+    this._tabConnection,
+    this._streamNotify,
+    this._currentInspector,
+    // TODO(401) - Remove.
+    this._root,
+  ) : _breakpoints = _Breakpoints(_currentInspector);
+
+  WipDebugger get _chromeDebugger => _tabConnection.debugger;
 
   /// The scripts and sourcemaps for the application, both JS and Dart.
   Sources sources;
@@ -39,8 +58,19 @@ class Debugger {
 
   Future<Success> pause() async {
     _isStepping = false;
-    var result = await chromeDebugger.sendCommand('Debugger.pause');
+    var result = await _chromeDebugger.sendCommand('Debugger.pause');
     handleErrorIfPresent(result);
+    return Success();
+  }
+
+  Future<Success> setExceptionPauseMode(String isolateId, String mode) async {
+    if (isolateId != _currentInspector().isolate?.id) {
+      throw ArgumentError.value(
+          isolateId, 'isolateId', 'Unrecognized isolate id');
+    }
+    var pauseState = _pauseModePauseStates[mode.toLowerCase()] ??
+        (throw ArgumentError.value('mode', 'Unsupported mode `$mode`'));
+    await _chromeDebugger.setPauseOnExceptions(pauseState);
     return Success();
   }
 
@@ -59,7 +89,7 @@ class Debugger {
   /// a location for which we have source information.
   Future<Success> resume(String isolateId,
       {String step, int frameIndex}) async {
-    if (isolateId != _mainProxy.isolate.id) {
+    if (isolateId != _currentInspector()?.isolate?.id) {
       throw ArgumentError.value(
           isolateId, 'isolateId', 'Unrecognized isolate id');
     }
@@ -71,20 +101,20 @@ class Debugger {
       _isStepping = true;
       switch (step) {
         case 'Over':
-          result = await chromeDebugger.sendCommand('Debugger.stepOver');
+          result = await _chromeDebugger.sendCommand('Debugger.stepOver');
           break;
         case 'Out':
-          result = await chromeDebugger.sendCommand('Debugger.stepOut');
+          result = await _chromeDebugger.sendCommand('Debugger.stepOut');
           break;
         case 'Into':
-          result = await chromeDebugger.sendCommand('Debugger.stepInto');
+          result = await _chromeDebugger.sendCommand('Debugger.stepInto');
           break;
         default:
           throw ArgumentError('Unexpected value for step: $step');
       }
     } else {
       _isStepping = false;
-      result = await chromeDebugger.sendCommand('Debugger.resume');
+      result = await _chromeDebugger.sendCommand('Debugger.resume');
     }
     handleErrorIfPresent(result);
     return Success();
@@ -94,7 +124,7 @@ class Debugger {
   ///
   /// Returns null if the debugger is not paused.
   Future<Stack> getStack(String isolateId) async {
-    if (isolateId != _mainProxy.isolate.id) {
+    if (isolateId != _currentInspector()?.isolate?.id) {
       throw ArgumentError.value(
           isolateId, 'isolateId', 'Unrecognized isolate id');
     }
@@ -102,16 +132,15 @@ class Debugger {
   }
 
   Future<Null> initialize() async {
-    sources = Sources(_mainProxy);
+    sources = Sources(_assetHandler);
     // We must add a listener before enabling the debugger otherwise we will
     // miss events.
-    chromeDebugger.onScriptParsed.listen(sources.scriptParsed);
-    chromeDebugger.onPaused.listen(_pauseHandler);
-    chromeDebugger.onResumed.listen(_resumeHandler);
+    _chromeDebugger.onScriptParsed.listen(sources.scriptParsed);
+    _chromeDebugger.onPaused.listen(_pauseHandler);
+    _chromeDebugger.onResumed.listen(_resumeHandler);
 
-    handleErrorIfPresent(
-        await _mainProxy.tabConnection.page.enable() as WipResponse);
-    handleErrorIfPresent(await chromeDebugger.enable() as WipResponse);
+    handleErrorIfPresent(await _tabConnection.page.enable() as WipResponse);
+    handleErrorIfPresent(await _chromeDebugger.enable() as WipResponse);
   }
 
   /// Add a breakpoint at the given position.
@@ -119,16 +148,16 @@ class Debugger {
   /// Note that line and column are Dart source locations and one-based.
   Future<Breakpoint> addBreakpoint(String isolateId, String scriptId, int line,
       {int column}) async {
-    Isolate isolate;
-    // Validate the isolate id is correct, _getIsolate throws if not.
-    if (isolateId != null) {
-      isolate = await _mainProxy.getIsolate(isolateId) as Isolate;
+    var isolate = _currentInspector().isolate;
+    if (isolateId != isolate.id) {
+      throw ArgumentError.value(
+          isolateId, 'isolateId', 'Unrecognized isolate id');
     }
 
     var dartScript = await _scriptWithId(isolateId, scriptId);
     // TODO(401): Remove the additional parameter.
-    var dartUri = DartUri(
-        dartScript.uri, '${Uri.parse(_mainProxy.uri).path}/garbage.dart');
+    var dartUri =
+        DartUri(dartScript.uri, '${Uri.parse(_root).path}/garbage.dart');
     var location = _locationForDart(dartUri, line);
     // TODO: Handle cases where a breakpoint can't be set exactly at that line.
     if (location == null) return null;
@@ -147,7 +176,7 @@ class Debugger {
       ..location = (SourceLocation()
         ..script = dartScript
         ..tokenPos = location.tokenPos);
-    _mainProxy.streamNotify(
+    _streamNotify(
         'Debug',
         Event()
           ..kind = EventKind.kBreakpointAdded
@@ -157,11 +186,12 @@ class Debugger {
   }
 
   /// Remove a Dart breakpoint.
-  Future<void> removeBreakpoint(String isolateId, String breakpointId) async {
-    Isolate isolate;
-    // Validate the isolate id is correct, _getIsolate throws if not.
-    if (isolateId != null) {
-      isolate = await _mainProxy.getIsolate(isolateId) as Isolate;
+  Future<Success> removeBreakpoint(
+      String isolateId, String breakpointId) async {
+    var isolate = _currentInspector().isolate;
+    if (isolateId != isolate.id) {
+      throw ArgumentError.value(
+          isolateId, 'isolateId', 'Unrecognized isolate id');
     }
     if (breakpointId == null) {
       throw ArgumentError.notNull('breakpointId');
@@ -172,13 +202,14 @@ class Debugger {
       throw ArgumentError.value(
           breakpointId, 'Breakpoint not found with this id.');
     }
-    _mainProxy.streamNotify(
+    _streamNotify(
         'Debug',
         Event()
           ..kind = EventKind.kBreakpointRemoved
           ..isolate = toIsolateRef(isolate)
           ..breakpoint = bp);
-    return _removeBreakpoint(jsId);
+    await _removeBreakpoint(jsId);
+    return Success();
   }
 
   /// Look up the script by id in an isolate.
@@ -186,7 +217,7 @@ class Debugger {
     // TODO: Reduce duplication with _scriptRefs in mainProxy.
     if (_scriptRefs == null) {
       _scriptRefs = {};
-      var scripts = await _mainProxy.scriptRefs(isolateId);
+      var scripts = await _currentInspector()?.scriptRefs(isolateId);
       for (var script in scripts) {
         _scriptRefs[script.id] = script;
       }
@@ -199,7 +230,7 @@ class Debugger {
     // Location is 0 based according to:
     // https://chromedevtools.github.io/devtools-protocol/tot/Debugger#type-Location
     var response =
-        await chromeDebugger.sendCommand('Debugger.setBreakpoint', params: {
+        await _chromeDebugger.sendCommand('Debugger.setBreakpoint', params: {
       'location': {
         'scriptId': location.jsLocation.scriptId,
         'lineNumber': location.jsLocation.line - 1,
@@ -211,7 +242,8 @@ class Debugger {
 
   /// Call the Chrome protocol removeBreakpoint.
   Future<void> _removeBreakpoint(String breakpointId) async {
-    var response = await chromeDebugger.sendCommand('Debugger.removeBreakpoint',
+    var response = await _chromeDebugger.sendCommand(
+        'Debugger.removeBreakpoint',
         params: {'breakpointId': breakpointId});
     handleErrorIfPresent(response);
   }
@@ -284,8 +316,8 @@ class Debugger {
       }
     }
     if (bestLocation == null) return null;
-    var script =
-        _mainProxy.scriptRefFor(bestLocation.dartLocation.uri.serverPath);
+    var script = _currentInspector()
+        ?.scriptRefFor(bestLocation.dartLocation.uri.serverPath);
     return Frame()
       ..code = (CodeRef()..kind = CodeKind.kDart)
       ..location = (SourceLocation()
@@ -296,8 +328,9 @@ class Debugger {
 
   /// Handles pause events coming from the Chrome connection.
   Future<void> _pauseHandler(DebuggerPausedEvent e) async {
-    if (_mainProxy.isolate == null) return;
-    var event = Event()..isolate = toIsolateRef(_mainProxy.isolate);
+    var isolate = _currentInspector()?.isolate;
+    if (isolate == null) return;
+    var event = Event()..isolate = toIsolateRef(isolate);
     var params = e.params;
     var breakpoints = params['hitBreakpoints'] as List;
     if (breakpoints.isNotEmpty) {
@@ -307,7 +340,7 @@ class Debugger {
     } else {
       // If we don't have source location continue stepping.
       if (_isStepping && _sourceLocation(e) == null) {
-        await chromeDebugger.sendCommand('Debugger.stepInto');
+        await _chromeDebugger.sendCommand('Debugger.stepInto');
         return;
       }
       event.kind = EventKind.kPauseInterrupted;
@@ -317,18 +350,19 @@ class Debugger {
       ..frames = frames
       ..messages = [];
     if (frames.isNotEmpty) event.topFrame = frames.first;
-    _mainProxy.streamNotify('Debug', event);
+    _streamNotify('Debug', event);
   }
 
   /// Handles resume events coming from the Chrome connection.
   Future<void> _resumeHandler(DebuggerResumedEvent e) async {
-    if (_mainProxy.isolate == null) return;
+    var isolate = _currentInspector()?.isolate;
+    if (isolate == null) return;
     _pausedStack = null;
-    _mainProxy.streamNotify(
+    _streamNotify(
         'Debug',
         Event()
           ..kind = EventKind.kResume
-          ..isolate = toIsolateRef(_mainProxy.isolate));
+          ..isolate = toIsolateRef(isolate));
   }
 }
 
@@ -337,12 +371,9 @@ class _Breakpoints {
   final Map<String, String> _byJsId = {};
   final Map<String, String> _byDartId = {};
 
-  // TODO(439): We need to resolve the way we talk to other components.
-  final ChromeProxyService _mainProxy;
+  final CurrentInspector _currentInspector;
 
-  Isolate get _isolate => _mainProxy.isolate;
-
-  _Breakpoints(this._mainProxy);
+  _Breakpoints(this._currentInspector);
 
   /// Record the breakpoint.
   ///
@@ -350,27 +381,26 @@ class _Breakpoints {
   void noteBreakpoint({String js, String dartId, Breakpoint bp}) {
     _byJsId[js] = dartId ?? bp?.id;
     _byDartId[dartId ?? bp?.id] = js;
+    var isolate = _currentInspector()?.isolate;
     if (bp != null) {
-      _isolate?.breakpoints?.add(bp);
+      isolate?.breakpoints?.add(bp);
     }
   }
 
   Breakpoint removeBreakpoint({String js, String dartId, Breakpoint bp}) {
+    var isolate = _currentInspector()?.isolate;
     _byJsId.remove(js);
     _byDartId.remove(dartId ?? bp?.id);
     Breakpoint dartBp;
     // TODO: Do something better than the default throw when it's not found.
     dartBp = bp ??
-        _isolate.breakpoints
+        isolate.breakpoints
             .firstWhere((b) => b.id == dartId, orElse: () => null);
-    _isolate?.breakpoints?.remove(dartBp);
+    isolate?.breakpoints?.remove(dartBp);
     return dartBp;
   }
 
   String dartId(String jsId) => _byJsId[jsId];
 
   String jsId(String dartId) => _byDartId[dartId];
-
-  // TODO(https://github.com/dart-lang/webdev/issues/400): Support removing
-  // breakpoints
 }

--- a/dwds/lib/src/inspector.dart
+++ b/dwds/lib/src/inspector.dart
@@ -33,22 +33,15 @@ class Inspector {
   final Debugger _debugger;
   final Isolate isolate;
 
-  Inspector(
-    String id,
+  Inspector._(
+    this.isolate,
     this._tabConnection,
     this._assetHandler,
     this._debugger,
     this._root,
-  ) : isolate = Isolate()
-          ..id = id
-          ..number = id
-          ..name = '$_root:main()'
-          ..runnable = true
-          ..breakpoints = []
-          ..libraries = []
-          ..extensionRPCs = [];
+  );
 
-  Future<void> initialize() async {
+  Future<void> _initialize() async {
     isolate.libraries.addAll(await _getLibraryRefs());
 
     // TODO: Something more robust here, right now we rely on the 2nd to last
@@ -60,6 +53,27 @@ class Inspector {
     isolate.pauseEvent = Event()
       ..kind = EventKind.kResume
       ..isolate = toIsolateRef(isolate);
+  }
+
+  static Future<Inspector> initialize(
+    WipConnection tabConnection,
+    AssetHandler assetHandler,
+    Debugger debugger,
+    String root,
+  ) async {
+    var id = createId();
+    var isolate = Isolate()
+      ..id = id
+      ..number = id
+      ..name = '$root:main()'
+      ..runnable = true
+      ..breakpoints = []
+      ..libraries = []
+      ..extensionRPCs = [];
+    var inspector =
+        Inspector._(isolate, tabConnection, assetHandler, debugger, root);
+    await inspector._initialize();
+    return inspector;
   }
 
   Future evaluate(String isolateId, String targetId, String expression,

--- a/dwds/lib/src/inspector.dart
+++ b/dwds/lib/src/inspector.dart
@@ -339,7 +339,7 @@ function($argsString) {
     return scripts;
   }
 
-  /// Returns all library names in the app.
+  /// Returns all libraryRefs in the app.
   ///
   /// Note this can return a cached result.
   Future<List<LibraryRef>> _getLibraryRefs() async {

--- a/dwds/lib/src/inspector.dart
+++ b/dwds/lib/src/inspector.dart
@@ -1,0 +1,386 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.import 'dart:async';
+
+import 'package:vm_service_lib/vm_service_lib.dart';
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+import 'chrome_proxy_service.dart';
+import 'dart_uri.dart';
+import 'debugger.dart';
+import 'helpers.dart';
+
+/// An Inspector for a running Dart application contained in the
+/// [WipConnection].
+class Inspector {
+  /// Map of class ID to [Class].
+  final _classes = <String, Class>{};
+
+  /// Map of scriptRef ID to [ScriptRef].
+  final _scriptRefs = <String, ScriptRef>{};
+
+  /// Map of Dart server path to [ScriptRef].
+  final _serverPathToScriptRef = <String, ScriptRef>{};
+
+  /// Map of library ID to [Library].
+  final _libraries = <String, Library>{};
+
+  /// Map of libraryRef ID to [LibraryRef].
+  final _libraryRefs = <String, LibraryRef>{};
+
+  final WipConnection _tabConnection;
+  final AssetHandler _assetHandler;
+  final String _root;
+  final Debugger _debugger;
+  final Isolate isolate;
+
+  Inspector(
+    String id,
+    this._tabConnection,
+    this._assetHandler,
+    this._debugger,
+    this._root,
+  ) : isolate = Isolate()
+          ..id = id
+          ..number = id
+          ..name = '$_root:main()'
+          ..runnable = true
+          ..breakpoints = []
+          ..libraries = []
+          ..extensionRPCs = [];
+
+  Future<void> initialize() async {
+    isolate.libraries.addAll(await _getLibraryRefs());
+
+    // TODO: Something more robust here, right now we rely on the 2nd to last
+    // library being the root one (the last library is the bootstrap lib).
+    isolate.rootLib = isolate.libraries[isolate.libraries.length - 2];
+
+    isolate.extensionRPCs.addAll(await _getExtensionRpcs());
+
+    isolate.pauseEvent = Event()
+      ..kind = EventKind.kResume
+      ..isolate = toIsolateRef(isolate);
+  }
+
+  Future evaluate(String isolateId, String targetId, String expression,
+      {Map<String, String> scope, bool disableBreakpoints}) async {
+    scope ??= {};
+    disableBreakpoints ??= false;
+    var library = await _getLibrary(isolateId, targetId);
+    if (library == null) {
+      throw UnsupportedError(
+          'Evaluate is only supported when `targetId` is a library.');
+    }
+    WipResponse result;
+
+    // If there is scope, we use `callFunctionOn` because that accepts the
+    // `arguments` option.
+    //
+    // If there is no scope we run a normal evaluate call.
+    if (scope.isEmpty) {
+      var evalExpression = '''
+(function() {
+  ${_getLibrarySnippet(library.uri)};
+  return library.$expression;
+})();
+    ''';
+      result = await _tabConnection.runtime.sendCommand('Runtime.evaluate',
+          params: {'expression': evalExpression});
+      handleErrorIfPresent(result,
+          evalContents: evalExpression,
+          additionalDetails: {
+            'Dart expression': expression,
+          });
+    } else {
+      var argsString = scope.keys.join(', ');
+      var arguments = scope.values.map((id) => {'objectId': id}).toList();
+      var evalExpression = '''
+function($argsString) {
+  ${_getLibrarySnippet(library.uri)};
+  return library.$expression;
+}
+    ''';
+      result = await _tabConnection.runtime
+          .sendCommand('Runtime.callFunctionOn', params: {
+        'functionDeclaration': evalExpression,
+        'arguments': arguments,
+        // TODO(jakemac): Use the executionContext instead, or possibly the
+        // library object. This will get weird if people try to use `this` in
+        // their expression.
+        'objectId': scope.values.first,
+      });
+      handleErrorIfPresent(result,
+          evalContents: evalExpression,
+          additionalDetails: {
+            'Dart expression': expression,
+            'scope': scope,
+          });
+    }
+    var remoteObject =
+        RemoteObject(result.result['result'] as Map<String, dynamic>);
+
+    switch (remoteObject.type) {
+      case 'string':
+        return _primitiveInstance(InstanceKind.kString, remoteObject);
+      case 'number':
+        return _primitiveInstance(InstanceKind.kDouble, remoteObject);
+      case 'boolean':
+        return _primitiveInstance(InstanceKind.kBool, remoteObject);
+      case 'object':
+        return InstanceRef()
+          ..kind = InstanceKind.kPlainInstance
+          ..id = remoteObject.objectId
+          // TODO(jakemac): Create a real ClassRef, we need a way of looking
+          // up the library for a given instance to create it though.
+          // https://github.com/dart-lang/sdk/issues/36771.
+          ..classRef = ClassRef();
+      default:
+        throw UnsupportedError(
+            'Unsupported response type ${remoteObject.type}');
+    }
+  }
+
+  Future<Library> _getLibrary(String isolateId, String objectId) async {
+    if (isolateId != isolate.id) return null;
+    var libraryRef = _libraryRefs[objectId];
+    if (libraryRef == null) return null;
+    var library = _libraries[objectId];
+    if (library != null) return library;
+    library = await _constructLibrary(libraryRef);
+    _libraries[objectId] = library;
+    return library;
+  }
+
+  Future getObject(String isolateId, String objectId,
+      {int offset, int count}) async {
+    var library = await _getLibrary(isolateId, objectId);
+    if (library != null) return library;
+    var clazz = _classes[objectId];
+    if (clazz != null) return clazz;
+    var scriptRef = _scriptRefs[objectId];
+    if (scriptRef != null) return await _getScript(isolateId, scriptRef);
+
+    throw UnsupportedError(
+        'Only libraries and classes are supported for getObject');
+  }
+
+  Future<Library> _constructLibrary(LibraryRef libraryRef) async {
+    // Fetch information about all the classes in this library.
+    var expression = '''
+    (function() {
+    ${_getLibrarySnippet(libraryRef.uri)}
+      var classes = Object.values(library)
+        .filter((l) => l && sdkUtils.isType(l));
+      return classes.map(function(clazz) {
+        var descriptor = {'name': clazz.name};
+
+        // TODO(jakemac): static methods once ddc supports them
+        var methods = sdkUtils.getMethods(clazz);
+        var methodNames = methods ? Object.keys(methods) : [];
+        descriptor['methods'] = {};
+        for (var name of methodNames) {
+          var method = methods[name];
+          descriptor['methods'][name] = {
+            // TODO(jakemac): how can we get actual const info?
+            "isConst": false,
+            "isStatic": false,
+          }
+        }
+
+        // TODO(jakemac): static fields once ddc supports them
+        var fields = sdkUtils.getFields(clazz);
+        var fieldNames = fields ? Object.keys(fields) : [];
+        descriptor['fields'] = {};
+        for (var name of fieldNames) {
+          var field = fields[name];
+          descriptor['fields'][name] = {
+            // TODO(jakemac): how can we get actual const info?
+            "isConst": false,
+            "isFinal": field.isFinal,
+            "isStatic": false,
+          }
+        }
+
+        return descriptor;
+      });
+    })()
+    ''';
+    var classesResult = await _tabConnection.runtime.sendCommand(
+        'Runtime.evaluate',
+        params: {'expression': expression, 'returnByValue': true});
+    handleErrorIfPresent(classesResult, evalContents: expression);
+    var classDescriptors = (classesResult.result['result']['value'] as List)
+        .cast<Map<String, Object>>();
+    var classRefs = <ClassRef>[];
+    for (var classDescriptor in classDescriptors) {
+      var name = classDescriptor['name'] as String;
+      var classId = '${libraryRef.id}:$name';
+      var classRef = ClassRef()
+        ..name = name
+        ..id = classId;
+      classRefs.add(classRef);
+
+      var methodRefs = <FuncRef>[];
+      var methodDescriptors =
+          classDescriptor['methods'] as Map<String, dynamic>;
+      methodDescriptors.forEach((name, descriptor) {
+        var methodId = '$classId:$name';
+        methodRefs.add(FuncRef()
+          ..id = methodId
+          ..name = name
+          ..owner = classRef
+          ..isConst = descriptor['isConst'] as bool
+          ..isStatic = descriptor['isStatic'] as bool);
+      });
+
+      var fieldRefs = <FieldRef>[];
+      var fieldDescriptors = classDescriptor['fields'] as Map<String, dynamic>;
+      fieldDescriptors.forEach((name, descriptor) {
+        fieldRefs.add(FieldRef()
+          ..name = name
+          ..declaredType = (InstanceRef()..classRef = ClassRef())
+          ..owner = classRef
+          ..isConst = descriptor['isConst'] as bool
+          ..isFinal = descriptor['isFinal'] as bool
+          ..isStatic = descriptor['isStatic'] as bool);
+      });
+
+      // TODO: Implement the rest of these
+      // https://github.com/dart-lang/webdev/issues/176.
+      _classes[classId] = Class()
+        ..classRef = classRef
+        ..fields = fieldRefs
+        ..functions = methodRefs
+        ..id = classId
+        ..library = libraryRef
+        ..name = name
+        ..interfaces = []
+        ..subclasses = [];
+    }
+
+    // TODO(grouma) - This currently does not support part files.
+    // Figure out how to support them.
+    var scriptRef = ScriptRef()
+      ..uri = libraryRef.uri
+      ..id = createId();
+
+    _scriptRefs[scriptRef.id] = scriptRef;
+    _serverPathToScriptRef[DartUri(libraryRef.id, scriptRef.uri).serverPath] =
+        scriptRef;
+
+    return Library()
+      ..id = libraryRef.id
+      ..name = libraryRef.name
+      ..uri = libraryRef.uri
+      ..classes = classRefs
+      ..debuggable = true
+      ..dependencies = []
+      ..functions = []
+      ..scripts = [scriptRef]
+      ..variables = [];
+  }
+
+  Future<Script> _getScript(String isolateId, ScriptRef scriptRef) async {
+    var libraryId = scriptRef.uri;
+    // TODO(401): Remove uri parameter.
+    var serverPath = DartUri(libraryId, _root).serverPath;
+    var script = await _assetHandler(serverPath);
+    return Script()
+      ..library = _libraryRefs[libraryId]
+      ..id = scriptRef.id
+      ..uri = libraryId
+      ..tokenPosTable = _debugger.sources.tokenPosTableFor(serverPath)
+      ..source = script;
+  }
+
+  /// Returns the [ScriptRef] for the provided Dart server path [uri].
+  ScriptRef scriptRefFor(String uri) => _serverPathToScriptRef[uri];
+
+  Future<ScriptList> getScripts(String isolateId) async {
+    var scripts = await scriptRefs(isolateId);
+    return ScriptList()..scripts = scripts;
+  }
+
+  /// Internal method to list all scripts in the isolate.
+  ///
+  /// This is used as the underlying mechanism
+  /// for [getScripts].
+  Future<List<ScriptRef>> scriptRefs(String isolateId) async {
+    if (isolateId != isolate.id) {
+      throw ArgumentError.value(
+          isolateId, 'isolateId', 'Unrecognized isolate id');
+    }
+    var scripts = <ScriptRef>[];
+    for (var lib in isolate.libraries) {
+      // We can't provide the source for `dart:` imports so ignore for now.
+      // Also `main.dart.bootstrap` does not have a corresponding script.
+      if (lib.id.startsWith('dart:') || lib.id.endsWith('.bootstrap')) continue;
+      scripts.addAll((await _getLibrary(isolateId, lib.id)).scripts);
+    }
+    // TODO(alanknight): Is this the same as the values in _scriptRefs after
+    // constructing all the libraries? Make that clearer.
+    return scripts;
+  }
+
+  /// Returns all library names in the app.
+  ///
+  /// Note this can return a cached result.
+  Future<List<LibraryRef>> _getLibraryRefs() async {
+    if (_libraryRefs.isNotEmpty) return _libraryRefs.values.toList();
+    var expression = "require('dart_sdk').dart.getLibraries();";
+    var librariesResult = await _tabConnection.runtime.sendCommand(
+        'Runtime.evaluate',
+        params: {'expression': expression, 'returnByValue': true});
+    handleErrorIfPresent(librariesResult, evalContents: expression);
+    var libraries =
+        List<String>.from(librariesResult.result['result']['value'] as List);
+    for (var library in libraries) {
+      var ref = LibraryRef()
+        ..id = library
+        ..name = library
+        ..uri = library;
+      _libraryRefs[ref.id] = ref;
+    }
+    return _libraryRefs.values.toList();
+  }
+
+  /// Runs an eval on the page to compute all existing registered extensions.
+  Future<List<String>> _getExtensionRpcs() async {
+    var expression = "require('dart_sdk').developer._extensions.keys.toList();";
+    var extensionsResult = await _tabConnection.runtime.sendCommand(
+        'Runtime.evaluate',
+        params: {'expression': expression, 'returnByValue': true});
+    handleErrorIfPresent(extensionsResult, evalContents: expression);
+    return List.from(extensionsResult.result['result']['value'] as List);
+  }
+}
+
+/// Creates a snippet of JS code that initializes a `library` variable that has
+/// the actual library object in DDC for [libraryUri].
+///
+/// In DDC we have module libraries indexed by names of the form
+/// 'packages/package/mainFile' with no .dart suffix on the file, or
+/// 'directory/packageName/mainFile', also with no .dart suffix, and relative to
+/// the serving root, normally /web within the package. These modules have a map
+/// from the URI with a Dart-specific scheme (package: or org-dartlang-app:) to
+/// the library objects. The [libraryUri] parameter should be one of these
+/// Dart-specific scheme URIs, and we set `library` the corresponding library.
+String _getLibrarySnippet(String libraryUri) => '''
+  var libraryName = '$libraryUri';
+  var sdkUtils = require('dart_sdk').dart;
+  var moduleName = sdkUtils.getModuleNames().find(
+    (name) => sdkUtils.getModuleLibraries(name)[libraryName]);
+  var library = sdkUtils.getModuleLibraries(moduleName)[libraryName];
+  if (!library) throw 'cannot find library for ' + libraryName + ' under ' + moduleName;
+''';
+
+/// Creates an [InstanceRef] for a primitive [RemoteObject].
+InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
+  var classRef = ClassRef()
+    ..id = 'dart:core:${remoteObject.type}'
+    ..name = kind;
+  return InstanceRef()
+    ..valueAsString = '${remoteObject.value}'
+    ..classRef = classRef
+    ..kind = kind;
+}

--- a/dwds/lib/src/sources.dart
+++ b/dwds/lib/src/sources.dart
@@ -14,13 +14,8 @@ import 'location.dart';
 
 /// The scripts and sourcemaps for the application, both JS and Dart.
 class Sources {
-  final ChromeProxyService _mainProxy;
-
   /// Controller for a stream of events when a source map is loaded.
   final _sourceMapLoadedController = StreamController<String>.broadcast();
-
-  /// Stream of events that a source map has been loaded.
-  Stream<String> get _sourceMapLoaded => _sourceMapLoadedController.stream;
 
   /// Map from Dart server path to tokenPosTable as defined in the
   /// Dart VM Service Protocol:
@@ -33,7 +28,9 @@ class Sources {
   /// Map from JS scriptId to all corresponding [Location] data.
   final _scriptIdToLocation = <String, Set<Location>>{};
 
-  Sources(this._mainProxy);
+  final AssetHandler _assetHandler;
+
+  Sources(this._assetHandler);
 
   /// Returns all [Location] data for a provided Dart source.
   Set<Location> locationsForDart(String serverPath) =>
@@ -109,13 +106,6 @@ class Sources {
     return tokenPosTable;
   }
 
-  /// Waits until the source map for the Dart server path has been loaded.
-  // TODO(grouma) - This is only used in a test context. Can we use an
-  // alternative signal and remove this method?
-  Future<void> waitForSourceMap(String serverPath) async =>
-      _sourceToLocation[serverPath] ??
-      _sourceMapLoaded.firstWhere((loadedUri) => serverPath == loadedUri);
-
   /// The source map for a DDC-compiled JS [script].
   // TODO(grouma) - Reuse this logic in `DartUri`.
   Future<String> _sourceMap(WipScript script) {
@@ -125,6 +115,6 @@ class Sources {
     }
     var scriptPath = DartUri(script.url).serverPath;
     var sourcemapPath = p.join(p.dirname(scriptPath), sourceMapUrl);
-    return _mainProxy.assetHandler(sourcemapPath);
+    return _assetHandler(sourcemapPath);
   }
 }

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -42,7 +42,6 @@ void main() {
       scripts = await service.getScripts(isolate.id);
       mainScript =
           scripts.scripts.firstWhere((each) => each.uri.contains('main.dart'));
-      await service.debugger.sources.waitForSourceMap('hello_world/main.dart');
     });
 
     test('addBreakpoint', () async {
@@ -372,7 +371,6 @@ void main() {
       stream = service.onEvent('Debug');
       mainScript = scripts.scripts
           .firstWhere((script) => script.uri.contains('main.dart'));
-      await service.debugger.sources.waitForSourceMap('hello_world/main.dart');
       var bp = await service.addBreakpoint(isolateId, mainScript.id, 45);
       // Wait for breakpoint to trigger.
       await stream
@@ -439,7 +437,6 @@ void main() {
       stream = service.onEvent('Debug');
       mainScript =
           scripts.scripts.firstWhere((each) => each.uri.contains('main.dart'));
-      await service.debugger.sources.waitForSourceMap('hello_world/main.dart');
     });
 
     test('returns null if not paused', () async {
@@ -546,10 +543,8 @@ void main() {
         _isSuccess);
     // Make sure this is the last one - or future tests might hang.
     expect(await service.setExceptionPauseMode(isolateId, 'none'), _isSuccess);
-    expect(
-        service.setExceptionPauseMode(isolateId, 'invalid'),
-        throwsA(isA<RPCError>()
-            .having((e) => e.code, 'invalid params error', equals(-32602))));
+    expect(service.setExceptionPauseMode(isolateId, 'invalid'),
+        throwsA(isA<ArgumentError>()));
   });
 
   test('setFlag', () {


### PR DESCRIPTION
- Create new `AppInspector` abstraction
  - This abstraction constructs an `isolate`
  - It handles all things related to inspection, e.g. `getObject`, `evaluate` etc.
  - Note that essentially no new code is in this abstraction, just logic moved from `ChromeProxyService`
- Update `ChromeProxyService` to delegate to the `Inspector`
- Update `Debugger` to no longer need a reference to the main proxy
- Make the `Debugger` constructor private
  - This ensures that we call `initialize` upon construction
- Move logic for pause modes over to the `Debugger`
