### PR TITLE
Enabled serveDevTools for Dart Debug Extension.

### DIFF
--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -63,7 +63,7 @@ class Dwds {
     reloadConfiguration ??= ReloadConfiguration.none;
     enableDebugExtension ??= false;
     // `serveDevTools` is true by default when the extension is enabled.
-    serveDevTools = enableDebugExtension ? true : serveDevTools;
+    serveDevTools = serveDevTools || enableDebugExtension;
     logWriter ??= (level, message) => print(message);
     verbose ??= false;
     var assetHandler = AssetHandler(

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -63,7 +63,7 @@ class Dwds {
     reloadConfiguration ??= ReloadConfiguration.none;
     enableDebugExtension ??= false;
     // `serveDevTools` is true by default when the extension is enabled.
-    serveDevTools ??= enableDebugExtension;
+    serveDevTools = enableDebugExtension ? true : false;
     logWriter ??= (level, message) => print(message);
     verbose ??= false;
     var assetHandler = AssetHandler(

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -63,7 +63,7 @@ class Dwds {
     reloadConfiguration ??= ReloadConfiguration.none;
     enableDebugExtension ??= false;
     // `serveDevTools` is true by default when the extension is enabled.
-    serveDevTools = enableDebugExtension ? true : false;
+    serveDevTools = enableDebugExtension ? true : serveDevTools;
     logWriter ??= (level, message) => print(message);
     verbose ??= false;
     var assetHandler = AssetHandler(


### PR DESCRIPTION
If `--debug` is not set, `serveDevTools` is already defaulted to `false`. The null check is too late.