### PR TITLE
Avoid executing top-level getters to find classes

### DIFF
--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -357,7 +357,7 @@ function($argsString) {
       var parts = sdkUtils.getParts('${libraryRef.uri}');
       var result = {'parts' : parts}
       var classes = Object.values(Object.getOwnPropertyDescriptors(library))
-        .filter((p) => "value" in p)
+        .filter((p) => 'value' in p)
         .map((p) => p.value)
         .filter((l) => l && sdkUtils.isType(l));
       var classList = classes.map(function(clazz) {

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -356,7 +356,9 @@ function($argsString) {
       ${_getLibrarySnippet(libraryRef.uri)}
       var parts = sdkUtils.getParts('${libraryRef.uri}');
       var result = {'parts' : parts}
-      var classes = Object.values(library)
+      var classes = Object.values(Object.getOwnPropertyDescriptors(library))
+        .filter((p) => "value" in p)
+        .map((p) => p.value)
         .filter((l) => l && sdkUtils.isType(l));
       var classList = classes.map(function(clazz) {
         var descriptor = {'name': clazz.name};


### PR DESCRIPTION
When looking for the classes defined in a library we were iterating over
`Object.values` for the library, this evaluates any top level getters
defined on the library. When we are looking to understand the static
structure of a library we should not be executing any of the code it
contains.

- Use `Object.getOwnPropertyDescriptors` so that each value is not
  evaluated, but turned into an object which may have either a `value`
  or a `get` key.
- Filter down to the values which have a `value` key, since those are
  the ones that exist without executing any code.