### PR TITLE
Better expand

### DIFF
--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -4,8 +4,6 @@
 
 import 'dart:async';
 
-import 'package:dwds/src/debugging/instance.dart';
-import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
@@ -13,7 +11,9 @@ import '../services/chrome_proxy_service.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/domain.dart';
 import '../utilities/objects.dart';
+import 'instance.dart';
 import 'location.dart';
+import 'remote_debugger.dart';
 import 'sources.dart';
 
 /// Converts from ExceptionPauseMode strings to [PauseState] enums.

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -11,7 +11,6 @@ import '../services/chrome_proxy_service.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/domain.dart';
 import '../utilities/objects.dart';
-import 'instance.dart';
 import 'location.dart';
 import 'remote_debugger.dart';
 import 'sources.dart';
@@ -304,10 +303,10 @@ class Debugger extends Domain {
     var properties = await getProperties(scope['object']['objectId'] as String);
     // We return one level of properties from this object. Sub-properties are
     // another round trip.
-    var refs = properties
-        .map<Future<BoundVariable>>((property) async => BoundVariable()
-          ..name = property.name
-          ..value = await instanceRefFor(_remoteDebugger, property.value));
+    var refs = properties.map<
+        Future<BoundVariable>>((property) async => BoundVariable()
+      ..name = property.name
+      ..value = await inspector.instanceHelper.instanceRefFor(property.value));
     // Actual null values will still have a variable value of an InstanceRef.
     return (await Future.wait(refs))
         .where((variable) => variable.value != null);

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -307,8 +307,9 @@ class Debugger extends Domain {
         .map<Future<BoundVariable>>((property) async => BoundVariable()
           ..name = property.name
           ..value = await inspector.instanceRefFor(property.value));
-    var bounds = await Future.wait(refs);
-    return bounds.where((bound) => bound.value != null);
+    // Actual null values will still have a variable value of an InstanceRef.
+    return (await Future.wait(refs))
+        .where((variable) => variable.value != null);
   }
 
   /// Calls the Chrome Runtime.getProperties API for the object with [id].

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -307,7 +307,8 @@ class Debugger extends Domain {
         .map<Future<BoundVariable>>((property) async => BoundVariable()
           ..name = property.name
           ..value = await inspector.instanceRefFor(property.value));
-    return Future.wait(refs);
+    var bounds = await Future.wait(refs);
+    return bounds.where((bound) => bound.value != null);
   }
 
   /// Calls the Chrome Runtime.getProperties API for the object with [id].

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:dwds/src/debugging/instance.dart';
 import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
@@ -294,7 +295,7 @@ class Debugger extends Domain {
     // the dynamically visible variables, so we should omit library scope.
     return [
       for (var scope in scopeChain.take(2)) ...await _boundVariables(scope)
-    ];
+    ]..sort((a, b) => a.name.compareTo(b.name));
   }
 
   /// The [BoundVariable]s visible in a v8 'scope' object as found in the
@@ -306,7 +307,7 @@ class Debugger extends Domain {
     var refs = properties
         .map<Future<BoundVariable>>((property) async => BoundVariable()
           ..name = property.name
-          ..value = await inspector.instanceRefFor(property.value));
+          ..value = await instanceRefFor(_remoteDebugger, property.value));
     // Actual null values will still have a variable value of an InstanceRef.
     return (await Future.wait(refs))
         .where((variable) => variable.value != null);

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -44,6 +44,7 @@ class AppInspector extends Domain {
   final Debugger debugger;
   final Isolate isolate;
   final IsolateRef isolateRef;
+  final InstanceHelper instanceHelper;
 
   /// The root URI from which the application is served.
   final String _root;
@@ -55,6 +56,7 @@ class AppInspector extends Domain {
     this._root,
     this._remoteDebugger,
   )   : isolateRef = _toIsolateRef(isolate),
+        instanceHelper = InstanceHelper(debugger, _remoteDebugger),
         super.forInspector();
 
   @override
@@ -268,9 +270,8 @@ function($argsString) {
     if (clazz != null) return clazz;
     var scriptRef = _scriptRefs[objectId];
     if (scriptRef != null) return await _getScript(isolateId, scriptRef);
-    // TODO(grouma) - store debuggers in instance.dart to simplify the API.
-    var instance = instanceFor(
-        debugger, _remoteDebugger, RemoteObject({'objectId': objectId}));
+    var instance =
+        instanceHelper.instanceFor(RemoteObject({'objectId': objectId}));
     if (instance != null) return instance;
     throw UnsupportedError('Only libraries, instances, classes, and scripts '
         'are supported for getObject');

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -268,10 +268,12 @@ function($argsString) {
     if (clazz != null) return clazz;
     var scriptRef = _scriptRefs[objectId];
     if (scriptRef != null) return await _getScript(isolateId, scriptRef);
-    var instance = instanceFor(debugger, _remoteDebugger, objectId);
+    // TODO(grouma) - store debuggers in instance.dart to simplify the API.
+    var instance = instanceFor(
+        debugger, _remoteDebugger, RemoteObject({'objectId': objectId}));
     if (instance != null) return instance;
-    throw UnsupportedError(
-        'Only libraries, classes, and scripts are supported for getObject');
+    throw UnsupportedError('Only libraries, instances, classes, and scripts '
+        'are supported for getObject');
   }
 
   Future<Library> _constructLibrary(LibraryRef libraryRef) async {

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -36,7 +36,6 @@ const _namesToIgnore = <String>{
 /// Returns null if there isn't a corresponding instance.
 Future<Instance> instanceFor(
     Debugger debugger, RemoteDebugger remoteDebugger, String objectId) async {
-  // if (!objectId.contains('"injectedScriptId"')) return null;
   var remoteObject = RemoteObject({'objectId': objectId});
   var metaData = await classMetaDataFor(remoteDebugger, remoteObject);
   var classRef = ClassRef()
@@ -56,7 +55,7 @@ Future<Instance> instanceFor(
       .toList()
         ..sort((a, b) => a.decl.name.compareTo(b.decl.name));
   var result = Instance()
-    ..type = InstanceKind.kPlainInstance
+    ..kind = InstanceKind.kPlainInstance
     ..id = objectId
     ..fields = fields
     ..classRef = classRef;

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -45,8 +45,8 @@ InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
 
 /// Contains a set of methods for getting [Instance]s and [InstanceRef]s.
 class InstanceHelper {
-  Debugger _debugger;
-  RemoteDebugger _remoteDebugger;
+  final Debugger _debugger;
+  final RemoteDebugger _remoteDebugger;
 
   InstanceHelper(this._debugger, this._remoteDebugger);
 

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -1,0 +1,116 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.import 'dart:async';
+
+import 'package:vm_service/vm_service.dart';
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import 'debugger.dart';
+import 'metadata.dart';
+import 'remote_debugger.dart';
+
+/// JS field names to ignore when constructing a Dart [Instance].
+const _namesToIgnore = <String>{
+  'constructor',
+  'noSuchMethod',
+  'runtimeType',
+  'toString',
+  '_equals',
+  '__defineGetter__',
+  '__defineSetter__',
+  '__lookupGetter__',
+  '__lookupSetter__',
+  '__proto__',
+  'classGetter',
+  'hasOwnProperty',
+  'hashCode',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+  'valueOf',
+  '_identityHashCode'
+};
+
+/// Create an [Instance] for the given [objectId].
+///
+/// Returns null if there isn't a corresponding instance.
+Future<Instance> instanceFor(
+    Debugger debugger, RemoteDebugger remoteDebugger, String objectId) async {
+  // if (!objectId.contains('"injectedScriptId"')) return null;
+  var remoteObject = RemoteObject({'objectId': objectId});
+  var metaData = await classMetaDataFor(remoteDebugger, remoteObject);
+  var classRef = ClassRef()
+    ..id = metaData.id
+    ..name = metaData.name;
+  var properties = await debugger.getProperties(objectId);
+  var fields = await Future.wait(
+      properties.map<Future<BoundField>>((property) async => BoundField()
+        ..decl = (FieldRef()
+          // TODO(grouma) - Convert JS name to Dart.
+          ..name = property.name
+          ..owner = classRef
+          ..declaredType = (InstanceRef()..classRef = ClassRef()))
+        ..value = await instanceRefFor(remoteDebugger, property.value)));
+  fields = fields
+      .where((f) => f.value != null && !_namesToIgnore.contains(f.decl.name))
+      .toList()
+        ..sort((a, b) => a.decl.name.compareTo(b.decl.name));
+  var result = Instance()
+    ..type = InstanceKind.kPlainInstance
+    ..id = objectId
+    ..fields = fields
+    ..classRef = classRef;
+  return result;
+}
+
+/// Create an [InstanceRef] for the given Chrome [remoteObject].
+Future<InstanceRef> instanceRefFor(
+    RemoteDebugger remoteDebugger, RemoteObject remoteObject) async {
+  // If we have a null result, treat it as a reference to null.
+  if (remoteObject == null) {
+    return _primitiveInstance(InstanceKind.kNull, remoteObject);
+  }
+  switch (remoteObject.type) {
+    case 'string':
+      return _primitiveInstance(InstanceKind.kString, remoteObject);
+    case 'number':
+      return _primitiveInstance(InstanceKind.kDouble, remoteObject);
+    case 'boolean':
+      return _primitiveInstance(InstanceKind.kBool, remoteObject);
+    case 'undefined':
+      return _primitiveInstance(InstanceKind.kNull, remoteObject);
+    case 'object':
+      if (remoteObject.type == 'object' && remoteObject.objectId == null) {
+        return _primitiveInstance(InstanceKind.kNull, remoteObject);
+      }
+      var metaData = await classMetaDataFor(remoteDebugger, remoteObject);
+      if (metaData == null) return null;
+      return InstanceRef()
+        ..kind = InstanceKind.kPlainInstance
+        ..id = remoteObject.objectId
+        ..classRef = (ClassRef()
+          ..name = metaData.name
+          ..id = '${metaData.libraryId}:${metaData.name}');
+    case 'function':
+      var crudeAttemptAtName = remoteObject.description.split('(').first;
+      return InstanceRef()
+        ..kind = InstanceKind.kPlainInstance
+        ..id = remoteObject.objectId
+        ..valueAsString = crudeAttemptAtName
+        ..classRef = ClassRef();
+    default:
+      // Return null for an unsupported type. This is likely a JS construct.
+      return null;
+  }
+}
+
+/// Creates an [InstanceRef] for a primitive [RemoteObject].
+InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
+  var classRef = ClassRef()
+    ..id = 'dart:core:${remoteObject.type}'
+    ..name = kind;
+  return InstanceRef()
+    ..valueAsString = '${remoteObject.value}'
+    ..classRef = classRef
+    ..kind = kind;
+}

--- a/dwds/lib/src/debugging/metadata.dart
+++ b/dwds/lib/src/debugging/metadata.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.import 'dart:async';
+
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import '../services/chrome_proxy_service.dart';
+import 'remote_debugger.dart';
+
+class ClassMetaData {
+  final String name;
+  final String libraryId;
+  ClassMetaData(this.name, this.libraryId);
+  String get id => '$libraryId:$name';
+}
+
+/// Returns the [ClassMetaData] for the Chrome [remoteObject].
+///
+/// Returns null if the [remoteObject] is not a Dart class.
+Future<ClassMetaData> classMetaDataFor(
+    RemoteDebugger remoteDebugger, RemoteObject remoteObject) async {
+  try {
+    var evalExpression = '''
+      function(arg) {
+        var sdkUtils = require('dart_sdk').dart;
+        var classObject = sdkUtils.getType(arg);
+        var result = {};
+        result['name'] = classObject.name;
+        result['libraryId'] = sdkUtils.getLibraryUri(classObject);
+        return result;
+      }
+    ''';
+    var arguments = [
+      {'objectId': remoteObject.objectId}
+    ];
+    var result =
+        await remoteDebugger.sendCommand('Runtime.callFunctionOn', params: {
+      'functionDeclaration': evalExpression,
+      'arguments': arguments,
+      'objectId': remoteObject.objectId,
+      'returnByValue': true,
+    });
+    handleErrorIfPresent(
+      result,
+      evalContents: evalExpression,
+    );
+    return ClassMetaData(result.result['result']['value']['name'] as String,
+        result.result['result']['value']['libraryId'] as String);
+  } on ChromeDebugException {
+    return null;
+  }
+}

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -220,7 +220,7 @@ class DevHandler {
             .sendCommand('Target.createTarget', params: {
           'newWindow': true,
           'url': 'http://${_devTools.hostname}:${_devTools.port}'
-              '/?hide=none&uri=${appServices.debugService.uri}',
+              '/?uri=${appServices.debugService.uri}',
         });
       } else if (message is ConnectRequest) {
         if (appId != null) {
@@ -307,7 +307,7 @@ class DevHandler {
       await _extensionDebugger.sendCommand('Target.createTarget', params: {
         'newWindow': true,
         'url': 'http://${_devTools.hostname}:${_devTools.port}'
-            '/?hide=none&uri=${appServices.debugService.uri}',
+            '/?uri=${appServices.debugService.uri}',
       });
     });
   }

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -12,7 +12,6 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../debugging/debugger.dart';
 import '../debugging/inspector.dart';
-import '../debugging/instance.dart';
 import '../debugging/remote_debugger.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/shared.dart';
@@ -222,7 +221,7 @@ require("dart_sdk").developer.invokeExtension(
       {Map<String, String> scope, bool disableBreakpoints}) async {
     var remote = await _inspector?.evaluate(isolateId, targetId, expression,
         scope: scope, disableBreakpoints: disableBreakpoints);
-    return instanceRefFor(remoteDebugger, remote);
+    return _inspector?.instanceHelper?.instanceRefFor(remote);
   }
 
   @override

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -6,14 +6,15 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dwds/src/debugging/remote_debugger.dart';
-import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../debugging/debugger.dart';
 import '../debugging/inspector.dart';
+import '../debugging/instance.dart';
+import '../debugging/remote_debugger.dart';
+import '../utilities/dart_uri.dart';
 import '../utilities/shared.dart';
 
 /// A handler for application assets, e.g. Dart sources.
@@ -221,7 +222,7 @@ require("dart_sdk").developer.invokeExtension(
       {Map<String, String> scope, bool disableBreakpoints}) async {
     var remote = await _inspector?.evaluate(isolateId, targetId, expression,
         scope: scope, disableBreakpoints: disableBreakpoints);
-    return _inspector?.instanceRefFor(remote);
+    return instanceRefFor(remoteDebugger, remote);
   }
 
   @override

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   build_daemon: ^2.0.0
   built_value: ^6.7.0
   crypto: ^2.0.6
-  devtools: ^0.1.0
+  devtools: ^0.1.6-dev.2
   http: ^0.12.0
   http_multi_server: ^2.0.0
   logging: ^0.11.3

--- a/dwds/test/fixtures/debugger_data.dart
+++ b/dwds/test/fixtures/debugger_data.dart
@@ -93,8 +93,14 @@ var variables1 = [
     'id': 1,
     'result': {
       'result': [
-        {'name': 'a', 'value': null},
-        {'name': 'b', 'value': null}
+        {
+          'name': 'a',
+          'value': {'type': 'string', 'value': 'foo'}
+        },
+        {
+          'name': 'b',
+          'value': {'type': 'string', 'value': 'bar'}
+        }
       ]
     }
   }),

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:async/src/stream_sink_transformer.dart';
 import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/inspector.dart';
+import 'package:dwds/src/debugging/instance.dart';
 import 'package:dwds/src/debugging/webkit_debugger.dart';
 import 'package:dwds/src/utilities/domain.dart';
 import 'package:sse/server/sse_handler.dart';
@@ -65,6 +66,9 @@ class FakeInspector extends Domain implements AppInspector {
   Future<RemoteObject> evaluateJsExpressionOnLibrary(
           String expression, String libraryUri) =>
       throw UnsupportedError('This is a fake');
+
+  @override
+  InstanceHelper get instanceHelper => InstanceHelper(null, null);
 }
 
 class FakeSseConnection implements SseConnection {

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -34,8 +34,6 @@ class FakeInspector extends Domain implements AppInspector {
   @override
   Future<ScriptList> getScripts(String isolateId) => null;
   @override
-  Future<InstanceRef> instanceRefFor(RemoteObject remoteObject) => null;
-  @override
   Future<ScriptRef> scriptRefFor(String uri) => null;
   @override
   Future<List<ScriptRef>> scriptRefs(String isolateId) => null;
@@ -67,8 +65,6 @@ class FakeInspector extends Domain implements AppInspector {
   Future<RemoteObject> evaluateJsExpressionOnLibrary(
           String expression, String libraryUri) =>
       throw UnsupportedError('This is a fake');
-  @override
-  Future<String> toStringOf(RemoteObject receiver) async => '';
 }
 
 class FakeSseConnection implements SseConnection {

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -4,7 +4,10 @@
 
 @TestOn('vm')
 import 'package:dwds/src/connections/debug_connection.dart';
+import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/inspector.dart';
+import 'package:dwds/src/debugging/instance.dart';
+import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
@@ -18,13 +21,16 @@ WipConnection get tabConnection => context.tabConnection;
 
 void main() {
   AppInspector inspector;
-  RemoteObject instance;
+  RemoteDebugger remoteDebugger;
+  Debugger debugger;
 
   setUpAll(() async {
     await context.setUp();
+    var chromeProxyService = fetchChromeProxyService(context.debugConnection);
     // TODO(alanknight): A nicer way of getting the inspector.
-    inspector =
-        fetchChromeProxyService(context.debugConnection).appInspectorProvider();
+    inspector = chromeProxyService.appInspectorProvider();
+    remoteDebugger = chromeProxyService.remoteDebugger;
+    debugger = inspector.debugger;
   });
 
   tearDownAll(() async {
@@ -41,41 +47,88 @@ void main() {
       .evaluateJsExpression(libraryVariableExpression('libraryPublicFinal'));
 
   test('send toString', () async {
-    instance = await libraryPublicFinal();
-    var toString = await inspector.sendMessage(instance, 'toString', []);
+    var remoteObject = await libraryPublicFinal();
+    var toString = await inspector.sendMessage(remoteObject, 'toString', []);
     expect(toString.value, 'A test class with message world');
   });
 
-  test('instanceRef toString', () async {
-    instance = await libraryPublicFinal();
-    var ref = await inspector.instanceRefFor(instance);
-    expect(ref.valueAsString, 'A test class with message world');
+  group('instanceRef', () {
+    test('for a null', () async {
+      var remoteObject = await libraryPublicFinal();
+      var nullVariable = await inspector.loadField(remoteObject, 'notFinal');
+      var ref = await instanceRefFor(remoteDebugger, nullVariable);
+      expect(ref.valueAsString, 'null');
+      expect(ref.kind, InstanceKind.kNull);
+      var classRef = ref.classRef;
+      expect(classRef.name, 'Null');
+      expect(classRef.id, 'dart:core:object');
+    });
+
+    test('for a double', () async {
+      var remoteObject = await libraryPublicFinal();
+      var count = await inspector.loadField(remoteObject, 'count');
+      var ref = await instanceRefFor(remoteDebugger, count);
+      expect(ref.valueAsString, '0');
+      expect(ref.kind, InstanceKind.kDouble);
+      var classRef = ref.classRef;
+      expect(classRef.name, 'Double');
+      expect(classRef.id, 'dart:core:number');
+    });
+
+    test('for a class', () async {
+      var remoteObject = await libraryPublicFinal();
+      var count = await inspector.loadField(remoteObject, 'myselfField');
+      var ref = await instanceRefFor(remoteDebugger, count);
+      expect(ref.kind, InstanceKind.kPlainInstance);
+      var classRef = ref.classRef;
+      expect(classRef.name, 'MyTestClass');
+      expect(
+          classRef.id, 'org-dartlang-app:///web/scopes_main.dart:MyTestClass');
+    });
   });
 
-  test('instanceRef for null', () async {
-    instance = await libraryPublicFinal();
-    var nullVariable = await inspector.loadField(instance, 'notFinal');
-    var ref = await inspector.instanceRefFor(nullVariable);
-    expect(ref.valueAsString, 'null');
-    expect(ref.kind, InstanceKind.kNull);
+  group('instance', () {
+    test('for class object', () async {
+      var remoteObject = await libraryPublicFinal();
+      var instance =
+          await instanceFor(debugger, remoteDebugger, remoteObject.objectId);
+      expect(instance.kind, InstanceKind.kPlainInstance);
+      var classRef = instance.classRef;
+      expect(classRef, isNotNull);
+      expect(classRef.name, 'MyTestClass');
+    });
+
+    test('for a nested class ', () async {
+      var libraryRemoteObject = await libraryPublicFinal();
+      var fieldRemoteObject =
+          await inspector.loadField(libraryRemoteObject, 'myselfField');
+      var instance = await instanceFor(
+          debugger, remoteDebugger, fieldRemoteObject.objectId);
+      expect(instance.kind, InstanceKind.kPlainInstance);
+      var classRef = instance.classRef;
+      expect(classRef, isNotNull);
+      expect(classRef.name, 'MyTestClass');
+    });
   });
 
-  test('get string field', () async {
-    instance = await libraryPublicFinal();
-    var message = await inspector.loadField(instance, 'message');
-    expect(message.value, 'world');
-  });
+  group('loadField', () {
+    test('for string', () async {
+      var remoteObject = await libraryPublicFinal();
+      var message = await inspector.loadField(remoteObject, 'message');
+      expect(message.value, 'world');
+    });
 
-  test('get Object field', () async {
-    instance = await libraryPublicFinal();
-    var message = await inspector.loadField(instance, 'myselfField');
-    var toString = await inspector.toStringOf(message);
-    expect(toString, 'A test class with message world');
+    test('for num', () async {
+      var remoteObject = await libraryPublicFinal();
+      var count = await inspector.loadField(remoteObject, 'count');
+      expect(count.value, 0);
+    });
   });
 
   test('properties', () async {
-    instance = await libraryPublicFinal();
-    var properties = await inspector.debugger.getProperties(instance.objectId);
+    var remoteObject = await libraryPublicFinal();
+    var properties =
+        await inspector.debugger.getProperties(remoteObject.objectId);
     var names =
         properties.map((p) => p.name).where((x) => x != '__proto__').toList();
     var expected = [

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -4,12 +4,8 @@
 
 @TestOn('vm')
 import 'package:dwds/src/connections/debug_connection.dart';
-import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/inspector.dart';
-import 'package:dwds/src/debugging/instance.dart';
-import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:test/test.dart';
-import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
@@ -21,16 +17,12 @@ WipConnection get tabConnection => context.tabConnection;
 
 void main() {
   AppInspector inspector;
-  RemoteDebugger remoteDebugger;
-  Debugger debugger;
 
   setUpAll(() async {
     await context.setUp();
-    var chromeProxyService = fetchChromeProxyService(context.debugConnection);
     // TODO(alanknight): A nicer way of getting the inspector.
-    inspector = chromeProxyService.appInspectorProvider();
-    remoteDebugger = chromeProxyService.remoteDebugger;
-    debugger = inspector.debugger;
+    inspector =
+        fetchChromeProxyService(context.debugConnection).appInspectorProvider();
   });
 
   tearDownAll(() async {
@@ -50,65 +42,6 @@ void main() {
     var remoteObject = await libraryPublicFinal();
     var toString = await inspector.sendMessage(remoteObject, 'toString', []);
     expect(toString.value, 'A test class with message world');
-  });
-
-  group('instanceRef', () {
-    test('for a null', () async {
-      var remoteObject = await libraryPublicFinal();
-      var nullVariable = await inspector.loadField(remoteObject, 'notFinal');
-      var ref = await instanceRefFor(remoteDebugger, nullVariable);
-      expect(ref.valueAsString, 'null');
-      expect(ref.kind, InstanceKind.kNull);
-      var classRef = ref.classRef;
-      expect(classRef.name, 'Null');
-      expect(classRef.id, 'dart:core:object');
-    });
-
-    test('for a double', () async {
-      var remoteObject = await libraryPublicFinal();
-      var count = await inspector.loadField(remoteObject, 'count');
-      var ref = await instanceRefFor(remoteDebugger, count);
-      expect(ref.valueAsString, '0');
-      expect(ref.kind, InstanceKind.kDouble);
-      var classRef = ref.classRef;
-      expect(classRef.name, 'Double');
-      expect(classRef.id, 'dart:core:number');
-    });
-
-    test('for a class', () async {
-      var remoteObject = await libraryPublicFinal();
-      var count = await inspector.loadField(remoteObject, 'myselfField');
-      var ref = await instanceRefFor(remoteDebugger, count);
-      expect(ref.kind, InstanceKind.kPlainInstance);
-      var classRef = ref.classRef;
-      expect(classRef.name, 'MyTestClass');
-      expect(
-          classRef.id, 'org-dartlang-app:///web/scopes_main.dart:MyTestClass');
-    });
-  });
-
-  group('instance', () {
-    test('for class object', () async {
-      var remoteObject = await libraryPublicFinal();
-      var instance =
-          await instanceFor(debugger, remoteDebugger, remoteObject.objectId);
-      expect(instance.kind, InstanceKind.kPlainInstance);
-      var classRef = instance.classRef;
-      expect(classRef, isNotNull);
-      expect(classRef.name, 'MyTestClass');
-    });
-
-    test('for a nested class ', () async {
-      var libraryRemoteObject = await libraryPublicFinal();
-      var fieldRemoteObject =
-          await inspector.loadField(libraryRemoteObject, 'myselfField');
-      var instance = await instanceFor(
-          debugger, remoteDebugger, fieldRemoteObject.objectId);
-      expect(instance.kind, InstanceKind.kPlainInstance);
-      var classRef = instance.classRef;
-      expect(classRef, isNotNull);
-      expect(classRef.name, 'MyTestClass');
-    });
   });
 
   group('loadField', () {

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -23,6 +23,7 @@ void main() {
   AppInspector inspector;
   RemoteDebugger remoteDebugger;
   Debugger debugger;
+  InstanceHelper instanceHelper;
 
   setUpAll(() async {
     await context.setUp();
@@ -30,6 +31,7 @@ void main() {
     inspector = chromeProxyService.appInspectorProvider();
     remoteDebugger = chromeProxyService.remoteDebugger;
     debugger = inspector.debugger;
+    instanceHelper = InstanceHelper(debugger, remoteDebugger);
   });
 
   tearDownAll(() async {
@@ -49,7 +51,7 @@ void main() {
     test('for a null', () async {
       var remoteObject = await libraryPublicFinal();
       var nullVariable = await inspector.loadField(remoteObject, 'notFinal');
-      var ref = await instanceRefFor(remoteDebugger, nullVariable);
+      var ref = await instanceHelper.instanceRefFor(nullVariable);
       expect(ref.valueAsString, 'null');
       expect(ref.kind, InstanceKind.kNull);
       var classRef = ref.classRef;
@@ -60,7 +62,7 @@ void main() {
     test('for a double', () async {
       var remoteObject = await libraryPublicFinal();
       var count = await inspector.loadField(remoteObject, 'count');
-      var ref = await instanceRefFor(remoteDebugger, count);
+      var ref = await instanceHelper.instanceRefFor(count);
       expect(ref.valueAsString, '0');
       expect(ref.kind, InstanceKind.kDouble);
       var classRef = ref.classRef;
@@ -71,7 +73,7 @@ void main() {
     test('for a class', () async {
       var remoteObject = await libraryPublicFinal();
       var count = await inspector.loadField(remoteObject, 'myselfField');
-      var ref = await instanceRefFor(remoteDebugger, count);
+      var ref = await instanceHelper.instanceRefFor(count);
       expect(ref.kind, InstanceKind.kPlainInstance);
       var classRef = ref.classRef;
       expect(classRef.name, 'MyTestClass');
@@ -83,7 +85,7 @@ void main() {
   group('instance', () {
     test('for class object', () async {
       var remoteObject = await libraryPublicFinal();
-      var instance = await instanceFor(debugger, remoteDebugger, remoteObject);
+      var instance = await instanceHelper.instanceFor(remoteObject);
       expect(instance.kind, InstanceKind.kPlainInstance);
       var classRef = instance.classRef;
       expect(classRef, isNotNull);
@@ -94,8 +96,7 @@ void main() {
       var libraryRemoteObject = await libraryPublicFinal();
       var fieldRemoteObject =
           await inspector.loadField(libraryRemoteObject, 'myselfField');
-      var instance =
-          await instanceFor(debugger, remoteDebugger, fieldRemoteObject);
+      var instance = await instanceHelper.instanceFor(fieldRemoteObject);
       expect(instance.kind, InstanceKind.kPlainInstance);
       var classRef = instance.classRef;
       expect(classRef, isNotNull);

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -39,7 +39,8 @@ void main() {
   final url = 'org-dartlang-app:///web/scopes_main.dart';
 
   String libraryVariableExpression(String variable) =>
-      'require("dart_sdk").dart.getModuleLibraries("web/scopes_main")["$url"]["$variable"];';
+      'require("dart_sdk").dart.getModuleLibraries("web/scopes_main")'
+      '["$url"]["$variable"];';
 
   Future<RemoteObject> libraryPublicFinal() => inspector
       .evaluateJsExpression(libraryVariableExpression('libraryPublicFinal'));
@@ -82,8 +83,7 @@ void main() {
   group('instance', () {
     test('for class object', () async {
       var remoteObject = await libraryPublicFinal();
-      var instance =
-          await instanceFor(debugger, remoteDebugger, remoteObject.objectId);
+      var instance = await instanceFor(debugger, remoteDebugger, remoteObject);
       expect(instance.kind, InstanceKind.kPlainInstance);
       var classRef = instance.classRef;
       expect(classRef, isNotNull);
@@ -94,8 +94,8 @@ void main() {
       var libraryRemoteObject = await libraryPublicFinal();
       var fieldRemoteObject =
           await inspector.loadField(libraryRemoteObject, 'myselfField');
-      var instance = await instanceFor(
-          debugger, remoteDebugger, fieldRemoteObject.objectId);
+      var instance =
+          await instanceFor(debugger, remoteDebugger, fieldRemoteObject);
       expect(instance.kind, InstanceKind.kPlainInstance);
       var classRef = instance.classRef;
       expect(classRef, isNotNull);

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -1,0 +1,106 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+import 'package:dwds/src/connections/debug_connection.dart';
+import 'package:dwds/src/debugging/debugger.dart';
+import 'package:dwds/src/debugging/inspector.dart';
+import 'package:dwds/src/debugging/instance.dart';
+import 'package:dwds/src/debugging/remote_debugger.dart';
+import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import 'fixtures/context.dart';
+
+final context = TestContext(
+    directory: '../example', path: 'scopes.html', pathToServe: 'web');
+
+WipConnection get tabConnection => context.tabConnection;
+
+void main() {
+  AppInspector inspector;
+  RemoteDebugger remoteDebugger;
+  Debugger debugger;
+
+  setUpAll(() async {
+    await context.setUp();
+    var chromeProxyService = fetchChromeProxyService(context.debugConnection);
+    inspector = chromeProxyService.appInspectorProvider();
+    remoteDebugger = chromeProxyService.remoteDebugger;
+    debugger = inspector.debugger;
+  });
+
+  tearDownAll(() async {
+    await context.tearDown();
+  });
+
+  final url = 'org-dartlang-app:///web/scopes_main.dart';
+
+  /// A convenient way to get a library variable without boilerplate.
+  String libraryVariableExpression(String variable) =>
+      'require("dart_sdk").dart.getModuleLibraries("web/scopes_main")["$url"]["$variable"];';
+
+  Future<RemoteObject> libraryPublicFinal() => inspector
+      .evaluateJsExpression(libraryVariableExpression('libraryPublicFinal'));
+
+  group('instanceRef', () {
+    test('for a null', () async {
+      var remoteObject = await libraryPublicFinal();
+      var nullVariable = await inspector.loadField(remoteObject, 'notFinal');
+      var ref = await instanceRefFor(remoteDebugger, nullVariable);
+      expect(ref.valueAsString, 'null');
+      expect(ref.kind, InstanceKind.kNull);
+      var classRef = ref.classRef;
+      expect(classRef.name, 'Null');
+      expect(classRef.id, 'dart:core:object');
+    });
+
+    test('for a double', () async {
+      var remoteObject = await libraryPublicFinal();
+      var count = await inspector.loadField(remoteObject, 'count');
+      var ref = await instanceRefFor(remoteDebugger, count);
+      expect(ref.valueAsString, '0');
+      expect(ref.kind, InstanceKind.kDouble);
+      var classRef = ref.classRef;
+      expect(classRef.name, 'Double');
+      expect(classRef.id, 'dart:core:number');
+    });
+
+    test('for a class', () async {
+      var remoteObject = await libraryPublicFinal();
+      var count = await inspector.loadField(remoteObject, 'myselfField');
+      var ref = await instanceRefFor(remoteDebugger, count);
+      expect(ref.kind, InstanceKind.kPlainInstance);
+      var classRef = ref.classRef;
+      expect(classRef.name, 'MyTestClass');
+      expect(
+          classRef.id, 'org-dartlang-app:///web/scopes_main.dart:MyTestClass');
+    });
+  });
+
+  group('instance', () {
+    test('for class object', () async {
+      var remoteObject = await libraryPublicFinal();
+      var instance =
+          await instanceFor(debugger, remoteDebugger, remoteObject.objectId);
+      expect(instance.kind, InstanceKind.kPlainInstance);
+      var classRef = instance.classRef;
+      expect(classRef, isNotNull);
+      expect(classRef.name, 'MyTestClass');
+    });
+
+    test('for a nested class ', () async {
+      var libraryRemoteObject = await libraryPublicFinal();
+      var fieldRemoteObject =
+          await inspector.loadField(libraryRemoteObject, 'myselfField');
+      var instance = await instanceFor(
+          debugger, remoteDebugger, fieldRemoteObject.objectId);
+      expect(instance.kind, InstanceKind.kPlainInstance);
+      var classRef = instance.classRef;
+      expect(classRef, isNotNull);
+      expect(classRef.name, 'MyTestClass');
+    });
+  });
+}

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -38,7 +38,6 @@ void main() {
 
   final url = 'org-dartlang-app:///web/scopes_main.dart';
 
-  /// A convenient way to get a library variable without boilerplate.
   String libraryVariableExpression(String variable) =>
       'require("dart_sdk").dart.getModuleLibraries("web/scopes_main")["$url"]["$variable"];';
 

--- a/example/web/main.dart
+++ b/example/web/main.dart
@@ -17,9 +17,12 @@ void main() {
   document.body.append(SpanElement()..text = 'Hello World!!');
 
   var count = 0;
-  var foo = Foo(5);
+  var a = 0;
+  var z = 0;
+  var b = 0;
   Timer.periodic(Duration(seconds: 1), (_) {
-    print('Counter is: ${++count} $foo');
+    var foo = Foo(5);
+    print('Counter is: ${++count} $foo $a $b $z');
   });
 }
 

--- a/example/web/main.dart
+++ b/example/web/main.dart
@@ -17,16 +17,7 @@ void main() {
   document.body.append(SpanElement()..text = 'Hello World!!');
 
   var count = 0;
-  var a = 0;
-  var z = 0;
-  var b = 0;
   Timer.periodic(Duration(seconds: 1), (_) {
-    var foo = Foo(5);
-    print('Counter is: ${++count} $foo $a $b $z');
+    print('Counter is: ${++count}');
   });
-}
-
-class Foo {
-  int something;
-  Foo(this.something);
 }

--- a/example/web/main.dart
+++ b/example/web/main.dart
@@ -17,7 +17,13 @@ void main() {
   document.body.append(SpanElement()..text = 'Hello World!!');
 
   var count = 0;
+  var foo = Foo(5);
   Timer.periodic(Duration(seconds: 1), (_) {
-    print('Counter is: ${++count}');
+    print('Counter is: ${++count} $foo');
   });
+}
+
+class Foo {
+  int something;
+  Foo(this.something);
 }


### PR DESCRIPTION
- Rev `devtools` version as inspection logic only works with this version
- Create new `instance.dart` which contains methods for creating `Instance`s and `InstanceRef`s.
- Now properly construct an `Instance` for objects
- Sort variables and fields
- No longer pass `hide=none` so that only working tabs are available
- Add some basic tests for the updated instance methods