### PR TITLE
upgrade the webkit_inspection_protocol dependency

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Depend on the latest `package:webkit_inspection_protocol`.
+
 ## 0.5.0
 
 - Fix an issue where we source map paths were not normalized.

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   sse: ^2.0.2
   vm_service: 1.1.0
   web_socket_channel: ^1.0.0
-  webkit_inspection_protocol: ^0.4.0
+  webkit_inspection_protocol: '>=0.4.0 <0.6.0'
 
 dev_dependencies:
   args: ^1.0.0

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Depend on the latest `package:webkit_inspection_protocol`.
+
 ## 2.4.0
 
 - Add a `--no-injected-client` option which can be used to work around issues

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   shelf_static: ^0.2.8
   sse: ^2.0.0
   vm_service: ^1.1.0
-  webkit_inspection_protocol: ^0.4.0
+  webkit_inspection_protocol: '>=0.4.0 <0.6.0'
   yaml: ^2.1.13
 
 dev_dependencies:


### PR DESCRIPTION
- upgrade the webkit_inspection_protocol dependency

This wides the dep on `package:webkit_inspection_protocol` to allow us to bring in `0.5.0`; it's mostly the same as `0.4.0` but with fewer transitive deps.
