### PR TITLE
Better instanceRefs for undefined and function types

### DIFF
--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -289,6 +289,8 @@ function($argsString) {
         return _primitiveInstance(InstanceKind.kDouble, remoteObject);
       case 'boolean':
         return _primitiveInstance(InstanceKind.kBool, remoteObject);
+      case 'undefined':
+        return _primitiveInstance(InstanceKind.kNull, remoteObject);
       case 'object':
         if (_asDartObject(remoteObject) == null) {
           return _primitiveInstance(InstanceKind.kNull, remoteObject);
@@ -304,6 +306,14 @@ function($argsString) {
           // TODO(jakemac): Create a real ClassRef, we need a way of looking
           // up the library for a given instance to create it though.
           // https://github.com/dart-lang/sdk/issues/36771.
+          ..classRef = ClassRef();
+      case 'function':
+        var crudeAttemptAtName =
+            remoteObject.description.split('(').first;
+        return InstanceRef()
+          ..kind = InstanceKind.kPlainInstance
+          ..id = remoteObject.objectId
+          ..valueAsString = crudeAttemptAtName
           ..classRef = ClassRef();
       default:
         // Return unsupported types as a String placeholder for now.

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -308,8 +308,7 @@ function($argsString) {
           // https://github.com/dart-lang/sdk/issues/36771.
           ..classRef = ClassRef();
       case 'function':
-        var crudeAttemptAtName =
-            remoteObject.description.split('(').first;
+        var crudeAttemptAtName = remoteObject.description.split('(').first;
         return InstanceRef()
           ..kind = InstanceKind.kPlainInstance
           ..id = remoteObject.objectId

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -10,7 +10,7 @@ import 'dart:html';
 final libraryPublicFinal = MyTestClass();
 
 final _libraryPrivateFinal = 1;
-
+Object libraryNull;
 var libraryPublic = ['library', 'public', 'variable'];
 
 var _libraryPrivate = ['library', 'private', 'variable'];
@@ -32,10 +32,12 @@ void main() async {
 
   Timer.periodic(Duration(seconds: 1), (Timer t) {
     var ticks = t.tick;
+    var closureLocal;
     libraryPublicFinal.printCount();
     print('ticking... $ticks (the answer is $intLocalInMain)');
     print(nestedFunction('$ticks ${testClass.message}'));
     print(localThatsNull);
+    print(libraryNull);
   });
 
   document.body.append(SpanElement()..text = 'Exercising some scopes');

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -32,8 +32,7 @@ void main() async {
 
   Timer.periodic(Duration(seconds: 1), (Timer t) {
     var ticks = t.tick;
-    // ignore: unused_local_variable
-    // ignore: prefer_typing_uninitialized_variables
+    // ignore: unused_local_variable, prefer_typing_uninitialized_variables
     var closureLocal;
     libraryPublicFinal.printCount();
     print('ticking... $ticks (the answer is $intLocalInMain)');

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -32,6 +32,8 @@ void main() async {
 
   Timer.periodic(Duration(seconds: 1), (Timer t) {
     var ticks = t.tick;
+    // ignore: unused_local_variable
+    // ignore: prefer_typing_uninitialized_variables
     var closureLocal;
     libraryPublicFinal.printCount();
     print('ticking... $ticks (the answer is $intLocalInMain)');


### PR DESCRIPTION
Undefined can occur when we are paused part-way through initializing a variable.

Adds ignores because we're explicitly testing an uninitialized local variable, and the lints want us to type uninitialized variables but not locals.