### PR TITLE
add a fullReload service extension which performs a full page refresh

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.0-dev
 
-- Added a `slowReload` service extension which performs a full page refresh.
+- Added a `fullReload` service extension which performs a full page refresh.
 
 ## 2.1.0
 

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0-dev
+
+- Added a `slowReload` service extension which performs a full page refresh.
+
 ## 2.1.0
 
 - Add an explicit error if there are no directories to serve. Typically this

--- a/webdev/lib/src/serve/debugger/webdev_vm_client.dart
+++ b/webdev/lib/src/serve/debugger/webdev_vm_client.dart
@@ -38,6 +38,7 @@ class WebdevVmClient {
             .add(jsonDecode(request) as Map<String, dynamic>));
     var chromeProxyService =
         debugService.chromeProxyService as ChromeProxyService;
+
     client.registerServiceCallback('hotRestart', (request) async {
       var response = await chromeProxyService.tabConnection.runtime.sendCommand(
           'Runtime.evaluate',
@@ -55,7 +56,16 @@ class WebdevVmClient {
         return {'result': Success().toJson()};
       }
     });
-    await client.registerService('hotRestart', 'WebDev');
+    await client.registerService('hotRestart', 'WebDev slowReload');
+
+    client.registerServiceCallback('slowReload', (request) async {
+      await chromeProxyService.tabConnection.page.enable();
+      // TODO: use built in `page.reload` once it works,
+      // https://github.com/google/webkit_inspection_protocol.dart/issues/44
+      await chromeProxyService.tabConnection.sendCommand('Page.reload');
+      return {'result': Success().toJson()};
+    });
+    await client.registerService('slowReload', 'WebDev');
 
     return WebdevVmClient(client, requestController, responseController);
   }

--- a/webdev/lib/src/serve/debugger/webdev_vm_client.dart
+++ b/webdev/lib/src/serve/debugger/webdev_vm_client.dart
@@ -56,16 +56,16 @@ class WebdevVmClient {
         return {'result': Success().toJson()};
       }
     });
-    await client.registerService('hotRestart', 'WebDev slowReload');
+    await client.registerService('hotRestart', 'WebDev fullReload');
 
-    client.registerServiceCallback('slowReload', (request) async {
+    client.registerServiceCallback('fullReload', (request) async {
       await chromeProxyService.tabConnection.page.enable();
       // TODO: use built in `page.reload` once it works,
       // https://github.com/google/webkit_inspection_protocol.dart/issues/44
       await chromeProxyService.tabConnection.sendCommand('Page.reload');
       return {'result': Success().toJson()};
     });
-    await client.registerService('slowReload', 'WebDev');
+    await client.registerService('fullReload', 'WebDev');
 
     return WebdevVmClient(client, requestController, responseController);
   }

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.1.0';
+const packageVersion = '2.2.0-dev';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdev
-version: 2.1.0
+version: 2.2.0-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-
@@ -54,5 +54,5 @@ executables:
   webdev:
 
 # dependency_overrides:
-#  dwds:
-#    path: ../dwds
+#   dwds:
+#     path: ../dwds

--- a/webdev/test/serve/injected/devtools_test.dart
+++ b/webdev/test/serve/injected/devtools_test.dart
@@ -154,14 +154,11 @@ void main() {
       await fixture.webdev.kill();
     });
 
-    test('can refresh the page via the slowReload service extension', () async {
-      fixture.webdev.stderrStream().listen(print);
-      fixture.webdev.stdoutStream().listen(print);
+    test('can refresh the page via the fullReload service extension', () async {
       var client = await vmServiceConnectUri(debugUri);
       await fixture.changeInput();
 
-      expect(await client.callServiceExtension('slowReload'),
-          const TypeMatcher<Success>());
+      expect(await client.callServiceExtension('fullReload'), isA<Success>());
       await Future.delayed(const Duration(seconds: 2));
 
       var source = await fixture.webdriver.pageSource;

--- a/webdev/test/serve/injected/devtools_test.dart
+++ b/webdev/test/serve/injected/devtools_test.dart
@@ -153,6 +153,23 @@ void main() {
       await eventsDone;
       await fixture.webdev.kill();
     });
+
+    test('can refresh the page via the slowReload service extension', () async {
+      fixture.webdev.stderrStream().listen(print);
+      fixture.webdev.stdoutStream().listen(print);
+      var client = await vmServiceConnectUri(debugUri);
+      await fixture.changeInput();
+
+      expect(await client.callServiceExtension('slowReload'),
+          const TypeMatcher<Success>());
+      await Future.delayed(const Duration(seconds: 2));
+
+      var source = await fixture.webdriver.pageSource;
+      // Should see only the new text
+      expect(source, isNot(contains('Hello World!')));
+      expect(source, contains('Gary is awesome!'));
+      await fixture.webdev.kill();
+    });
   });
 
   group('Injected client with --auto restart', () {


### PR DESCRIPTION
Closes https://github.com/dart-lang/webdev/issues/446

Now is the time to give pushback on the name as well if people have opinions, we could call it `refreshPage` or something more explicitly describing the behavior as well.

cc @natebosch @jonahwilliams