### PR TITLE
Improve Configuration Validation

### DIFF
--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -200,6 +200,12 @@ class Configuration {
         ? argResults[tlsCertKeyFlag] as String
         : defaultConfiguration.tlsCertKey;
 
+    if ((tlsCertKey != null && tlsCertChain == null) ||
+        (tlsCertKey == null && tlsCertChain != null)) {
+      throw InvalidConfiguration(
+          'Must use --$tlsCertKey with --$tlsCertChain.');
+    }
+
     var launchInChrome = argResults.options.contains(launchInChromeFlag) &&
             argResults.wasParsed(launchInChromeFlag)
         ? argResults[launchInChromeFlag] as bool

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -124,7 +124,39 @@ class Configuration {
         _reload = reload,
         _requireBuildWebCompilers = requireBuildWebCompilers,
         _verbose = verbose {
+    _validateConfiguration();
+  }
+
+  void _validateConfiguration() {
     if (outputInput != null) ensureIsTopLevelDir(outputInput);
+
+    if ((tlsCertKey != null && tlsCertChain == null) ||
+        (tlsCertKey == null && tlsCertChain != null)) {
+      throw InvalidConfiguration(
+          'Must use --$tlsCertKey with --$tlsCertChain.');
+    }
+    if (debug && chromeDebugPort == 0 && !launchInChrome) {
+      throw InvalidConfiguration(
+          'Must either use --$chromeDebugPortFlag or --$launchInChromeFlag '
+          'with --$debugFlag.');
+    }
+
+    // Check that no debugging options were passed if the injected client is
+    // disabled.
+    if (!enableInjectedClient) {
+      if (debug) {
+        throw InvalidConfiguration(
+            '--$debugFlag cannot be used with --no-$enableInjectedClientFlag');
+      }
+      if (debugExtension) {
+        throw InvalidConfiguration('--$debugExtensionFlag cannot be used with '
+            '--no-$enableInjectedClientFlag');
+      }
+      if (chromeDebugPort != 0) {
+        throw InvalidConfiguration('--$chromeDebugPortFlag cannot be used '
+            'with --no-$enableInjectedClientFlag');
+      }
+    }
   }
 
   factory Configuration.noInjectedClientDefaults() =>
@@ -203,12 +235,6 @@ class Configuration {
         ? argResults[tlsCertKeyFlag] as String
         : defaultConfiguration.tlsCertKey;
 
-    if ((tlsCertKey != null && tlsCertChain == null) ||
-        (tlsCertKey == null && tlsCertChain != null)) {
-      throw InvalidConfiguration(
-          'Must use --$tlsCertKey with --$tlsCertChain.');
-    }
-
     var launchInChrome = argResults.options.contains(launchInChromeFlag) &&
             argResults.wasParsed(launchInChromeFlag)
         ? argResults[launchInChromeFlag] as bool
@@ -251,29 +277,6 @@ class Configuration {
     var verbose = argResults.options.contains(verboseFlag)
         ? argResults[verboseFlag] as bool
         : defaultConfiguration.verbose;
-
-    if (debug && chromeDebugPort == 0 && !launchInChrome) {
-      throw InvalidConfiguration(
-          'Must either use --$chromeDebugPortFlag or --$launchInChromeFlag '
-          'with --$debugFlag.');
-    }
-
-    // Check that no debugging options were passed if the injected client is
-    // disabled.
-    if (!enableInjectedClient) {
-      if (debug) {
-        throw InvalidConfiguration(
-            '--$debugFlag cannot be used with --no-$enableInjectedClientFlag');
-      }
-      if (debugExtension) {
-        throw InvalidConfiguration('--$debugExtensionFlag cannot be used with '
-            '--no-$enableInjectedClientFlag');
-      }
-      if (chromeDebugPort != defaultConfiguration.chromeDebugPort) {
-        throw InvalidConfiguration('--$chromeDebugPortFlag cannot be used '
-            'with --no-$enableInjectedClientFlag');
-      }
-    }
 
     return Configuration(
         chromeDebugPort: chromeDebugPort,

--- a/webdev/test/configuration_test.dart
+++ b/webdev/test/configuration_test.dart
@@ -25,6 +25,31 @@ void main() {
     expect(argConfiguration.release, isTrue);
   });
 
+  test('tlsCertKey and tlsCertChain must be provided together', () {
+    expect(() => Configuration(tlsCertKey: 'blah'),
+        throwsA(isA<InvalidConfiguration>()));
+    expect(() => Configuration(tlsCertChain: 'blah'),
+        throwsA(isA<InvalidConfiguration>()));
+  });
+
+  test('must provide a debug port when launchInChrome is false ', () {
+    expect(() => Configuration(debug: true, launchInChrome: false),
+        throwsA(isA<InvalidConfiguration>()));
+  });
+
+  test(
+      'must not provide debug related configuartion when enableInjectedClient '
+      'is false', () {
+    expect(() => Configuration(enableInjectedClient: false, debug: true),
+        throwsA(isA<InvalidConfiguration>()));
+    expect(
+        () => Configuration(enableInjectedClient: false, debugExtension: true),
+        throwsA(isA<InvalidConfiguration>()));
+    expect(
+        () => Configuration(enableInjectedClient: false, chromeDebugPort: 8080),
+        throwsA(isA<InvalidConfiguration>()));
+  });
+
   test('only top level directories are allowed for outputInput', () {
     expect(() => Configuration(outputInput: '.'),
         throwsA(isA<InvalidConfiguration>()));


### PR DESCRIPTION
Validate configuration during construction to ensure we never get an invalid configuration. Add some related tests.