### PR TITLE
Provide initial support of SSE with DevTools

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,8 +1,11 @@
-## 0.4.1
+## 0.5.0
 
 - Fix an issue where we source map paths were not normalized.
 - Added a check to tests for the variable DWDS_DEBUG_CHROME to run Chrome with a
   UI rather than headless.
+- Add support for an SSE connection with Dart DevTools.
+- Rename `wsUri` to `uri` on `DebugConnection` to reflect that the uri may not
+  be a websocket.
 
 ## 0.4.0
 

--- a/dwds/lib/src/connections/debug_connection.dart
+++ b/dwds/lib/src/connections/debug_connection.dart
@@ -26,8 +26,8 @@ class DebugConnection {
   /// The port of the host Dart VM Service.
   int get port => _appDebugServices.debugService.port;
 
-  /// The websocket endpoint of the Dart VM Service.
-  String get wsUri => _appDebugServices.debugService.wsUri;
+  /// The endpoint of the Dart VM Service.
+  String get uri => _appDebugServices.debugService.uri;
 
   /// A client of the Dart VM Service with DWDS specific extensions.
   VmService get vmService => _appDebugServices.dwdsVmClient.client;

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -119,6 +119,8 @@ class DevHandler {
                   'VmService proxy responded with an error:\n$response');
             }
           : null,
+      // TODO(grouma) - Use SSE for Dart Debug Extension workflow.
+      useSse: false,
     );
   }
 
@@ -212,7 +214,7 @@ class DevHandler {
             .sendCommand('Target.createTarget', params: {
           'newWindow': true,
           'url': 'http://${_devTools.hostname}:${_devTools.port}'
-              '/?hide=none&uri=${appServices.debugService.wsUri}',
+              '/?hide=none&uri=${appServices.debugService.uri}',
         });
       } else if (message is ConnectRequest) {
         if (appId != null) {
@@ -269,7 +271,7 @@ class DevHandler {
     _logWriter(
         Level.INFO,
         'Debug service listening on '
-        '${debugService.wsUri}\n');
+        '${debugService.uri}\n');
     var webdevClient = await DwdsVmClient.create(debugService);
     return AppDebugServices(debugService, webdevClient);
   }

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -308,7 +308,7 @@ class DevHandler {
     await _extensionDebugger.sendCommand('Target.createTarget', params: {
       'newWindow': true,
       'url': 'http://${_devTools.hostname}:${_devTools.port}'
-          '/?hide=none&uri=${appServices.debugService.wsUri}',
+          '/?hide=none&uri=${appServices.debugService.uri}',
     });
   }
 }

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -10,11 +10,14 @@ import 'dart:typed_data';
 
 import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:http_multi_server/http_multi_server.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart' as shelf;
+import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:sse/server/sse_handler.dart';
 
 import '../utilities/shared.dart';
 import 'chrome_proxy_service.dart';
@@ -49,6 +52,33 @@ void Function(WebSocketChannel, String) _createNewConnectionHandler(
   };
 }
 
+Future<void> _handleSseConnections(
+  SseHandler handler,
+  ChromeProxyService chromeProxyService,
+  ServiceExtensionRegistry serviceExtensionRegistry, {
+  void Function(Map<String, dynamic>) onRequest,
+  void Function(Map<String, dynamic>) onResponse,
+}) async {
+  while (await handler.connections.hasNext) {
+    var connection = await handler.connections.next;
+    var responseController = StreamController<Map<String, Object>>();
+    var sub = responseController.stream.map((response) {
+      if (onResponse != null) onResponse(response);
+      return jsonEncode(response);
+    }).listen((event) {
+      connection.sink.add(event);
+    });
+    var inputStream = connection.stream.map((value) {
+      var request = jsonDecode(value) as Map<String, Object>;
+      if (onRequest != null) onRequest(request);
+      return request;
+    });
+    var vmServerConnection = VmServerConnection(inputStream,
+        responseController.sink, serviceExtensionRegistry, chromeProxyService);
+    unawaited(vmServerConnection.done.then((_) => sub.cancel()));
+  }
+}
+
 /// A Dart Web Debug Service.
 ///
 /// Creates a [ChromeProxyService] from an existing Chrome instance.
@@ -59,15 +89,24 @@ class DebugService {
   final int port;
   final HttpServer _server;
   final String _authToken;
+  final bool _useSse;
 
-  DebugService._(this.chromeProxyService, this.hostname, this.port,
-      this._authToken, this.serviceExtensionRegistry, this._server);
+  DebugService._(
+      this.chromeProxyService,
+      this.hostname,
+      this.port,
+      this._authToken,
+      this.serviceExtensionRegistry,
+      this._server,
+      this._useSse);
 
   Future<void> close() async {
     await _server.close();
   }
 
-  String get wsUri => 'ws://$hostname:$port/$_authToken';
+  String get uri => _useSse
+      ? 'sse://$hostname:$port/$_authToken/\$debugHandler'
+      : 'ws://$hostname:$port/$_authToken';
 
   /// [appInstanceId] is a unique String embedded in the instance of the
   /// application available through `window.$dartAppInstanceId`.
@@ -79,27 +118,44 @@ class DebugService {
     String appInstanceId, {
     void Function(Map<String, dynamic>) onRequest,
     void Function(Map<String, dynamic>) onResponse,
+    bool useSse,
   }) async {
     var chromeProxyService = await ChromeProxyService.create(
         remoteDebugger, tabUrl, assetHandler, appInstanceId);
-    var serviceExtensionRegistry = ServiceExtensionRegistry();
     var authToken = _makeAuthToken();
-    var innerHandler = webSocketHandler(_createNewConnectionHandler(
-        chromeProxyService, serviceExtensionRegistry,
-        onRequest: onRequest, onResponse: onResponse));
-    var handler = (shelf.Request request) {
-      if (request.url.pathSegments.first != authToken) {
-        return shelf.Response.forbidden('Incorrect auth token');
-      }
-      return innerHandler(request);
-    };
+    var serviceExtensionRegistry = ServiceExtensionRegistry();
+    Handler handler;
+    if (useSse) {
+      var sseHandler = SseHandler(Uri.parse('/$authToken/\$debugHandler'));
+      handler = sseHandler.handler;
+      unawaited(_handleSseConnections(
+          sseHandler, chromeProxyService, serviceExtensionRegistry,
+          onRequest: onRequest, onResponse: onResponse));
+    } else {
+      var innerHandler = webSocketHandler(_createNewConnectionHandler(
+          chromeProxyService, serviceExtensionRegistry,
+          onRequest: onRequest, onResponse: onResponse));
+      handler = (shelf.Request request) {
+        if (request.url.pathSegments.first != authToken) {
+          return shelf.Response.forbidden('Incorrect auth token');
+        }
+        return innerHandler(request);
+      };
+    }
     var port = await findUnusedPort();
     var server = hostname == 'localhost'
         ? await HttpMultiServer.loopback(port)
         : await HttpServer.bind(hostname, port);
     serveRequests(server, handler);
-    return DebugService._(chromeProxyService, hostname, port, authToken,
-        serviceExtensionRegistry, server);
+    return DebugService._(
+      chromeProxyService,
+      hostname,
+      port,
+      authToken,
+      serviceExtensionRegistry,
+      server,
+      useSse,
+    );
   }
 }
 

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -65,9 +65,7 @@ Future<void> _handleSseConnections(
     var sub = responseController.stream.map((response) {
       if (onResponse != null) onResponse(response);
       return jsonEncode(response);
-    }).listen((event) {
-      connection.sink.add(event);
-    });
+    }).listen(connection.sink.add);
     var inputStream = connection.stream.map((value) {
       var request = jsonDecode(value) as Map<String, Object>;
       if (onRequest != null) onRequest(request);
@@ -75,7 +73,7 @@ Future<void> _handleSseConnections(
     });
     var vmServerConnection = VmServerConnection(inputStream,
         responseController.sink, serviceExtensionRegistry, chromeProxyService);
-    unawaited(vmServerConnection.done.then((_) => sub.cancel()));
+    unawaited(vmServerConnection.done.whenComplete(sub.cancel));
   }
 }
 

--- a/dwds/test/debug_service_test.dart
+++ b/dwds/test/debug_service_test.dart
@@ -26,6 +26,6 @@ void main() {
   });
 
   test('Accepts connections with the auth token', () async {
-    expect(WebSocket.connect('${context.debugConnection.wsUri}/ws'), completes);
+    expect(WebSocket.connect('${context.debugConnection.uri}/ws'), completes);
   });
 }

--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -101,7 +101,7 @@ class AppDomain extends Domain {
       sendEvent('app.debugPort', {
         'appId': _appId,
         'port': _debugConnection.port,
-        'wsUri': _debugConnection.wsUri,
+        'wsUri': _debugConnection.uri,
       });
       _resultSub = server.buildResults.listen(_handleBuildResult);
 


### PR DESCRIPTION
- Add option to the `DebugService` to start an `SSE` server instead of a `Websocket` server
- Update debug connection `wsUri` to be called `uri` to reflect that it may not be a websocket

Once https://github.com/flutter/devtools/issues/881 is resolved we should be able to do some E2E testing. I'll leave this work to @pisimulation.