### PR TITLE
Add a --no-injected-client flag

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Fix an issue where we source map paths were not normalized.
 - Added a check to tests for the variable DWDS_DEBUG_CHROME to run Chrome with a
   UI rather than headless.
+- Catch unhandled errors in `client.js` and recommend using the
+  `--no-injected-client` flag for webdev users.
 
 ## 0.4.0
 

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.4.1-dev
+version: 0.4.1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.4.0
+
+- Add a `--no-injected-client` option which can be used to work around issues
+  relating to the injected `client.js` file. All debugging features must be
+  disabled if you use this option.
+
 ## 2.3.0
 
 - Depend on the latest `package:dwds`.

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -58,6 +58,13 @@ Usage: webdev serve [arguments] [<directory>[:<port>]]...
                                   Option + D). This also enables
                                   --launch-in-chrome.
 
+    --[no-]injected-client        Whether or not to inject the client.js script
+                                  in web apps. This is required for all
+                                  debugging related features, but may interact
+                                  poorly with proxy servers or other
+                                  environments.
+                                  (defaults to on)
+
 Advanced:
     --chrome-debug-port           Specify which port the Chrome debugger is
                                   listening on. If used with launch-in-chrome

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -237,12 +237,12 @@ class Configuration {
             '--$debugFlag cannot be used with --no-$enableInjectedClientFlag');
       }
       if (debugExtension) {
-        throw InvalidConfiguration('--$debugExtension cannot be used with '
+        throw InvalidConfiguration('--$debugExtensionFlag cannot be used with '
             '--no-$enableInjectedClientFlag');
       }
       if (chromeDebugPort != defaultConfiguration.chromeDebugPort) {
-        throw InvalidConfiguration('--$chromeDebugPort cannot be used with '
-            '--no-$enableInjectedClientFlag');
+        throw InvalidConfiguration('--$chromeDebugPortFlag cannot be used '
+            'with --no-$enableInjectedClientFlag');
       }
     }
 

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -60,6 +60,11 @@ refresh: Performs a full page refresh.
             'This also enables --$launchInChromeFlag.')
     ..addFlag(debugExtensionFlag,
         help: 'Enable the backend for the Dart Debug Extension.', hide: true)
+    ..addFlag(enableInjectedClientFlag,
+        help: 'Whether or not to inject the client.js script in web apps. This '
+            'is required for all debugging related features, but may interact '
+            'poorly with proxy servers or other environments.',
+        defaultsTo: true)
     ..addSeparator('Advanced:')
     ..addOption(chromeDebugPortFlag,
         help: 'Specify which port the Chrome debugger is listening on. '

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.3.0';
+const packageVersion = '2.4.0';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.3.0
+version: 2.4.0
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/540

- Disables dwds altogether in favor of a simple proxy server when this flag is present
- Wrapped client.js in runZoned to catch all errors and notify of this flag
- Added checks that incompatible debugging flags aren't used when this flag is provided