### PR TITLE
Handle missing sources and source maps gracefully

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1
+
+- Fix an issue where missing source maps would cause a crash. A warning will
+  now be logged to the console instead.
+
 ## 0.5.0
 
 - Fix an issue where we source map paths were not normalized.

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:dwds/dwds.dart' show LogWriter;
 import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
@@ -27,13 +28,13 @@ const _pauseModePauseStates = {
 };
 
 class Debugger extends Domain {
-  final RemoteDebugger _remoteDebugger;
-
   final AssetHandler _assetHandler;
-  final StreamNotify _streamNotify;
+  final LogWriter _logWriter;
+  final RemoteDebugger _remoteDebugger;
 
   /// The root URI from which the application is served.
   final String _root;
+  final StreamNotify _streamNotify;
 
   Debugger._(
     this._assetHandler,
@@ -42,6 +43,7 @@ class Debugger extends Domain {
     AppInspectorProvider provider,
     // TODO(401) - Remove.
     this._root,
+    this._logWriter,
   )   : _breakpoints = _Breakpoints(provider),
         super(provider);
 
@@ -130,7 +132,8 @@ class Debugger extends Domain {
       RemoteDebugger remoteDebugger,
       StreamNotify streamNotify,
       AppInspectorProvider appInspectorProvider,
-      String root) async {
+      String root,
+      LogWriter logWriter) async {
     var debugger = Debugger._(
       assetHandler,
       remoteDebugger,
@@ -138,13 +141,14 @@ class Debugger extends Domain {
       appInspectorProvider,
       // TODO(401) - Remove.
       root,
+      logWriter,
     );
     await debugger._initialize();
     return debugger;
   }
 
   Future<Null> _initialize() async {
-    sources = Sources(_assetHandler, _remoteDebugger);
+    sources = Sources(_assetHandler, _remoteDebugger, _logWriter);
     // We must add a listener before enabling the debugger otherwise we will
     // miss events.
     // Allow a null debugger/connection for unit tests.

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -8,6 +8,7 @@ import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../handlers/asset_handler.dart';
 import '../services/chrome_proxy_service.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/domain.dart';

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -4,17 +4,17 @@
 
 import 'dart:async';
 
-import 'package:dwds/dwds.dart' show LogWriter;
-import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../../dwds.dart' show LogWriter;
 import '../handlers/asset_handler.dart';
 import '../services/chrome_proxy_service.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/domain.dart';
 import '../utilities/objects.dart';
 import 'location.dart';
+import 'remote_debugger.dart';
 import 'sources.dart';
 
 /// Converts from ExceptionPauseMode strings to [PauseState] enums.

--- a/dwds/lib/src/debugging/exceptions.dart
+++ b/dwds/lib/src/debugging/exceptions.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.import 'dart:async';
+
+import 'package:shelf/shelf.dart' as shelf;
+
+class ScriptNotFound implements Exception {
+  final String scriptPath;
+  final shelf.Response response;
+
+  ScriptNotFound(this.scriptPath, this.response) : super();
+
+  @override
+  String toString() => '''
+Failed to load script at path: $scriptPath
+
+Response status code: ${response.statusCode}
+''';
+}

--- a/dwds/lib/src/debugging/sources.dart
+++ b/dwds/lib/src/debugging/sources.dart
@@ -6,9 +6,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import 'package:dwds/dwds.dart' show LogWriter;
 
 import '../handlers/asset_handler.dart';
 import '../utilities/dart_uri.dart';
@@ -41,9 +44,11 @@ class Sources {
   /// logging unsuccessful responses.
   final AssetHandler _assetHandler;
 
+  final LogWriter _logWriter;
+
   final RemoteDebugger _remoteDebugger;
 
-  Sources(this._assetHandler, this._remoteDebugger);
+  Sources(this._assetHandler, this._remoteDebugger, this._logWriter);
 
   /// Returns all [Location] data for a provided Dart source.
   Set<Location> locationsForDart(String serverPath) =>
@@ -146,7 +151,7 @@ class Sources {
     if (response.statusCode == HttpStatus.ok) {
       return response.readAsString();
     }
-    print('''
+    _logWriter(Level.WARNING, '''
 Failed to load asset at path: $path.
 
 Status code: ${response.statusCode}

--- a/dwds/lib/src/debugging/sources.dart
+++ b/dwds/lib/src/debugging/sources.dart
@@ -11,8 +11,7 @@ import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import 'package:dwds/dwds.dart' show LogWriter;
-
+import '../../dwds.dart' show LogWriter;
 import '../handlers/asset_handler.dart';
 import '../utilities/dart_uri.dart';
 import 'location.dart';

--- a/dwds/lib/src/debugging/sources.dart
+++ b/dwds/lib/src/debugging/sources.dart
@@ -64,10 +64,10 @@ class Sources {
     var script = e.script;
     // TODO(grouma) - This should be configurable.
     await _blackBoxIfNecessary(script);
-    var sourceMapContents = await _sourceMapOrNull(script);
-    if (sourceMapContents == null) return;
     _clearCacheFor(script);
     _sourceToScriptId[script.url] = script.scriptId;
+    var sourceMapContents = await _sourceMapOrNull(script);
+    if (sourceMapContents == null) return;
     // This happens to be a [SingleMapping] today in DDC.
     var mapping = parse(sourceMapContents);
     if (mapping is SingleMapping) {

--- a/dwds/lib/src/debugging/sources.dart
+++ b/dwds/lib/src/debugging/sources.dart
@@ -3,12 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import '../services/chrome_proxy_service.dart';
+import '../handlers/asset_handler.dart';
 import '../utilities/dart_uri.dart';
 import 'location.dart';
 import 'remote_debugger.dart';
@@ -35,7 +37,10 @@ class Sources {
   /// Paths to black box in the Chrome debugger.
   final _pathsToBlackBox = {'/packages/stack_trace/'};
 
+  /// Use `_readAssetOrNull` instead of using this directly, as it handles
+  /// logging unsuccessful responses.
   final AssetHandler _assetHandler;
+
   final RemoteDebugger _remoteDebugger;
 
   Sources(this._assetHandler, this._remoteDebugger);
@@ -54,7 +59,7 @@ class Sources {
     var script = e.script;
     // TODO(grouma) - This should be configurable.
     await _blackBoxIfNecessary(script);
-    var sourceMapContents = await _sourceMap(script);
+    var sourceMapContents = await _sourceMapOrNull(script);
     if (sourceMapContents == null) return;
     _clearCacheFor(script);
     _sourceToScriptId[script.url] = script.scriptId;
@@ -132,15 +137,40 @@ class Sources {
     _sourceToScriptId.remove(script.url);
   }
 
+  /// Reads an asset at [path] relative to the server root.
+  ///
+  /// Returns `null` and logs the response if the status is anything other than
+  /// [HttpStatus.ok].
+  Future<String> _readAssetOrNull(String path) async {
+    var response = await _assetHandler.getRelativeAsset(path);
+    if (response.statusCode == HttpStatus.ok) {
+      return response.readAsString();
+    }
+    print('''
+Failed to load asset at path: $path.
+
+Status code: ${response.statusCode}
+
+Headers:
+${const JsonEncoder.withIndent('  ').convert(response.headers)}
+
+Content:
+${await response.readAsString()}
+''');
+    return null;
+  }
+
   /// The source map for a DDC-compiled JS [script].
-  Future<String> _sourceMap(WipScript script) {
+  ///
+  /// Returns `null` and logs if it can't be read.
+  Future<String> _sourceMapOrNull(WipScript script) {
     var sourceMapUrl = script.sourceMapURL;
     if (sourceMapUrl == null || !sourceMapUrl.endsWith('.ddc.js.map')) {
       return null;
     }
     var scriptPath = DartUri(script.url).serverPath;
     var sourcemapPath = p.join(p.dirname(scriptPath), sourceMapUrl);
-    return _assetHandler(sourcemapPath);
+    return _readAssetOrNull(sourcemapPath);
   }
 
   /// Black boxes the Dart SDK and paths in [_pathsToBlackBox].
@@ -148,16 +178,18 @@ class Sources {
     if (script.url.endsWith('dart_sdk.js')) {
       await _blackBoxSdk(script);
     } else if (_pathsToBlackBox.any((path) => script.url.contains(path))) {
-      var lines =
-          (await _assetHandler(DartUri(script.url).serverPath)).split('\n');
+      var content = await _readAssetOrNull(DartUri(script.url).serverPath);
+      if (content == null) return;
+      var lines = content.split('\n');
       await _blackBoxRanges(script.scriptId, [lines.length]);
     }
   }
 
   /// Black boxes the SDK excluding the range which includes exception logic.
   Future<void> _blackBoxSdk(WipScript script) async {
-    var sdkSourceLines =
-        (await _assetHandler(DartUri(script.url).serverPath)).split('\n');
+    var content = await _readAssetOrNull(DartUri(script.url).serverPath);
+    if (content == null) return;
+    var sdkSourceLines = content.split('\n');
     // TODO(grouma) - Find a more robust way to identify this location.
     var throwIndex = sdkSourceLines.indexWhere(
         (line) => line.contains('dart.throw = function throw_(exception) {'));

--- a/dwds/lib/src/handlers/asset_handler.dart
+++ b/dwds/lib/src/handlers/asset_handler.dart
@@ -28,9 +28,6 @@ class AssetHandler {
   ///
   /// For example the path `main.dart` should return the raw text value of that
   /// corresponding file.
-  Future<String> getRelativeAsset(String path) async {
-    var response = await handler(Request(
-        'GET', Uri.parse('http://$_applicationHost:$_applicationPort/$path')));
-    return await response.readAsString();
-  }
+  Future<Response> getRelativeAsset(String path) async => handler(Request(
+      'GET', Uri.parse('http://$_applicationHost:$_applicationPort/$path')));
 }

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -118,6 +118,7 @@ class DevHandler {
       appTab.url,
       _assetHandler,
       appInstanceId,
+      _logWriter,
       onResponse: _verbose
           ? (response) {
               if (response['error'] == null) return;
@@ -302,6 +303,7 @@ class DevHandler {
           devToolsRequest.tabUrl,
           _assetHandler,
           devToolsRequest.appId,
+          _logWriter,
           onResponse: _verbose
               ? (response) {
                   if (response['error'] == null) return;

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -116,7 +116,7 @@ class DevHandler {
       _hostname,
       webkitDebugger,
       appTab.url,
-      _assetHandler.getRelativeAsset,
+      _assetHandler,
       appInstanceId,
       onResponse: _verbose
           ? (response) {
@@ -300,7 +300,7 @@ class DevHandler {
           _hostname,
           _extensionDebugger,
           devToolsRequest.tabUrl,
-          _assetHandler.getRelativeAsset,
+          _assetHandler,
           devToolsRequest.appId,
           onResponse: _verbose
               ? (response) {

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dwds/dwds.dart' show LogWriter;
 import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:pub_semver/pub_semver.dart' as semver;
@@ -28,6 +29,8 @@ typedef AppInspectorProvider = AppInspector Function();
 
 /// A proxy from the chrome debug protocol to the dart vm service protocol.
 class ChromeProxyService implements VmServiceInterface {
+  final LogWriter _logWriter;
+
   /// Cache of all existing StreamControllers.
   ///
   /// These are all created through [onEvent].
@@ -61,6 +64,7 @@ class ChromeProxyService implements VmServiceInterface {
     this.uri,
     this._assetHandler,
     this.remoteDebugger,
+    this._logWriter,
   );
 
   static Future<ChromeProxyService> create(
@@ -68,6 +72,7 @@ class ChromeProxyService implements VmServiceInterface {
     String tabUrl,
     AssetHandler assetHandler,
     String appInstanceId,
+    LogWriter logWriter,
   ) async {
     // TODO: What about `architectureBits`, `targetCPU`, `hostCPU` and `pid`?
     final vm = VM()
@@ -75,8 +80,8 @@ class ChromeProxyService implements VmServiceInterface {
       ..name = 'ChromeDebugProxy'
       ..startTime = DateTime.now().millisecondsSinceEpoch
       ..version = Platform.version;
-    var service =
-        ChromeProxyService._(vm, tabUrl, assetHandler, remoteDebugger);
+    var service = ChromeProxyService._(
+        vm, tabUrl, assetHandler, remoteDebugger, logWriter);
     await service._initialize();
     await service.createIsolate();
     return service;
@@ -89,6 +94,7 @@ class ChromeProxyService implements VmServiceInterface {
       _streamNotify,
       appInspectorProvider,
       uri,
+      _logWriter,
     );
   }
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -14,10 +14,8 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../debugging/debugger.dart';
 import '../debugging/inspector.dart';
+import '../handlers/asset_handler.dart';
 import '../utilities/shared.dart';
-
-/// A handler for application assets, e.g. Dart sources.
-typedef AssetHandler = Future<String> Function(String);
 
 /// Adds [event] to the stream with [streamId] if there is anybody listening
 /// on that stream.

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:dwds/dwds.dart' show LogWriter;
 import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:pedantic/pedantic.dart';
@@ -114,13 +115,14 @@ class DebugService {
     RemoteDebugger remoteDebugger,
     String tabUrl,
     AssetHandler assetHandler,
-    String appInstanceId, {
+    String appInstanceId,
+    LogWriter logWriter, {
     void Function(Map<String, dynamic>) onRequest,
     void Function(Map<String, dynamic>) onResponse,
     bool useSse,
   }) async {
     var chromeProxyService = await ChromeProxyService.create(
-        remoteDebugger, tabUrl, assetHandler, appInstanceId);
+        remoteDebugger, tabUrl, assetHandler, appInstanceId, logWriter);
     var authToken = _makeAuthToken();
     var serviceExtensionRegistry = ServiceExtensionRegistry();
     Handler handler;

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -12,13 +12,14 @@ import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart' as shelf;
-import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf.dart' hide Response;
 import 'package:shelf/shelf_io.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+import '../handlers/asset_handler.dart';
 import '../utilities/shared.dart';
 import 'chrome_proxy_service.dart';
 
@@ -112,7 +113,7 @@ class DebugService {
     String hostname,
     RemoteDebugger remoteDebugger,
     String tabUrl,
-    Future<String> Function(String) assetHandler,
+    AssetHandler assetHandler,
     String appInstanceId, {
     void Function(Map<String, dynamic>) onRequest,
     void Function(Map<String, dynamic>) onResponse,

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.5.0
+version: 0.5.1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -23,7 +23,15 @@ void main() async {
   setUpAll(() async {
     webkitDebugger = FakeWebkitDebugger();
     debugger = await Debugger.create(
-        null, webkitDebugger, null, () => inspector, 'fakeRoot');
+      null,
+      webkitDebugger,
+      null,
+      () => inspector,
+      'fakeRoot',
+      (level, message) {
+        printOnFailure('[$level]: $message');
+      },
+    );
     inspector = FakeInspector();
   });
 

--- a/dwds/test/debugging/sources_test.dart
+++ b/dwds/test/debugging/sources_test.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:logging/logging.dart';
+import 'package:shelf/shelf.dart';
+import 'package:test/test.dart';
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import 'package:dwds/src/debugging/sources.dart';
+import 'package:dwds/src/handlers/asset_handler.dart';
+
+void main() {
+  test('Gracefully handles missing source maps', () async {
+    var sourcePath = 'source.ddc.js';
+    var sourceMapPath = '$sourcePath.map';
+    var assets = {
+      sourcePath: '',
+    };
+    var logs = <LogRecord>[];
+    var sources = Sources(TestingAssetHandler(assets), null,
+        (level, message) => logs.add(LogRecord(level, message, '')));
+    var serverUri = 'http://localhost:1234/';
+    await sources.scriptParsed(ScriptParsedEvent(WipEvent({
+      'params': {
+        'url': '$serverUri$sourcePath',
+        'sourceMapURL': '$serverUri$sourceMapPath'
+      }
+    })));
+    expect(
+        logs,
+        contains(predicate((LogRecord log) =>
+            log.level >= Level.WARNING ||
+            log.message
+                .contains('Failed to load asset at path: $sourceMapPath'))));
+  });
+}
+
+class TestingAssetHandler implements AssetHandler {
+  final Map<String, String> _assets;
+
+  @override
+  Handler get handler => throw UnimplementedError();
+
+  TestingAssetHandler(this._assets);
+
+  @override
+  Future<Response> getRelativeAsset(String path) async {
+    var content = _assets[path];
+    if (content == null) {
+      return Response.notFound('Not found');
+    }
+    return Response.ok(content);
+  }
+}


### PR DESCRIPTION
Helps with issues like https://github.com/dart-lang/webdev/issues/514.

- Adds a warning log when we fail to fetch a source map
- Throws a ScriptNotFound exception when we fail to load a script
- Plumbs a `LogWriter` through various classes so we can use it for logging
- Cleans up the conflicting AssetHandler definitions by removing the typedef in favor of the class
- Changes `AssetHandler.getRelativeAsset` to return a `Future<Response>` instead of a `Future<String>` so the status code can be checked.