### PR TITLE
Log vm service rpc errors in verbose mode

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.3
 
 - Add support for `getScript` for paused isolates.
+- Add support for `onRequest` and `onResponse` listeners for the vm service.
 
 ## 0.3.2
 

--- a/webdev/lib/src/serve/handlers/dev_handler.dart
+++ b/webdev/lib/src/serve/handlers/dev_handler.dart
@@ -38,11 +38,12 @@ class DevHandler {
   final _connectedApps = StreamController<DevConnection>.broadcast();
   final _servicesByAppId = <String, Future<AppDebugServices>>{};
   final Stream<BuildResult> buildResults;
+  final bool _verbose;
 
   Stream<DevConnection> get connectedApps => _connectedApps.stream;
 
-  DevHandler(
-      this.buildResults, this._devTools, this._assetHandler, this._hostname) {
+  DevHandler(this.buildResults, this._devTools, this._assetHandler,
+      this._hostname, this._verbose) {
     _sub = buildResults.listen(_emitBuildResults);
     _listen();
   }
@@ -78,6 +79,13 @@ class DevHandler {
       chromeConnection,
       _assetHandler.getRelativeAsset,
       appInstanceId,
+      onResponse: _verbose
+          ? (response) {
+              if (response['error'] == null) return;
+              logWriter(Level.WARNING,
+                  'VmService proxy responded with an error:\n$response');
+            }
+          : null,
     );
   }
 

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -77,6 +77,7 @@ class WebDevServer {
       devTools,
       assetHandler,
       options.configuration.hostname,
+      options.configuration.verbose,
     );
     cascade = cascade.add(devHandler.handler).add(assetHandler.handler);
 

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   build_daemon: ^1.0.0
   built_value: ^6.3.0
   crypto: ^2.0.6
-  dwds: ^0.3.0
+  dwds: ^0.3.3
   devtools: ^0.0.15-dev.1
   http: ^0.12.0
   http_multi_server: ^2.1.0
@@ -53,6 +53,6 @@ dev_dependencies:
 executables:
   webdev:
 
-# dependency_overrides:
-#   dwds:
-#     path: ../dwds
+dependency_overrides:
+  dwds:
+    path: ../dwds


### PR DESCRIPTION
- added onResponse and onRequest listeners to dwds
- use onResponse to log failed responses in verbose mode for webdev (logged at warning level, some are always expected right now).

Closes https://github.com/dart-lang/webdev/issues/451