### PR TITLE
update the Service event registration

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+- Report that `package:dwds` supports the `Service` stream.
+
 ## 0.5.1
 
 - Fix an issue where missing source maps would cause a crash. A warning will

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -101,7 +101,7 @@ class ChromeProxyService implements VmServiceInterface {
   /// Creates a new isolate.
   ///
   /// Only one isolate at a time is supported, but they should be cleaned up
-  /// with [destroyIsolate] and recreated with this method there is a hot
+  /// with [destroyIsolate] and recreated with this method when there is a hot
   /// restart or full page refresh.
   Future<void> createIsolate() async {
     if (_inspector?.isolate != null) {
@@ -335,7 +335,7 @@ require("dart_sdk").developer.invokeExtension(
         case 'GC':
         // TODO: https://github.com/dart-lang/webdev/issues/168
         case 'Timeline':
-        case '_Service':
+        case 'Service':
           return StreamController<Event>.broadcast();
         case 'Debug':
           return StreamController<Event>.broadcast();

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.5.1
+version: ## 0.5.2
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: ## 0.5.2
+version: 0.5.2
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-


### PR DESCRIPTION
The `_Service` stream was removed in the `3.22` protocol version, and the `Service` stream added. `package:dwds` reports as supporting `3.25.0`.

Clients do make use of the version number to do feature detection; we may want some automated   way (or manual check?) to ensure that `package:dwds` conforms to the version it reports. Perhaps only manually reving between reported versions (and not using the `vmServiceVersion` global from `package:vm_service`)?
