### PR TITLE
Prepare to publish

### DIFF
--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -10,8 +10,7 @@ environment:
 dependencies:
   intl: ^0.15.8
   path: ^1.6.1
-  webdev: ^2.0.0
 
 dev_dependencies:
-  build_runner: ^1.0.0
+  build_runner: ^1.6.2
   build_web_compilers: '>=1.0.0 <3.0.0'

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.0-dev
+## 0.4.0
 
 - Move `data` abstractions from `package:webdev` into `package:dwds`.
 - Move debugging related handlers from `package:webdev` into `package:dwds`.

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.3.3
+version: 0.4.0
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
@@ -10,23 +10,34 @@ environment:
   sdk: ">=2.3.2-dev.0.1 <3.0.0"
 
 dependencies:
+  async: ^2.3.0
+  build: ^1.1.5
+  build_daemon: ^2.0.0
+  built_collection: ^4.2.2
+  built_value: ^6.7.0
+  crypto: ^2.0.6
   devtools: ^0.1.0
   http: ^0.12.0
   http_multi_server: ^2.0.0
+  logging: ^0.11.3
   meta: ^1.1.7
   path: ^1.6.0
   pedantic: ^1.5.0
   pub_semver: ^1.4.2
   shelf: ^0.7.0
   shelf_proxy: ^0.1.0+6
+  shelf_static: ^0.2.8
   shelf_web_socket: ^0.2.0
   source_maps: ^0.10.0
+  sse: ^2.0.2
+  stream_channel: ^2.0.0
   vm_service_lib: 3.20.0+02
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: ^0.4.0
 
 dev_dependencies:
   args: ^1.0.0
+  build: ^1.1.5
   build_runner: ^1.0.0
   build_web_compilers: '>=1.0.0 <3.0.0'
   built_value_generator: ^6.4.0

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
 
 dependencies:
   async: ^2.3.0
-  build: ^1.1.5
+  build: ^1.1.0
   build_daemon: ^2.0.0
-  built_collection: ^4.2.2
+  built_collection: ^4.2.0
   built_value: ^6.7.0
   crypto: ^2.0.6
   devtools: ^0.1.0
@@ -38,7 +38,7 @@ dependencies:
 dev_dependencies:
   args: ^1.0.0
   build: ^1.1.5
-  build_runner: ^1.0.0
+  build_runner: ^1.6.2
   build_web_compilers: '>=1.0.0 <3.0.0'
   built_value_generator: ^6.4.0
   graphs: ^0.2.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,12 @@ dependencies:
   angular_components: ^0.13.0
 
 dev_dependencies:
-  build_runner: '>=1.3.0 <2.0.0'
+  build_runner: '>=1.6.2 <2.0.0'
   build_web_compilers: '>=1.0.0 <3.0.0'
   webdev: ^2.0.0
+
+dependency_overrides:
+  webdev:
+    path: ../webdev
+  dwds:
+    path: ../dwds

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.3.0-dev
+## 2.3.0
 
 - Depend on the latest `package:dwds`.
+- Depend on the latest `package:build_daemon`.
 
 ## 2.2.0
 

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -14,7 +14,7 @@ similar to:
 ```yaml
 ...
 dev_dependencies:
-  build_runner: ^1.3.0
+  build_runner: ^1.6.2
   build_web_compilers: ^2.0.0
 ...
 ```

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -140,7 +140,7 @@ class PubspecLock {
 
 Future<List<PackageExceptionDetails>> _validateBuildDaemonVersion(
     PubspecLock pubspecLock) async {
-  var buildDaemonConstraint = '>=1.0.0 <2.0.0';
+  var buildDaemonConstraint = '>=2.0.0 <3.0.0';
 
   var issues = <PackageExceptionDetails>[];
 
@@ -180,7 +180,7 @@ Future<void> checkPubspecLock(PubspecLock pubspecLock,
   var issues = <PackageExceptionDetails>[];
 
   var buildRunnerIssues = pubspecLock.checkPackage(
-      'build_runner', VersionConstraint.parse('>=1.5.0 <2.0.0'));
+      'build_runner', VersionConstraint.parse('>=1.6.2 <2.0.0'));
 
   issues.addAll(buildRunnerIssues);
 

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.3.0-dev';
+const packageVersion = '2.3.0';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.3.0-dev
+version: 2.3.0
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-
@@ -13,7 +13,7 @@ environment:
 dependencies:
   args: ^1.5.0
   async: ^2.2.0
-  build_daemon: ^1.1.0
+  build_daemon: ^2.0.0
   built_value: ^6.3.0
   crypto: ^2.0.6
   dwds: ^0.4.0

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
 dev_dependencies:
   build: ^1.0.0
-  build_runner: ^1.0.0
+  build_runner: ^1.6.2
   build_verify: ^1.0.0
   build_version: ^2.0.0
   test: ^1.6.0

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -143,7 +143,7 @@ name: sample
               switch (entry.key) {
                 case 'build_runner':
                   buildRunnerVersion = version;
-                  supportedRange = '>=1.5.0 <2.0.0';
+                  supportedRange = '>=1.6.2 <2.0.0';
                   break;
                 case 'build_web_compilers':
                   webCompilersVersion = version;
@@ -288,9 +288,9 @@ dependencies:
   }
 }
 
-const _supportedBuildRunnerVersion = '1.5.0';
+const _supportedBuildRunnerVersion = '1.6.2';
 const _supportedWebCompilersVersion = '1.2.0';
-const _supportedBuildDaemonVersion = '1.0.0';
+const _supportedBuildDaemonVersion = '2.0.0';
 
 String _pubspecLock(
     {String runnerVersion = _supportedBuildRunnerVersion,


### PR DESCRIPTION
- Update `dwds`'s pubspec to include all deps
- Update `webdev` / `dwds` to depend on latest `build_daemon`
- Update `webdev` to restrict to proper `build_runner` version
- Temporarily override example deps