### PR TITLE
Public API to support Flutter CLI

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Move `data` abstractions from `package:webdev` into `package:dwds`.
 - Move debugging related handlers from `package:webdev` into `package:dwds`.
 - Move injected client from `package:webdev` into `package:dwds`.
+- Create new public entrypoint `dwds.dart`. Existing public API `services.dart`
+  is now private.
 
 ## 0.3.3
 

--- a/dwds/lib/app_connection.dart
+++ b/dwds/lib/app_connection.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:sse/server/sse_handler.dart';
+
+import 'data/connect_request.dart';
+import 'data/run_request.dart';
+import 'data/serializers.dart';
+
+/// A connection between the application loaded in the browser and DWDS.
+class AppConnection {
+  final ConnectRequest request;
+  final SseConnection _connection;
+
+  var _isStarted = false;
+
+  AppConnection(this.request, this._connection);
+
+  void runMain() {
+    if (!_isStarted) {
+      _connection.sink.add(jsonEncode(serializers.serialize(RunRequest())));
+    }
+    _isStarted = true;
+  }
+}

--- a/dwds/lib/debug_connection.dart
+++ b/dwds/lib/debug_connection.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:vm_service_lib/vm_service_lib.dart';
+
+import 'src/services/app_debug_services.dart';
+
+/// A debug connection between the application in the browser and DWDS.
+class DebugConnection {
+  final AppDebugServices _appDebugServices;
+  final _onDoneCompleter = Completer();
+
+  DebugConnection(this._appDebugServices) {
+    _appDebugServices.chromeProxyService.tabConnection.onClose.first.then((_) {
+      close();
+    });
+  }
+
+  int get port => _appDebugServices.debugService.port;
+
+  String get wsUri => _appDebugServices.debugService.wsUri;
+
+  VmService get vmService => _appDebugServices.dwdsVmClient.client;
+
+  Future<void> close() async {
+    if (!_onDoneCompleter.isCompleted) _onDoneCompleter.complete();
+    await _appDebugServices.chromeProxyService.tabConnection.close();
+    await _appDebugServices.close();
+  }
+
+  Future<void> get onDone => _onDoneCompleter.future;
+}

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:build_daemon/data/build_status.dart';
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+import 'package:shelf/shelf.dart';
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import 'app_connection.dart';
+import 'debug_connection.dart';
+import 'src/devtools.dart';
+import 'src/handlers/asset_handler.dart';
+import 'src/handlers/dev_handler.dart';
+import 'src/handlers/injected_handler.dart';
+
+typedef LogWriter = void Function(Level, String);
+typedef ConnectionProvider = Future<ChromeConnection> Function();
+enum ReloadConfiguration { none, hotReload, hotRestart, liveReload }
+
+/// The Dart Web Debug Service.
+class Dwds {
+  final Handler handler;
+  final DevTools _devTools;
+  final DevHandler _devHandler;
+
+  Dwds._(this.handler, this._devTools, this._devHandler);
+
+  Stream<AppConnection> get connectedApps => _devHandler.connectedApps;
+
+  Future<void> stop() async {
+    await _devTools?.close();
+    await _devHandler.close();
+  }
+
+  Future<DebugConnection> debugConnection(AppConnection appConnection) async {
+    var appDebugServices = await _devHandler.loadAppServices(
+        appConnection.request.appId, appConnection.request.instanceId);
+    return DebugConnection(appDebugServices);
+  }
+
+  static Future<Dwds> start({
+    @required String hostname,
+    @required int applicationPort,
+    @required int assetServerPort,
+    @required String applicationTarget,
+    @required ReloadConfiguration reloadConfiguration,
+    @required Stream<BuildResult> buildResults,
+    @required ConnectionProvider chromeConnection,
+    @required bool serveDevTools,
+    @required LogWriter logWriter,
+    @required bool verbose,
+  }) async {
+    var assetHandler = AssetHandler(
+      assetServerPort,
+      applicationTarget,
+      hostname,
+      applicationPort,
+    );
+    var cascade = Cascade();
+    var pipeline = const Pipeline();
+
+    pipeline =
+        pipeline.addMiddleware(createInjectedHandler(reloadConfiguration));
+
+    DevTools devTools;
+    if (serveDevTools) {
+      devTools = await DevTools.start(hostname);
+      logWriter(Level.INFO,
+          'Serving DevTools at http://${devTools.hostname}:${devTools.port}\n');
+    }
+    var devHandler = DevHandler(
+      chromeConnection,
+      buildResults,
+      devTools,
+      assetHandler,
+      hostname,
+      verbose,
+      logWriter,
+    );
+    cascade = cascade.add(devHandler.handler).add(assetHandler.handler);
+
+    return Dwds._(pipeline.addHandler(cascade.handler), devTools, devHandler);
+  }
+}

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -17,8 +17,8 @@ import 'src/handlers/asset_handler.dart';
 import 'src/handlers/dev_handler.dart';
 import 'src/handlers/injected_handler.dart';
 
-export 'src/connections/app_connection.dart';
-export 'src/connections/debug_connection.dart';
+export 'src/connections/app_connection.dart' show AppConnection;
+export 'src/connections/debug_connection.dart' show DebugConnection;
 
 typedef LogWriter = void Function(Level, String);
 typedef ConnectionProvider = Future<ChromeConnection> Function();

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:build_daemon/data/build_status.dart';

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -10,12 +10,15 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import 'app_connection.dart';
-import 'debug_connection.dart';
+import 'src/connections/app_connection.dart';
+import 'src/connections/debug_connection.dart';
 import 'src/devtools.dart';
 import 'src/handlers/asset_handler.dart';
 import 'src/handlers/dev_handler.dart';
 import 'src/handlers/injected_handler.dart';
+
+export 'src/connections/app_connection.dart';
+export 'src/connections/debug_connection.dart';
 
 typedef LogWriter = void Function(Level, String);
 typedef ConnectionProvider = Future<ChromeConnection> Function();

--- a/dwds/lib/src/connections/app_connection.dart
+++ b/dwds/lib/src/connections/app_connection.dart
@@ -6,23 +6,23 @@ import 'dart:convert';
 
 import 'package:sse/server/sse_handler.dart';
 
-import 'data/connect_request.dart';
-import 'data/run_request.dart';
-import 'data/serializers.dart';
+import '../../data/connect_request.dart';
+import '../../data/run_request.dart';
+import '../../data/serializers.dart';
 
 /// A connection between the application loaded in the browser and DWDS.
 class AppConnection {
+  /// The initial connection request sent from the application in the browser.
   final ConnectRequest request;
-  final SseConnection _connection;
 
+  final SseConnection _connection;
   var _isStarted = false;
 
   AppConnection(this.request, this._connection);
 
   void runMain() {
-    if (!_isStarted) {
-      _connection.sink.add(jsonEncode(serializers.serialize(RunRequest())));
-    }
+    if (_isStarted) throw StateError('Main has already started.');
+    _connection.sink.add(jsonEncode(serializers.serialize(RunRequest())));
     _isStarted = true;
   }
 }

--- a/dwds/lib/src/connections/debug_connection.dart
+++ b/dwds/lib/src/connections/debug_connection.dart
@@ -6,9 +6,12 @@ import 'dart:async';
 
 import 'package:vm_service_lib/vm_service_lib.dart';
 
-import 'src/services/app_debug_services.dart';
+import '../services/app_debug_services.dart';
 
 /// A debug connection between the application in the browser and DWDS.
+///
+/// Supports debugging your running application through the Dart VM Service
+/// Protocol.
 class DebugConnection {
   final AppDebugServices _appDebugServices;
   final _onDoneCompleter = Completer();
@@ -19,10 +22,13 @@ class DebugConnection {
     });
   }
 
+  /// The port of the host Dart VM Service.
   int get port => _appDebugServices.debugService.port;
 
+  /// The websocket endpoint of the Dart VM Service.
   String get wsUri => _appDebugServices.debugService.wsUri;
 
+  /// A client of the Dart VM Service with DWDS specific extensions.
   VmService get vmService => _appDebugServices.dwdsVmClient.client;
 
   Future<void> close() async {

--- a/dwds/lib/src/debugger.dart
+++ b/dwds/lib/src/debugger.dart
@@ -7,10 +7,10 @@ import 'dart:async';
 import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import 'chrome_proxy_service.dart';
 import 'dart_uri.dart';
 import 'domain.dart';
 import 'location.dart';
+import 'services/chrome_proxy_service.dart';
 import 'sources.dart';
 
 /// Converts from ExceptionPauseMode strings to [PauseState] enums.

--- a/dwds/lib/src/domain.dart
+++ b/dwds/lib/src/domain.dart
@@ -2,10 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
-import 'package:dwds/src/chrome_proxy_service.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import 'inspector.dart';
+import 'services/chrome_proxy_service.dart';
 
 /// A common superclass to allow implementations of different parts of the
 /// protocol to get access to the inspector and utility functions.

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -5,10 +5,10 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:dwds/service.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
-import 'chrome_proxy_service.dart' show ChromeProxyService;
+import 'services/chrome_proxy_service.dart' show ChromeProxyService;
+import 'services/debug_service.dart';
 
 // A client of the vm service that registers some custom extensions like
 // hotRestart.

--- a/dwds/lib/src/handlers/asset_handler.dart
+++ b/dwds/lib/src/handlers/asset_handler.dart
@@ -11,18 +11,18 @@ import 'package:shelf_proxy/shelf_proxy.dart';
 ///
 /// Proxies requests to the build daemon asset server.
 class AssetHandler {
-  final int _daemonPort;
+  final int _assetServerPort;
   final String _target;
   final int _applicationPort;
   final String _applicationHost;
 
   Handler _handler;
 
-  AssetHandler(this._daemonPort, this._target, this._applicationHost,
+  AssetHandler(this._assetServerPort, this._target, this._applicationHost,
       this._applicationPort);
 
   Handler get handler =>
-      _handler ??= proxyHandler('http://localhost:$_daemonPort/$_target/');
+      _handler ??= proxyHandler('http://localhost:$_assetServerPort/$_target/');
 
   /// Returns the asset from a relative [path].
   ///

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -106,7 +106,14 @@ class DevHandler {
     connection.stream.listen((data) async {
       var message = dwds.serializers.deserialize(jsonDecode(data));
       if (message is DevToolsRequest) {
-        if (_devTools == null) return;
+        if (_devTools == null) {
+          connection.sink.add(
+              jsonEncode(dwds.serializers.serialize(DevToolsResponse((b) => b
+                ..success = false
+                ..error = 'Debugging is not enabled.\n\n'
+                    'If you are using webdev please pass the --debug flag.'))));
+          return;
+        }
 
         if (appId != message.appId) {
           connection.sink.add(jsonEncode(dwds.serializers.serialize(

--- a/dwds/lib/src/handlers/injected_handler.dart
+++ b/dwds/lib/src/handlers/injected_handler.dart
@@ -9,7 +9,7 @@ import 'dart:isolate';
 import 'package:crypto/crypto.dart';
 import 'package:shelf/shelf.dart';
 
-import '../injected/configuration.dart';
+import '../../dwds.dart';
 
 /// File extension that build_web_compilers will place the
 /// [entrypointExtensionMarker] in.

--- a/dwds/lib/src/injected/configuration.dart
+++ b/dwds/lib/src/injected/configuration.dart
@@ -1,5 +1,0 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
-enum ReloadConfiguration { none, hotReload, hotRestart, liveReload }

--- a/dwds/lib/src/inspector.dart
+++ b/dwds/lib/src/inspector.dart
@@ -6,10 +6,10 @@ import 'package:path/path.dart' as p;
 import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import 'chrome_proxy_service.dart';
 import 'dart_uri.dart';
 import 'debugger.dart';
 import 'helpers.dart';
+import 'services/chrome_proxy_service.dart';
 
 /// An inspector for a running Dart application contained in the
 /// [WipConnection].

--- a/dwds/lib/src/services/app_debug_services.dart
+++ b/dwds/lib/src/services/app_debug_services.dart
@@ -4,9 +4,9 @@
 
 import 'dart:async';
 
-import '../service.dart';
+import '../dwds_vm_client.dart';
 import 'chrome_proxy_service.dart' show ChromeProxyService;
-import 'dwds_vm_client.dart';
+import 'debug_service.dart';
 
 /// A container for all the services required for debugging an application.
 class AppDebugServices {

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -11,9 +11,9 @@ import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import 'debugger.dart';
-import 'helpers.dart';
-import 'inspector.dart';
+import '../debugger.dart';
+import '../helpers.dart';
+import '../inspector.dart';
 
 /// A handler for application assets, e.g. Dart sources.
 typedef AssetHandler = Future<String> Function(String);

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -16,8 +16,8 @@ import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import './src/chrome_proxy_service.dart';
-import './src/helpers.dart';
+import '../helpers.dart';
+import 'chrome_proxy_service.dart';
 
 void Function(WebSocketChannel, String) _createNewConnectionHandler(
   ChromeProxyService chromeProxyService,

--- a/dwds/lib/src/sources.dart
+++ b/dwds/lib/src/sources.dart
@@ -8,9 +8,9 @@ import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import 'chrome_proxy_service.dart';
 import 'dart_uri.dart';
 import 'location.dart';
+import 'services/chrome_proxy_service.dart';
 
 /// The scripts and sourcemaps for the application, both JS and Dart.
 class Sources {

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   devtools: ^0.1.0
   http: ^0.12.0
   http_multi_server: ^2.0.0
+  meta: ^1.1.7
   path: ^1.6.0
   pedantic: ^1.5.0
   pub_semver: ^1.4.2

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -7,8 +7,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dwds/src/chrome_proxy_service.dart';
 import 'package:dwds/src/dart_uri.dart';
+import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:http/http.dart' as http;
 import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';

--- a/dwds/test/debug_service_test.dart
+++ b/dwds/test/debug_service_test.dart
@@ -4,9 +4,8 @@
 
 import 'dart:io';
 
+import 'package:dwds/src/services/debug_service.dart';
 import 'package:test/test.dart';
-
-import 'package:dwds/service.dart';
 
 import 'test_context.dart';
 

--- a/dwds/test/handlers/injected_handler_test.dart
+++ b/dwds/test/handlers/injected_handler_test.dart
@@ -4,8 +4,8 @@
 
 import 'dart:io';
 
+import 'package:dwds/dwds.dart';
 import 'package:dwds/src/handlers/injected_handler.dart';
-import 'package:dwds/src/injected/configuration.dart';
 import 'package:http/http.dart' as http;
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;

--- a/dwds/test/test_context.dart
+++ b/dwds/test/test_context.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dwds/service.dart';
-import 'package:dwds/src/chrome_proxy_service.dart';
 import 'package:dwds/src/helpers.dart';
+import 'package:dwds/src/services/chrome_proxy_service.dart';
+import 'package:dwds/src/services/debug_service.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
-import 'package:dwds/src/chrome_proxy_service.dart';
+import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:test/test.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:args/args.dart';
-import 'package:dwds/src/injected/configuration.dart'; // ignore: implementation_imports
+import 'package:dwds/dwds.dart';
 import 'package:logging/logging.dart';
 
 import '../logging.dart';

--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:build_daemon/data/build_status.dart';
-import 'package:dwds/debug_connection.dart';
+import 'package:dwds/dwds.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 

--- a/webdev/lib/src/serve/server_manager.dart
+++ b/webdev/lib/src/serve/server_manager.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:build_daemon/data/build_status.dart';
-import 'package:dwds/src/devtools.dart'; // ignore: implementation_imports
 
 import 'webdev_server.dart';
 
@@ -15,11 +14,13 @@ class ServerManager {
 
   ServerManager._(this.servers);
 
-  static Future<ServerManager> start(Set<ServerOptions> serverOptions,
-      Stream<BuildResults> buildResults, DevTools devTools) async {
+  static Future<ServerManager> start(
+    Set<ServerOptions> serverOptions,
+    Stream<BuildResults> buildResults,
+  ) async {
     var servers = Set<WebDevServer>();
     for (var options in serverOptions) {
-      servers.add(await WebDevServer.start(options, buildResults, devTools));
+      servers.add(await WebDevServer.start(options, buildResults));
     }
     return ServerManager._(servers);
   }

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -6,10 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:build_daemon/data/build_status.dart';
-import 'package:dwds/src/devtools.dart'; // ignore: implementation_imports
-import 'package:dwds/src/handlers/asset_handler.dart'; // ignore: implementation_imports
-import 'package:dwds/src/handlers/dev_handler.dart'; // ignore: implementation_imports
-import 'package:dwds/src/handlers/injected_handler.dart'; // ignore: implementation_imports
+import 'package:dwds/dwds.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
@@ -35,12 +32,19 @@ class ServerOptions {
 
 class WebDevServer {
   final HttpServer _server;
-  final DevHandler devHandler;
   final String target;
+  final Dwds dwds;
+  final Stream<BuildResult> buildResults;
 
-  WebDevServer._(this.target, this._server, this.devHandler, bool autoRun) {
+  WebDevServer._(
+    this.target,
+    this._server,
+    this.dwds,
+    this.buildResults,
+    bool autoRun,
+  ) {
     if (autoRun) {
-      devHandler.connectedApps.listen((connection) {
+      dwds.connectedApps.listen((connection) {
         connection.runMain();
       });
     }
@@ -50,45 +54,50 @@ class WebDevServer {
   int get port => _server.port;
 
   Future<void> stop() async {
-    await devHandler.close();
+    await dwds.stop();
     await _server.close(force: true);
   }
 
   static Future<WebDevServer> start(
     ServerOptions options,
     Stream<BuildResults> buildResults,
-    DevTools devTools,
   ) async {
-    var assetHandler = AssetHandler(options.daemonPort, options.target,
-        options.configuration.hostname, options.port);
-    var cascade = Cascade();
     var pipeline = const Pipeline();
 
     if (options.configuration.logRequests) {
       pipeline = pipeline.addMiddleware(logRequests());
     }
 
-    pipeline = pipeline
-        .addMiddleware(createInjectedHandler(options.configuration.reload))
-        .addMiddleware(interceptFavicon);
+    pipeline = pipeline.addMiddleware(interceptFavicon);
 
-    var devHandler = DevHandler(
-      () async => (await Chrome.connectedInstance).chromeConnection,
-      // Only provide relevant build results
-      buildResults.asyncMap<BuildResult>((results) => results.results
-          .firstWhere((result) => result.target == options.target)),
-      devTools,
-      assetHandler,
-      options.configuration.hostname,
-      options.configuration.verbose,
-      logWriter,
+    // Only provide relevant build results
+    var filteredBuildResults = buildResults.asyncMap<BuildResult>((results) =>
+        results.results
+            .firstWhere((result) => result.target == options.target));
+
+    var dwds = await Dwds.start(
+      hostname: options.configuration.hostname,
+      applicationPort: options.port,
+      applicationTarget: options.target,
+      assetServerPort: options.daemonPort,
+      buildResults: filteredBuildResults,
+      chromeConnection: () async =>
+          (await Chrome.connectedInstance).chromeConnection,
+      logWriter: logWriter,
+      reloadConfiguration: options.configuration.reload,
+      serveDevTools: options.configuration.debug,
+      verbose: options.configuration.verbose,
     );
-    cascade = cascade.add(devHandler.handler).add(assetHandler.handler);
 
     var hostname = options.configuration.hostname;
     var server = await HttpMultiServer.bind(hostname, options.port);
-    shelf_io.serveRequests(server, pipeline.addHandler(cascade.handler));
+    shelf_io.serveRequests(server, pipeline.addHandler(dwds.handler));
     return WebDevServer._(
-        options.target, server, devHandler, options.configuration.autoRun);
+      options.target,
+      server,
+      dwds,
+      filteredBuildResults,
+      options.configuration.autoRun,
+    );
   }
 }


### PR DESCRIPTION
- Rename `dwds/lib/service.dart` to `dwds/lib/src/services/debug_service.dart`
- Move `chrome_proxy_service.dart` and `app_debug_services.dart` to `dwds/lib/src/services`
- Rename `DevConnection` to `AppConnection` and promote as a public abstraction
- Create new public `DebugConnection` abstraction
- Create new public entrypoint `dwds.dart`
  - This entrypoint exposes a `handler` to be used with shelf (see changes to `webdev`)
- Update `webdev` to no longer import from `dwds`'s source

This mostly completes https://github.com/dart-lang/webdev/issues/475. In a follow up PR I'll shuffle the tests around so there is a better separation between `webdev` and `dwds` tests.

cc @jonahwilliams