### PR TITLE
Set isolate pause / resume state

### DIFF
--- a/dwds/lib/src/chrome_proxy_service.dart
+++ b/dwds/lib/src/chrome_proxy_service.dart
@@ -281,7 +281,7 @@ require("dart_sdk").developer.invokeExtension(
   }
 
   @override
-  Future getIsolate(String isolateId) async => _getIsolate(isolateId);
+  Future<Isolate> getIsolate(String isolateId) async => _getIsolate(isolateId);
 
   @override
   Future<dynamic> getMemoryUsage(String isolateId) async {

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -358,6 +358,7 @@ class Debugger {
       ..frames = frames
       ..messages = [];
     if (frames.isNotEmpty) event.topFrame = frames.first;
+    isolate.pauseEvent = event;
     _streamNotify('Debug', event);
   }
 
@@ -368,11 +369,11 @@ class Debugger {
     var isolate = _appInspectorProvider()?.isolate;
     if (isolate == null) return;
     _pausedStack = null;
-    _streamNotify(
-        'Debug',
-        Event()
-          ..kind = EventKind.kResume
-          ..isolate = toIsolateRef(isolate));
+    var event = Event()
+      ..kind = EventKind.kResume
+      ..isolate = toIsolateRef(isolate);
+    isolate.pauseEvent = event;
+    _streamNotify('Debug', event);
   }
 }
 


### PR DESCRIPTION
We weren't setting the current run state on the isolate. This caused issues if the user refreshed the devtools page while debugging.

cc @jacob314 