### PR TITLE
Allow building/serving top level dirs only

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - TLS support has been added to the `serve` command through the addition of two
   new options `tls-cert-chain` and `tls-cert-key`.
+- Added an explicit error if asked to build or serve anything other than a top
+  level directory under a package. This never worked before but silently didn't
+  actually do what the user expected.
 
 ## 2.4.1
 

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -7,6 +7,7 @@ import 'package:dwds/dwds.dart';
 import 'package:logging/logging.dart';
 
 import '../logging.dart';
+import 'shared.dart';
 
 const autoOption = 'auto';
 const chromeDebugPortFlag = 'chrome-debug-port';
@@ -226,6 +227,7 @@ class Configuration {
         outputPath = output;
       } else {
         outputInput = splitOutput.first;
+        ensureIsTopLevelDir(outputInput);
         outputPath = splitOutput.skip(1).join(':');
       }
     }

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -123,7 +123,9 @@ class Configuration {
         _release = release,
         _reload = reload,
         _requireBuildWebCompilers = requireBuildWebCompilers,
-        _verbose = verbose;
+        _verbose = verbose {
+    if (outputInput != null) ensureIsTopLevelDir(outputInput);
+  }
 
   factory Configuration.noInjectedClientDefaults() =>
       Configuration(autoRun: false, debug: false, debugExtension: false);
@@ -227,7 +229,6 @@ class Configuration {
         outputPath = output;
       } else {
         outputInput = splitOutput.first;
-        ensureIsTopLevelDir(outputInput);
         outputPath = splitOutput.skip(1).join(':');
       }
     }

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -28,6 +28,7 @@ Map<String, int> _parseDirectoryArgs(List<String> args) {
   } else {
     for (var arg in args) {
       var splitOption = arg.split(':');
+      ensureIsTopLevelDir(splitOption.first);
       if (splitOption.length == 2) {
         result[splitOption.first] = int.parse(splitOption.last);
       } else {

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:path/path.dart' as p;
 
 import '../pubspec.dart';
 import 'configuration.dart';
@@ -63,4 +64,21 @@ Future<PubspecLock> readPubspecLock(Configuration configuration) async {
   await checkPubspecLock(pubspecLock,
       requireBuildWebCompilers: configuration.requireBuildWebCompilers);
   return pubspecLock;
+}
+
+/// Checks that the normalized form of [path] is a top level directory under
+/// such as `web` or `test`.
+///
+/// If it is not then an [InvalidConfiguration] error will be thrown.
+void ensureIsTopLevelDir(String path) {
+  path = p.normalize(path);
+  if (path.isEmpty ||
+      path == '.' ||
+      path.contains(r'\') ||
+      path.contains(r'/') ||
+      path == '.') {
+    throw InvalidConfiguration(
+        'Only top level directories under the package can be built (such as '
+        '`web` or `test`), but was asked to build `$path`.');
+  }
 }

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -74,11 +74,13 @@ void ensureIsTopLevelDir(String path) {
   path = p.normalize(path);
   if (path.isEmpty ||
       path == '.' ||
+      path == '..' ||
       path.contains(r'\') ||
       path.contains(r'/') ||
       path == '.') {
     throw InvalidConfiguration(
-        'Only top level directories under the package can be built (such as '
-        '`web` or `test`), but was asked to build `$path`.');
+        'Only top level directories under the package can be built or served '
+        '(such as `web` or `test`), but was given `$path`.');
   }
+  print(path);
 }

--- a/webdev/test/configuration_test.dart
+++ b/webdev/test/configuration_test.dart
@@ -24,4 +24,17 @@ void main() {
     var argConfiguration = Configuration.fromArgs(argResults);
     expect(argConfiguration.release, isTrue);
   });
+
+  test('only top level directories are allowed for outputInput', () {
+    expect(() => Configuration(outputInput: '.'),
+        throwsA(isA<InvalidConfiguration>()));
+    expect(() => Configuration(outputInput: '../'),
+        throwsA(isA<InvalidConfiguration>()));
+    expect(() => Configuration(outputInput: '../foo'),
+        throwsA(isA<InvalidConfiguration>()));
+    expect(() => Configuration(outputInput: 'foo/bar'),
+        throwsA(isA<InvalidConfiguration>()));
+    expect(() => Configuration(outputInput: 'foo/../'),
+        throwsA(isA<InvalidConfiguration>()));
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/571

We will now throw an InvalidConfiguration error and give the appropriate exit code if asked to serve or build anything other than a top level directory in the package.

This never worked but silently just didn't do what people expected.