### PR TITLE
upgrade to the latest package:vm_service

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -538,6 +538,11 @@ require("dart_sdk").developer.invokeExtension(
       String isolateId, String targetId, int limit) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<Success> requestHeapSnapshot(String isolateId) {
+    throw UnimplementedError();
+  }
 }
 
 /// The `type`s of [ConsoleAPIEvent]s that are treated as `stderr` logs.

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   shelf_web_socket: ^0.2.0
   source_maps: ^0.10.0
   sse: ^2.0.2
-  vm_service: 1.1.0
+  vm_service: 1.1.1
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: '>=0.4.0 <0.6.0'
 

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   build_daemon: ^2.0.0
   built_value: ^6.7.0
   crypto: ^2.0.6
-  devtools: ^0.1.6-dev.2
+  devtools: ^0.1.6-dev.3
   http: ^0.12.0
   http_multi_server: ^2.0.0
   logging: ^0.11.3


### PR DESCRIPTION
This upgrades to the latest `package:vm_service` version. Version solving fails because devtools has not yet upgraded; that's in progress (https://github.com/flutter/devtools/pull/943).

Related to https://github.com/dart-lang/webdev/issues/580.

```
pub get
Resolving dependencies... 
Because devtools 0.1.6-dev.2 depends on vm_service 1.1.0 and no versions of devtools match >0.1.6-dev.2 <0.2.0, devtools ^0.1.6-dev.2 requires
  vm_service 1.1.0.
So, because dwds depends on both vm_service 1.1.1 and devtools ^0.1.6-dev.2, version solving failed.
```
