### PR TITLE
Added TLS support to webdev serve. (#564)

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.5.0-dev
+
+- TLS support has been added to the `serve` command through the addition of two
+  new options `tls-cert-chain` and `tls-cert-key`.
+
 ## 2.4.0
 
 - Add a `--no-injected-client` option which can be used to work around issues

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -6,7 +6,6 @@
 ## 2.4.1
 
 - Depend on the latest `package:webkit_inspection_protocol`.
->>>>>>> fed56f4c80c3e1d81bc45ad91c4dcce3694ca7d1
 
 ## 2.4.0
 

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -86,12 +86,10 @@ Advanced:
     --tls-cert-chain              The file location to a TLS Certificate to
                                   create an HTTPs server.
                                   Must be used with tls-cert-key.
-                                  (defaults to "")
 
     --tls-cert-key                The file location to a TLS Key to create an
                                   HTTPs server.
                                   Must be used with tls-cert-chain.
-                                  (defaults to "")
 
 Common:
 -h, --help                        Print this usage information.

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -83,6 +83,16 @@ Advanced:
     --log-requests                Enables logging for each request to the
                                   server.
 
+    --tls-cert-chain              The file location to a TLS Certificate to
+                                  create an HTTPs server.
+                                  Must be used with tls-cert-key.
+                                  (defaults to "")
+
+    --tls-cert-key                The file location to a TLS Key to create an
+                                  HTTPs server.
+                                  Must be used with tls-cert-chain.
+                                  (defaults to "")
+
 Common:
 -h, --help                        Print this usage information.
 -o, --output                      A directory to write the result of a build to.

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -140,9 +140,9 @@ class Configuration {
 
   String get hostname => _hostname ?? 'localhost';
 
-  String get tlsCertChain => _tlsCertChain ?? '';
+  String get tlsCertChain => _tlsCertChain ?? null;
 
-  String get tlsCertKey => _tlsCertKey ?? '';
+  String get tlsCertKey => _tlsCertKey ?? null;
 
   bool get launchInChrome => _launchInChrome ?? false;
 

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -140,9 +140,9 @@ class Configuration {
 
   String get hostname => _hostname ?? 'localhost';
 
-  String get tlsCertChain => _tlsCertChain ?? null;
+  String get tlsCertChain => _tlsCertChain ?? '';
 
-  String get tlsCertKey => _tlsCertKey ?? null;
+  String get tlsCertKey => _tlsCertKey ?? '';
 
   bool get launchInChrome => _launchInChrome ?? false;
 

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -140,9 +140,9 @@ class Configuration {
 
   String get hostname => _hostname ?? 'localhost';
 
-  String get tlsCertChain => _tlsCertChain ?? '';
+  String get tlsCertChain => _tlsCertChain;
 
-  String get tlsCertKey => _tlsCertKey ?? '';
+  String get tlsCertKey => _tlsCertKey;
 
   bool get launchInChrome => _launchInChrome ?? false;
 

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -14,6 +14,8 @@ const debugExtensionFlag = 'debug-extension';
 const debugFlag = 'debug';
 const enableInjectedClientFlag = 'injected-client';
 const hostnameFlag = 'hostname';
+const tlsCertChainFlag = 'tls-cert-chain';
+const tlsCertKeyFlag = 'tls-cert-key';
 const hotReloadFlag = 'hot-reload';
 const hotRestartFlag = 'hot-restart';
 const launchInChromeFlag = 'launch-in-chrome';
@@ -76,6 +78,8 @@ class Configuration {
   final bool _debug;
   final bool _enableInjectedClient;
   final String _hostname;
+  final String _tlsCertChain;
+  final String _tlsCertKey;
   final bool _launchInChrome;
   final bool _logRequests;
   final String _output;
@@ -93,6 +97,8 @@ class Configuration {
     bool debug,
     bool enableInjectedClient,
     String hostname,
+    String tlsCertChain,
+    String tlsCertKey,
     bool launchInChrome,
     bool logRequests,
     String output,
@@ -108,6 +114,8 @@ class Configuration {
         _debug = debug,
         _enableInjectedClient = enableInjectedClient,
         _hostname = hostname,
+        _tlsCertChain = tlsCertChain,
+        _tlsCertKey = tlsCertKey,
         _launchInChrome = launchInChrome,
         _logRequests = logRequests,
         _output = output,
@@ -131,6 +139,10 @@ class Configuration {
   bool get enableInjectedClient => _enableInjectedClient ?? true;
 
   String get hostname => _hostname ?? 'localhost';
+
+  String get tlsCertChain => _tlsCertChain ?? '';
+
+  String get tlsCertKey => _tlsCertKey ?? '';
 
   bool get launchInChrome => _launchInChrome ?? false;
 
@@ -179,6 +191,14 @@ class Configuration {
     var hostname = argResults.options.contains(hostnameFlag)
         ? argResults[hostnameFlag] as String
         : defaultConfiguration.hostname;
+
+    var tlsCertChain = argResults.options.contains(tlsCertChainFlag)
+        ? argResults[tlsCertChainFlag] as String
+        : defaultConfiguration.tlsCertChain;
+
+    var tlsCertKey = argResults.options.contains(tlsCertKeyFlag)
+        ? argResults[tlsCertKeyFlag] as String
+        : defaultConfiguration.tlsCertKey;
 
     var launchInChrome = argResults.options.contains(launchInChromeFlag) &&
             argResults.wasParsed(launchInChromeFlag)
@@ -252,6 +272,8 @@ class Configuration {
         debug: debug,
         enableInjectedClient: enableInjectedClient,
         hostname: hostname,
+        tlsCertChain: tlsCertChain,
+        tlsCertKey: tlsCertKey,
         launchInChrome: launchInChrome,
         logRequests: logRequests,
         output: output,

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -91,6 +91,14 @@ refresh: Performs a full page refresh.
     ..addFlag(logRequestsFlag,
         negatable: false,
         help: 'Enables logging for each request to the server.')
+    ..addOption(tlsCertChainFlag,
+        help: 'The file location to a TLS Certificate to create an HTTPs server.\n'
+            "Must be used with $tlsCertKeyFlag.",
+        defaultsTo: '')
+    ..addOption(tlsCertKeyFlag,
+        help: 'The file location to a TLS Key to create an HTTPs server.\n'
+            "Must be used with $tlsCertChainFlag.",
+        defaultsTo: '')
     ..addSeparator('Common:');
 
   ServeCommand() {

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -93,11 +93,11 @@ refresh: Performs a full page refresh.
         help: 'Enables logging for each request to the server.')
     ..addOption(tlsCertChainFlag,
         help: 'The file location to a TLS Certificate to create an HTTPs server.\n'
-            "Must be used with $tlsCertKeyFlag.",
+            'Must be used with $tlsCertKeyFlag.',
         defaultsTo: '')
     ..addOption(tlsCertKeyFlag,
         help: 'The file location to a TLS Key to create an HTTPs server.\n'
-            "Must be used with $tlsCertChainFlag.",
+            'Must be used with $tlsCertChainFlag.',
         defaultsTo: '')
     ..addSeparator('Common:');
 

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -92,7 +92,8 @@ refresh: Performs a full page refresh.
         negatable: false,
         help: 'Enables logging for each request to the server.')
     ..addOption(tlsCertChainFlag,
-        help: 'The file location to a TLS Certificate to create an HTTPs server.\n'
+        help:
+            'The file location to a TLS Certificate to create an HTTPs server.\n'
             'Must be used with $tlsCertKeyFlag.',
         defaultsTo: '')
     ..addOption(tlsCertKeyFlag,

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -94,12 +94,10 @@ refresh: Performs a full page refresh.
     ..addOption(tlsCertChainFlag,
         help:
             'The file location to a TLS Certificate to create an HTTPs server.\n'
-            'Must be used with $tlsCertKeyFlag.',
-        defaultsTo: '')
+            'Must be used with $tlsCertKeyFlag.')
     ..addOption(tlsCertKeyFlag,
         help: 'The file location to a TLS Key to create an HTTPs server.\n'
-            'Must be used with $tlsCertChainFlag.',
-        defaultsTo: '')
+            'Must be used with $tlsCertChainFlag.')
     ..addSeparator('Common:');
 
   ServeCommand() {

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -86,7 +86,7 @@ Future<ServerManager> _startServerManager(
     logWriter(
         logging.Level.INFO,
         'Serving `${server.target}` on '
-        'http://${server.host}:${server.port}\n');
+        '${server.protocol}://${server.host}:${server.port}\n');
   }
 
   return serverManager;

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -111,11 +111,12 @@ class WebDevServer {
 
     HttpServer server;
     var protocol = (tlsCertChain != '' && tlsCertKey != '') ? 'https' : 'http';
-    if  (protocol == 'https') {
+    if (protocol == 'https') {
       var serverContext = SecurityContext()
         ..useCertificateChain(tlsCertChain)
         ..usePrivateKey(tlsCertKey);
-      server = await HttpMultiServer.loopbackSecure(options.port, serverContext);
+      server =
+          await HttpMultiServer.loopbackSecure(options.port, serverContext);
     } else {
       server = await HttpMultiServer.bind(hostname, options.port);
     }

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -110,11 +110,12 @@ class WebDevServer {
     var tlsCertKey = options.configuration.tlsCertKey;
 
     HttpServer server;
-    var protocol = (tlsCertChain != '' && tlsCertKey != '') ? 'https' : 'http';
+    var protocol =
+        (tlsCertChain != null && tlsCertKey != null) ? 'https' : 'http';
     if (protocol == 'https') {
       var serverContext = SecurityContext()
-        ..useCertificateChain(tlsCertChain.toString())
-        ..usePrivateKey(tlsCertKey.toString());
+        ..useCertificateChain(tlsCertChain)
+        ..usePrivateKey(tlsCertKey);
       server =
           await HttpMultiServer.loopbackSecure(options.port, serverContext);
     } else {

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -110,7 +110,7 @@ class WebDevServer {
     var tlsCertKey = options.configuration.tlsCertKey;
 
     HttpServer server;
-    var protocol = (tlsCertChain != '' && tlsCertKey != '') ? 'https': 'http';
+    var protocol = (tlsCertChain != '' && tlsCertKey != '') ? 'https' : 'http';
     if (protocol == 'https') {
       var serverContext = SecurityContext()
         ..useCertificateChain(tlsCertChain.toString())

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -109,14 +109,13 @@ class WebDevServer {
     var tlsCertChain = options.configuration.tlsCertChain;
     var tlsCertKey = options.configuration.tlsCertKey;
 
-    var server;
-    String protocol = 'http';
-    if (tlsCertChain != '' && tlsCertKey != '') {
-      SecurityContext serverContext = SecurityContext()
+    HttpServer server;
+    var protocol = (tlsCertChain != '' && tlsCertKey != '') ? 'https' : 'http';
+    if  (protocol == 'https') {
+      var serverContext = SecurityContext()
         ..useCertificateChain(tlsCertChain)
         ..usePrivateKey(tlsCertKey);
       server = await HttpMultiServer.loopbackSecure(options.port, serverContext);
-      protocol = 'https';
     } else {
       server = await HttpMultiServer.bind(hostname, options.port);
     }

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -110,7 +110,8 @@ class WebDevServer {
     var tlsCertKey = options.configuration.tlsCertKey;
 
     HttpServer server;
-    var protocol = (tlsCertChain != '' && tlsCertKey != '') ? 'https' : 'http';
+    var protocol =
+        (tlsCertChain != null && tlsCertKey != null) ? 'https' : 'http';
     if (protocol == 'https') {
       var serverContext = SecurityContext()
         ..useCertificateChain(tlsCertChain)

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -110,12 +110,11 @@ class WebDevServer {
     var tlsCertKey = options.configuration.tlsCertKey;
 
     HttpServer server;
-    var protocol =
-        (tlsCertChain != null && tlsCertKey != null) ? 'https' : 'http';
+    var protocol = (tlsCertChain != '' && tlsCertKey != '') ? 'https': 'http';
     if (protocol == 'https') {
       var serverContext = SecurityContext()
-        ..useCertificateChain(tlsCertChain)
-        ..usePrivateKey(tlsCertKey);
+        ..useCertificateChain(tlsCertChain.toString())
+        ..usePrivateKey(tlsCertKey.toString());
       server =
           await HttpMultiServer.loopbackSecure(options.port, serverContext);
     } else {

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.4.1';
+const packageVersion = '2.5.0-dev';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.4.0
+version: 2.5.0-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-


### PR DESCRIPTION
Helps with issue: #564 

- Added option `tls-cert-chain`
- Added option `tls-cert-key`

By adding the above to flags to `webdev serve` users are able to launch the development server listening for HTTPS requests.

Known Issue:
The output line will show 127.0.0.1 regardless of what the `--hostname` flag is set to. However, the server will listen to all hostnames regardless. I did not see a place to set the hostname in HttpMultiServer's loopbackSecure to inject the hostname. Perhaps this issue could be resolved with a change in that output line?