### PR TITLE
Breakpoint support with refreshing

### DIFF
--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -51,8 +51,7 @@ class ChromeProxyService implements VmServiceInterface {
   Debugger _debugger;
 
   AppInspector _inspector;
-  AppInspector _appInspectorProvider() =>
-      _inspector ?? (throw StateError('Null AppInspetor.'));
+  AppInspector _appInspectorProvider() => _inspector;
 
   StreamSubscription<ConsoleAPIEvent> _consoleSubscription;
 

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -236,17 +236,9 @@ class Debugger {
   }
 
   /// Look up the script by id in an isolate.
-  Future<ScriptRef> _scriptWithId(String isolateId, String scriptId) async {
-    // TODO: Reduce duplication with _scriptRefs in mainProxy.
-    if (_scriptRefs == null) {
-      _scriptRefs = {};
-      var scripts = await _appInspectorProvider().scriptRefs(isolateId);
-      for (var script in scripts) {
-        _scriptRefs[script.id] = script;
-      }
-    }
-    return _scriptRefs[scriptId];
-  }
+  Future<ScriptRef> _scriptWithId(String isolateId, String scriptId) async =>
+      (await _appInspectorProvider().scriptRefs(isolateId))
+          .firstWhere((ref) => ref.id == scriptId);
 
   /// Call the Chrome protocol setBreakpoint and return the breakpoint ID.
   Future<String> _setBreakpoint(Location location) async {
@@ -378,7 +370,7 @@ class Debugger {
 
   /// Handles resume events coming from the Chrome connection.
   Future<void> _resumeHandler(DebuggerResumedEvent e) async {
-    var isolate = _appInspectorProvider().isolate;
+    var isolate = _appInspectorProvider()?.isolate;
     if (isolate == null) return;
     _pausedStack = null;
     _streamNotify(

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -47,9 +47,6 @@ class Debugger {
   /// The scripts and sourcemaps for the application, both JS and Dart.
   Sources sources;
 
-  /// Mapping from Dart script IDs to their ScriptRefs.
-  Map<String, ScriptRef> _scriptRefs;
-
   /// The breakpoints we have set so far, indexable by either
   /// Dart or JS ID.
   _Breakpoints _breakpoints;
@@ -370,6 +367,8 @@ class Debugger {
 
   /// Handles resume events coming from the Chrome connection.
   Future<void> _resumeHandler(DebuggerResumedEvent e) async {
+    // We can receive a resume event in the middle of a reload which will
+    // result in a null isolate.
     var isolate = _appInspectorProvider()?.isolate;
     if (isolate == null) return;
     _pausedStack = null;

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -168,13 +168,14 @@ class Debugger {
   /// Note that line and column are Dart source locations and one-based.
   Future<Breakpoint> addBreakpoint(String isolateId, String scriptId, int line,
       {int column}) async {
-    var isolate = _appInspectorProvider().isolate;
+    var inspector = _appInspectorProvider();
+    var isolate = inspector.isolate;
     if (isolateId != isolate.id) {
       throw ArgumentError.value(
           isolateId, 'isolateId', 'Unrecognized isolate id');
     }
 
-    var dartScript = await _scriptWithId(isolateId, scriptId);
+    var dartScript = await inspector.scriptWithId(scriptId);
     // TODO(401): Remove the additional parameter.
     var dartUri =
         DartUri(dartScript.uri, '${Uri.parse(_root).path}/garbage.dart');
@@ -231,11 +232,6 @@ class Debugger {
     await _removeBreakpoint(jsId);
     return Success();
   }
-
-  /// Look up the script by id in an isolate.
-  Future<ScriptRef> _scriptWithId(String isolateId, String scriptId) async =>
-      (await _appInspectorProvider().scriptRefs(isolateId))
-          .firstWhere((ref) => ref.id == scriptId);
 
   /// Call the Chrome protocol setBreakpoint and return the breakpoint ID.
   Future<String> _setBreakpoint(Location location) async {

--- a/dwds/lib/src/inspector.dart
+++ b/dwds/lib/src/inspector.dart
@@ -339,6 +339,10 @@ function($argsString) {
     return scripts;
   }
 
+  /// Look up the script by id in an isolate.
+  Future<ScriptRef> scriptWithId(String scriptId) async =>
+      (await scriptRefs(isolate.id)).firstWhere((ref) => ref.id == scriptId);
+
   /// Returns all libraryRefs in the app.
   ///
   /// Note this can return a cached result.

--- a/dwds/lib/src/sources.dart
+++ b/dwds/lib/src/sources.dart
@@ -54,6 +54,8 @@ class Sources {
     // This happens to be a [SingleMapping] today in DDC.
     var mapping = parse(sourceMapContents);
     if (mapping is SingleMapping) {
+      var serverPaths =
+          _sourceToServerPaths.putIfAbsent(script.url, () => Set());
       // Create TokenPos for each entry in the source map.
       for (var lineEntry in mapping.lines) {
         for (var entry in lineEntry.entries) {
@@ -66,9 +68,7 @@ class Sources {
             entry,
             dartUri,
           );
-          _sourceToServerPaths
-              .putIfAbsent(script.url, () => Set())
-              .add(dartUri.serverPath);
+          serverPaths.add(dartUri.serverPath);
           _sourceToLocation
               .putIfAbsent(dartUri.serverPath, () => Set())
               .add(location);

--- a/dwds/lib/src/sources.dart
+++ b/dwds/lib/src/sources.dart
@@ -115,6 +115,7 @@ class Sources {
       _sourceToLocation.remove(serverPath);
       _sourceToTokenPosTable.remove(serverPath);
     }
+    // This is the previous script ID for the file with the same URL.
     var scriptId = _sourceToScriptId[script.url];
     _scriptIdToLocation.remove(scriptId);
 

--- a/dwds/lib/src/sources.dart
+++ b/dwds/lib/src/sources.dart
@@ -14,9 +14,6 @@ import 'location.dart';
 
 /// The scripts and sourcemaps for the application, both JS and Dart.
 class Sources {
-  /// Controller for a stream of events when a source map is loaded.
-  final _sourceMapLoadedController = StreamController<String>.broadcast();
-
   /// Map from Dart server path to tokenPosTable as defined in the
   /// Dart VM Service Protocol:
   /// https://github.com/dart-lang/sdk/blob/master/runtime/vm/service/service.md#script
@@ -27,6 +24,12 @@ class Sources {
 
   /// Map from JS scriptId to all corresponding [Location] data.
   final _scriptIdToLocation = <String, Set<Location>>{};
+
+  /// Map from JS source url to corresponding Dart server paths.
+  final _sourceToServerPaths = <String, Set<String>>{};
+
+  /// Map from JS source url to Chrome script ID.
+  final _sourceToScriptId = <String, String>{};
 
   final AssetHandler _assetHandler;
 
@@ -46,6 +49,8 @@ class Sources {
     var script = e.script;
     var sourceMapContents = await _sourceMap(script);
     if (sourceMapContents == null) return;
+    _clearCacheFor(script);
+    _sourceToScriptId[script.url] = script.scriptId;
     // This happens to be a [SingleMapping] today in DDC.
     var mapping = parse(sourceMapContents);
     if (mapping is SingleMapping) {
@@ -61,6 +66,9 @@ class Sources {
             entry,
             dartUri,
           );
+          _sourceToServerPaths
+              .putIfAbsent(script.url, () => Set())
+              .add(dartUri.serverPath);
           _sourceToLocation
               .putIfAbsent(dartUri.serverPath, () => Set())
               .add(location);
@@ -68,11 +76,6 @@ class Sources {
               .putIfAbsent(script.scriptId, () => Set())
               .add(location);
         }
-      }
-
-      // Notify which Dart file's source maps have been parsed.
-      for (var serverPath in _sourceToLocation.keys) {
-        _sourceMapLoadedController.add(serverPath);
       }
     }
   }
@@ -106,8 +109,20 @@ class Sources {
     return tokenPosTable;
   }
 
+  void _clearCacheFor(WipScript script) {
+    var serverPaths = _sourceToServerPaths[script.url] ?? {};
+    for (var serverPath in serverPaths) {
+      _sourceToLocation.remove(serverPath);
+      _sourceToTokenPosTable.remove(serverPath);
+    }
+    var scriptId = _sourceToScriptId[script.url];
+    _scriptIdToLocation.remove(scriptId);
+
+    _sourceToServerPaths.remove(script.url);
+    _sourceToScriptId.remove(script.url);
+  }
+
   /// The source map for a DDC-compiled JS [script].
-  // TODO(grouma) - Reuse this logic in `DartUri`.
   Future<String> _sourceMap(WipScript script) {
     var sourceMapUrl = script.sourceMapURL;
     if (sourceMapUrl == null || !sourceMapUrl.endsWith('.ddc.js.map')) {

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -75,6 +75,21 @@ void main() {
       await service.removeBreakpoint(isolate.id, bp.id);
       expect(isolate.breakpoints, isEmpty);
     });
+
+    test('can add and remove after a refresh', () async {
+      var stream = service.onEvent('Isolate');
+      await context.webDriver.refresh();
+      // Wait for the refresh to propagate through.
+      await stream.firstWhere((e) => e.kind != EventKind.kIsolateStart);
+      var refreshedScriptList = await service.getScripts(isolate.id);
+      var refreshedMain = refreshedScriptList.scripts
+          .lastWhere((each) => each.uri.contains('main.dart'));
+      var bp = await service.addBreakpoint(isolate.id, refreshedMain.id, 21);
+      expect(isolate.breakpoints, [bp]);
+      expect(bp.id, '3');
+      await service.removeBreakpoint(isolate.id, bp.id);
+      expect(isolate.breakpoints, isEmpty);
+    });
   });
 
   group('callServiceExtension', () {

--- a/webdev/lib/src/serve/handlers/dev_handler.dart
+++ b/webdev/lib/src/serve/handlers/dev_handler.dart
@@ -157,7 +157,7 @@ class DevHandler {
             .sendCommand('Target.createTarget', {
           'newWindow': true,
           'url': 'http://${_devTools.hostname}:${_devTools.port}'
-              '/?uri=${appServices.debugService.wsUri}',
+              '/?hide=none&uri=${appServices.debugService.wsUri}',
         });
       } else if (message is ConnectRequest) {
         if (appId != null) {

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -53,6 +53,6 @@ dev_dependencies:
 executables:
   webdev:
 
-# dependency_overrides:
-#   dwds:
-#     path: ../dwds
+dependency_overrides:
+  dwds:
+    path: ../dwds


### PR DESCRIPTION
Closes https://github.com/dart-lang/webdev/issues/426

This change only supports adding breakpoints after a refresh. This does not keep breakpoints around after a refresh.