### PR TITLE
Better black boxing

### DIFF
--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -142,7 +142,7 @@ class Debugger extends Domain {
   }
 
   Future<Null> _initialize() async {
-    sources = Sources(_assetHandler);
+    sources = Sources(_assetHandler, _wipDebugger);
     // We must add a listener before enabling the debugger otherwise we will
     // miss events.
     // Allow a null debugger/connection for unit tests.
@@ -244,12 +244,10 @@ class Debugger extends Domain {
 
   /// Find the [Location] for the given JS source position.
   ///
-  /// The [line] and [column] are 1-based.
-  Location _locationForJs(String scriptId, int line, int column) =>
-      sources.locationsForJs(scriptId).firstWhere(
-          (location) =>
-              location.jsLocation.line == line &&
-              location.jsLocation.column == column,
+  /// The [line] number is 1-based.
+  Location _locationForJs(String scriptId, int line) => sources
+      .locationsForJs(scriptId)
+      .firstWhere((location) => location.jsLocation.line == line,
           orElse: () => null);
 
   /// Returns source [Location] for the paused event.
@@ -261,8 +259,7 @@ class Debugger extends Domain {
     var location = frame['location'];
     var jsLocation = JsLocation.fromZeroBased(location['scriptId'] as String,
         location['lineNumber'] as int, location['columnNumber'] as int);
-    return _locationForJs(
-        jsLocation.scriptId, jsLocation.line, jsLocation.column);
+    return _locationForJs(jsLocation.scriptId, jsLocation.line);
   }
 
   /// Translates Chrome callFrames contained in [DebuggerPausedEvent] into Dart

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -143,7 +143,7 @@ class Debugger extends Domain {
   }
 
   Future<Null> _initialize() async {
-    sources = Sources(_assetHandler, _wipDebugger);
+    sources = Sources(_assetHandler, _remoteDebugger);
     // We must add a listener before enabling the debugger otherwise we will
     // miss events.
     // Allow a null debugger/connection for unit tests.

--- a/dwds/lib/src/debugging/sources.dart
+++ b/dwds/lib/src/debugging/sources.dart
@@ -32,7 +32,7 @@ class Sources {
   final _sourceToScriptId = <String, String>{};
 
   /// Paths to black box in the Chrome debugger.
-  final _blackBoxPaths = {'/packages/stack_trace/'};
+  final _pathsToBlackBox = {'/packages/stack_trace/'};
 
   final AssetHandler _assetHandler;
   final WipDebugger _wipDebugger;
@@ -146,7 +146,7 @@ class Sources {
   Future<void> _blackBoxIfNecessary(WipScript script) async {
     if (script.url.endsWith('dart_sdk.js')) {
       await _blackBoxSdk(script);
-    } else if (_blackBoxPaths.any((path) => script.url.contains(path))) {
+    } else if (_pathsToBlackBox.any((path) => script.url.contains(path))) {
       var lines =
           (await _assetHandler(DartUri(script.url).serverPath)).split('\n');
       await _blackBoxRanges(script.scriptId, [lines.length]);
@@ -157,6 +157,7 @@ class Sources {
   Future<void> _blackBoxSdk(WipScript script) async {
     var sdkSourceLines =
         (await _assetHandler(DartUri(script.url).serverPath)).split('\n');
+    // TODO(grouma) - Find a more robust way to identify this location.
     var throwIndex = sdkSourceLines.indexWhere(
         (line) => line.contains('dart.throw = function throw_(exception) {'));
     if (throwIndex != -1) {

--- a/dwds/lib/src/debugging/sources.dart
+++ b/dwds/lib/src/debugging/sources.dart
@@ -153,6 +153,7 @@ class Sources {
     }
   }
 
+  /// Black boxes the SDK excluding the range which includes exception logic.
   Future<void> _blackBoxSdk(WipScript script) async {
     var sdkSourceLines =
         (await _assetHandler(DartUri(script.url).serverPath)).split('\n');

--- a/dwds/lib/src/debugging/sources.dart
+++ b/dwds/lib/src/debugging/sources.dart
@@ -11,6 +11,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 import '../services/chrome_proxy_service.dart';
 import '../utilities/dart_uri.dart';
 import 'location.dart';
+import 'remote_debugger.dart';
 
 /// The scripts and sourcemaps for the application, both JS and Dart.
 class Sources {
@@ -35,9 +36,9 @@ class Sources {
   final _pathsToBlackBox = {'/packages/stack_trace/'};
 
   final AssetHandler _assetHandler;
-  final WipDebugger _wipDebugger;
+  final RemoteDebugger _remoteDebugger;
 
-  Sources(this._assetHandler, this._wipDebugger);
+  Sources(this._assetHandler, this._remoteDebugger);
 
   /// Returns all [Location] data for a provided Dart source.
   Set<Location> locationsForDart(String serverPath) =>
@@ -166,7 +167,7 @@ class Sources {
   }
 
   Future<void> _blackBoxRanges(String scriptId, List<int> lineNumbers) async {
-    await _wipDebugger.sendCommand('Debugger.setBlackboxedRanges', params: {
+    await _remoteDebugger.sendCommand('Debugger.setBlackboxedRanges', params: {
       'scriptId': scriptId,
       'positions': [
         {'lineNumber': 0, 'columnNumber': 0},

--- a/dwds/lib/src/debugging/sources.dart
+++ b/dwds/lib/src/debugging/sources.dart
@@ -142,7 +142,7 @@ class Sources {
     return _assetHandler(sourcemapPath);
   }
 
-  /// Black boxes the Dart SDK and paths in [_blackBoxPaths].
+  /// Black boxes the Dart SDK and paths in [_pathsToBlackBox].
   Future<void> _blackBoxIfNecessary(WipScript script) async {
     if (script.url.endsWith('dart_sdk.js')) {
       await _blackBoxSdk(script);


### PR DESCRIPTION
- Do not consider the JS column number when looking for a matching JS location.
  - We use a heuristic to find the closest number based off a non-exact column number
- Add black boxing logic to the dart_sdk and stack_trace package to improve performance