### PR TITLE
Use dart.getFields to accurately find the fields for an object

### DIFF
--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -115,7 +115,7 @@ class AppInspector extends Domain {
           return require("dart_sdk").dart.dloadRepl(this, "$fieldName");
         }
         ''';
-    return _callFunctionOn(receiver, load, _marshallArguments([]));
+    return callFunctionOn(receiver, load, _marshallArguments([]));
   }
 
   /// Call a method by name on [receiver], with arguments [positionalArgs] and
@@ -133,7 +133,7 @@ class AppInspector extends Domain {
         }
         ''';
     var arguments = _marshallArguments(positionalArgs);
-    var remote = await _callFunctionOn(receiver, send, arguments);
+    var remote = await callFunctionOn(receiver, send, arguments);
     return remote;
   }
 
@@ -142,7 +142,7 @@ class AppInspector extends Domain {
   /// [arguments] is expected to be in the form returned by
   /// [_marshallArguments]. [evalExpression] should be a function definition
   /// that can accept [arguments].
-  Future<RemoteObject> _callFunctionOn(
+  Future<RemoteObject> callFunctionOn(
       RemoteObject receiver, String evalExpression, List arguments) async {
     var result =
         await _remoteDebugger.sendCommand('Runtime.callFunctionOn', params: {
@@ -209,8 +209,8 @@ class AppInspector extends Domain {
   }
 
   /// Evaluate [expression] by calling Chrome's Runtime.evaluate.
-  Future<RemoteObject> evaluateJsExpression(String expression) async {
-    // TODO(alanknight): Support a version with arguments if needed.
+  Future<RemoteObject> evaluateJsExpression(String expression,
+      [List<Object> arguments = const []]) async {
     WipResponse result;
     result = await _remoteDebugger
         .sendCommand('Runtime.evaluate', params: {'expression': expression});

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -209,8 +209,8 @@ class AppInspector extends Domain {
   }
 
   /// Evaluate [expression] by calling Chrome's Runtime.evaluate.
-  Future<RemoteObject> evaluateJsExpression(String expression,
-      [List<Object> arguments = const []]) async {
+  Future<RemoteObject> evaluateJsExpression(String expression) async {
+    // TODO(alanknight): Support a version with arguments if needed.
     WipResponse result;
     result = await _remoteDebugger
         .sendCommand('Runtime.evaluate', params: {'expression': expression});

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -311,8 +311,8 @@ require("dart_sdk").developer.invokeExtension(
   }
 
   @override
-  Future invoke(String isolateId, String targetId, String selector,
-      List argumentIds,
+  Future invoke(
+      String isolateId, String targetId, String selector, List argumentIds,
       {bool disableBreakpoints}) {
     throw UnimplementedError();
   }

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -312,7 +312,7 @@ require("dart_sdk").developer.invokeExtension(
 
   @override
   Future invoke(String isolateId, String targetId, String selector,
-      List<String> argumentIds,
+      List argumentIds,
       {bool disableBreakpoints}) {
     throw UnimplementedError();
   }

--- a/dwds/lib/src/utilities/objects.dart
+++ b/dwds/lib/src/utilities/objects.dart
@@ -35,7 +35,18 @@ class Property {
   }
 
   /// The name of the property
-  String get name => _map['name'] as String;
+  String get name {
+    const prefix = 'Symbol(';
+    var nonSymbol = (rawName.startsWith(prefix))
+        ? rawName.substring(prefix.length, rawName.length - 1)
+        : rawName;
+    return nonSymbol.split('.').last;
+  }
+
+  /// The name of the property.
+  ///
+  /// May be of the form 'Symbol(_actualName)'.
+  String get rawName => _map['name'] as String;
 
   @override
   String toString() => '$name $value';

--- a/dwds/lib/src/utilities/objects.dart
+++ b/dwds/lib/src/utilities/objects.dart
@@ -43,9 +43,9 @@ class Property {
     return nonSymbol.split('.').last;
   }
 
-  /// The name of the property.
+  /// The raw name of the property in JS.
   ///
-  /// May be of the form 'Symbol(_actualName)'.
+  /// Will be of the form 'Symbol(_actualName)' for private fields.
   String get rawName => _map['name'] as String;
 
   @override

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -69,6 +69,11 @@ class FakeInspector extends Domain implements AppInspector {
 
   @override
   InstanceHelper get instanceHelper => InstanceHelper(null, null);
+  @override
+  Future<RemoteObject> callFunctionOn(
+      RemoteObject receiver, String evalExpression, List arguments) {
+    throw UnsupportedError('This is a fake');
+  }
 }
 
 class FakeSseConnection implements SseConnection {

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -65,10 +65,11 @@ void main() {
     var names =
         properties.map((p) => p.name).where((x) => x != '__proto__').toList();
     var expected = [
-      'Symbol(MyTestClass.count)',
-      'Symbol(MyTestClass.message)',
-      'Symbol(MyTestClass.myselfField)',
-      'Symbol(MyTestClass.notFinal)'
+      '_privateField',
+      'count',
+      'message',
+      'myselfField',
+      'notFinal'
     ];
     names.sort();
     expect(expected, names);

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -90,6 +90,10 @@ void main() {
       var classRef = instance.classRef;
       expect(classRef, isNotNull);
       expect(classRef.name, 'MyTestClass');
+      var fieldNames =
+          instance.fields.map((boundField) => boundField.decl.name).toList();
+      expect(fieldNames,
+          ['_privateField', 'count', 'message', 'myselfField', 'notFinal']);
     });
 
     test('for a nested class ', () async {

--- a/dwds/test/objects_test.dart
+++ b/dwds/test/objects_test.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+import 'package:dwds/src/utilities/objects.dart';
+import 'package:test/test.dart';
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+void main() {
+  group('Property', () {
+    final exampleMap = {'objectId': '1234', 'value': 'abcd'};
+
+    test('from a map', () {
+      // Verify that we behave the same whether created from a Map
+      // or from a RemoteObject.
+      var property = Property({'name': 'prop', 'value': exampleMap});
+      expect(property.rawValue, exampleMap);
+      expect(property.value.objectId, '1234');
+      expect(property.value.value, 'abcd');
+      expect(property.name, 'prop');
+    });
+    test('from a RemoteObject', () {
+      var remoteObject = RemoteObject({'objectId': '1234', 'value': 'abcd'});
+      var property = Property({'name': 'prop', 'value': remoteObject});
+      expect(property.rawValue, remoteObject);
+      expect(property.value.objectId, '1234');
+      expect(property.value.value, 'abcd');
+      expect(property.name, 'prop');
+    });
+
+    test('stripping the "Symbol(" from a private field', () {
+      var property =
+          Property({'name': 'Symbol(_privateThing)', 'value': exampleMap});
+      expect(property.name, '_privateThing');
+    });
+  });
+}

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -93,6 +93,9 @@ class MyTestClass {
     libraryFunction('abc');
   }
 
+  // ignore: unused_field
+  final _privateField = 'a private field';
+
   @override
   String toString() => 'A test class with message $message';
 }


### PR DESCRIPTION
Also strip out the Symbol() portion from private field names.
Removes an unrelated generic type that I noticed causing exceptions when passed a List<dynamic> coming from JSON, instead of the correct 'not implemented' exception :-)