### PR TITLE
Normalize paths in DartUri

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- Fix an issue where we source map paths were not normalized.
+
 ## 0.4.0
 
 - Move `data` abstractions from `package:webdev` into `package:dwds`.

--- a/dwds/lib/src/utilities/dart_uri.dart
+++ b/dwds/lib/src/utilities/dart_uri.dart
@@ -70,6 +70,7 @@ class DartUri {
   factory DartUri._fromServerPath(String uri) {
     uri = uri[0] == '.' ? uri.substring(1) : uri;
     uri = uri[0] == '/' ? uri.substring(1) : uri;
+    uri = p.normalize(uri);
     return DartUri._(uri);
   }
 }

--- a/dwds/lib/src/utilities/dart_uri.dart
+++ b/dwds/lib/src/utilities/dart_uri.dart
@@ -45,7 +45,7 @@ class DartUri {
     if (serverUri != null) {
       var path = Uri.parse(serverUri).path;
       var dir = p.dirname(path);
-      return DartUri._fromServerPath(p.join(dir, uri));
+      return DartUri._fromServerPath(p.normalize(p.join(dir, uri)));
     }
     throw FormatException('Unsupported URI form', uri);
   }
@@ -70,7 +70,6 @@ class DartUri {
   factory DartUri._fromServerPath(String uri) {
     uri = uri[0] == '.' ? uri.substring(1) : uri;
     uri = uri[0] == '/' ? uri.substring(1) : uri;
-    uri = p.normalize(uri);
     return DartUri._(uri);
   }
 }

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.4.0
+version: 0.4.1-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-

--- a/dwds/test/dart_ui_test.dart
+++ b/dwds/test/dart_ui_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dwds/src/utilities/dart_uri.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DartUri', () {
+    test('normalizes server paths', () {
+      var uri = DartUri('/packages/blah/src/../foo.dart');
+      expect(uri.serverPath, 'packages/blah/foo.dart');
+    });
+
+    test('parses package : paths', () {
+      var uri = DartUri('package:path/path.dart');
+      expect(uri.serverPath, 'packages/path/path.dart');
+    });
+
+    test('parses org-dartlang-app paths', () {
+      var uri = DartUri('org-dartlang-app:////web/main.dart');
+      expect(uri.serverPath, 'web/main.dart');
+    });
+
+    test('parses packages paths', () {
+      var uri = DartUri('/packages/blah/foo.dart');
+      expect(uri.serverPath, 'packages/blah/foo.dart');
+    });
+
+    test('parses http paths', () {
+      var uri = DartUri('http://localhost:8080/web/main.dart');
+      expect(uri.serverPath, 'web/main.dart');
+    });
+  });
+}

--- a/dwds/test/dart_ui_test.dart
+++ b/dwds/test/dart_ui_test.dart
@@ -18,8 +18,8 @@ void main() {
     });
 
     test('parses org-dartlang-app paths', () {
-      var uri = DartUri('org-dartlang-app:////web/main.dart');
-      expect(uri.serverPath, 'web/main.dart');
+      var uri = DartUri('org-dartlang-app:////blah/main.dart');
+      expect(uri.serverPath, 'blah/main.dart');
     });
 
     test('parses packages paths', () {

--- a/dwds/test/dart_ui_test.dart
+++ b/dwds/test/dart_ui_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   group('DartUri', () {
     test('normalizes server paths', () {
-      var uri = DartUri('/packages/blah/src/../foo.dart');
+      var uri = DartUri('../foo.dart', '/packages/blah/src/blah.dart');
       expect(uri.serverPath, 'packages/blah/foo.dart');
     });
 

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -47,3 +47,7 @@ dev_dependencies:
 
 executables:
   webdev:
+
+dependency_overrides:
+  dwds:
+    path: ../dwds


### PR DESCRIPTION
Source map paths are often relative, e.g. `/packages/src/../foo.dart`. Account for this and add corresponding tests.

Closes: https://github.com/dart-lang/webdev/issues/505