### PR TITLE
Implement invoke

### DIFF
--- a/_test/example/hello_world/main.dart
+++ b/_test/example/hello_world/main.dart
@@ -18,7 +18,7 @@ final myInstance = MyTestClass();
 void main() async {
   print(DateFormat());
   // Long running so that we can test the pause / resume behavior.
-  Timer.periodic(Duration(seconds: 1), (_) {});
+  Timer.periodic(const Duration(seconds: 1), (_) {});
 
   print(p.join('Hello', 'World'));
 
@@ -45,7 +45,7 @@ void main() async {
     });
   };
 
-  Timer.periodic(Duration(seconds: 1), (_) {
+  Timer.periodic(const Duration(seconds: 1), (_) {
     printCount();
   });
 

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.1
+
+ - Implements `invoke`.
+ - Adds support for VM object IDs for things that don't have Chrome object Ids
+   (e.g. int, double, bool, null).
+
 ## 0.6.0
 
 - Add new required parameter `enableDebugging` to `Dwds.start`. If `false` is

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -192,14 +192,14 @@ class AppInspector extends Domain {
     // it's not really a Dart object.
     if (isLibraryId(targetId)) {
       var library = await getObject(isolateId, targetId) as Library;
-      return await _invokeFunction(library, selector, remoteArguments);
+      return await _invokeLibraryFunction(library, selector, remoteArguments);
     } else {
       return invokeMethod(remoteObjectFor(targetId), selector, remoteArguments);
     }
   }
 
   /// Invoke the function named [selector] from [library] with [arguments].
-  Future<RemoteObject> _invokeFunction(
+  Future<RemoteObject> _invokeLibraryFunction(
       Library library, String selector, List<RemoteObject> arguments) {
     return _evaluateInLibrary(
         library,

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -83,12 +83,11 @@ class AppInspector extends Domain {
       IsolateRef(id: isolate.id, name: isolate.name, number: isolate.number);
 
   static Future<AppInspector> initialize(
-    RemoteDebugger remoteDebugger,
-    AssetHandler assetHandler,
-    Debugger debugger,
-    String root,
-    InstanceHelper instanceHelper
-  ) async {
+      RemoteDebugger remoteDebugger,
+      AssetHandler assetHandler,
+      Debugger debugger,
+      String root,
+      InstanceHelper instanceHelper) async {
     var id = createId();
     var time = DateTime.now().millisecondsSinceEpoch;
     var isolate = Isolate(
@@ -105,8 +104,8 @@ class AppInspector extends Domain {
         exceptionPauseMode: debugger.pauseState)
       ..extensionRPCs = [];
     debugger.notifyPausedAtStart();
-    var inspector =
-        AppInspector._(isolate, assetHandler, debugger, root, remoteDebugger, instanceHelper);
+    var inspector = AppInspector._(
+        isolate, assetHandler, debugger, root, remoteDebugger, instanceHelper);
     await inspector._initialize();
     return inspector;
   }
@@ -124,7 +123,8 @@ class AppInspector extends Domain {
   /// Call a method by name on [receiver], with arguments [positionalArgs] and
   /// [namedArgs].
   Future<RemoteObject> invokeMethod(RemoteObject receiver, String methodName,
-      [List<RemoteObject> positionalArgs = const [], Map namedArgs = const {}]) async {
+      [List<RemoteObject> positionalArgs = const [],
+      Map namedArgs = const {}]) async {
     // TODO(alanknight): Support named arguments.
     if (namedArgs.isNotEmpty) {
       throw UnsupportedError('Named arguments are not yet supported');
@@ -144,8 +144,9 @@ class AppInspector extends Domain {
   ///
   /// [evalExpression] should be a JS function definition that can accept
   /// [arguments].
-  Future<RemoteObject> jsCallFunctionOn(
-      RemoteObject receiver, String evalExpression, List<RemoteObject> arguments, {bool returnByValue = false}) async {
+  Future<RemoteObject> jsCallFunctionOn(RemoteObject receiver,
+      String evalExpression, List<RemoteObject> arguments,
+      {bool returnByValue = false}) async {
     var jsArguments = arguments.map(callArgumentFor).toList();
     var result =
         await _remoteDebugger.sendCommand('Runtime.callFunctionOn', params: {
@@ -180,30 +181,31 @@ class AppInspector extends Domain {
   ///
   /// The [targetId] can be the URL of a Dart library, in which case this means
   /// invoking a top-level function. The [arguments] are always strings that are
-  /// Dart object Ids (which can also be Chrome RemoteObject objectIds that are 
+  /// Dart object Ids (which can also be Chrome RemoteObject objectIds that are
   /// for non-Dart JS objects.)
   Future<RemoteObject> invoke(String isolateId, String targetId,
       String selector, List<dynamic> arguments) async {
     checkIsolate(isolateId);
-    var remoteArguments = arguments.cast<String>().map(remoteObjectFor).toList();
+    var remoteArguments =
+        arguments.cast<String>().map(remoteObjectFor).toList();
     // We special case the Dart library, where invokeMethod won't work because
-    // it's not really a Dart object. 
+    // it's not really a Dart object.
     if (isLibraryId(targetId)) {
-        var library = await getObject(isolateId, targetId) as Library;
-        return await _invokeFunction(library, selector, remoteArguments);
+      var library = await getObject(isolateId, targetId) as Library;
+      return await _invokeFunction(library, selector, remoteArguments);
     } else {
-      return invokeMethod(remoteObjectFor(targetId),
-          selector, remoteArguments);
+      return invokeMethod(remoteObjectFor(targetId), selector, remoteArguments);
     }
   }
 
-/// Invoke the function named [selector] from [library] with [arguments].
-Future<RemoteObject> _invokeFunction(Library library, String selector, List<RemoteObject> arguments) {
-      return _evaluateInLibrary(
-          library,
-          'function () { return this.$selector.apply(this, arguments);}',
-          arguments);
-}
+  /// Invoke the function named [selector] from [library] with [arguments].
+  Future<RemoteObject> _invokeFunction(
+      Library library, String selector, List<RemoteObject> arguments) {
+    return _evaluateInLibrary(
+        library,
+        'function () { return this.$selector.apply(this, arguments);}',
+        arguments);
+  }
 
   /// Evaluate [expression] as a member/message of the library identified by
   /// [libraryUri].
@@ -251,8 +253,7 @@ Future<RemoteObject> _invokeFunction(Library library, String selector, List<Remo
   Future<RemoteObject> evaluateInLibrary(
       Library library, Map<String, String> scope, String expression) async {
     var argsString = scope.keys.join(', ');
-    var arguments = scope.values
-        .map(remoteObjectFor).toList();
+    var arguments = scope.values.map(remoteObjectFor).toList();
     var evalExpression = '''
 function($argsString) {
   ${_getLibrarySnippet(library.uri)};

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -43,8 +43,6 @@ class InstanceHelper extends Domain {
       this._debugger, this._remoteDebugger, AppInspector Function() provider)
       : super(provider);
 
-
-
   Future<Instance> _stringInstanceFor(RemoteObject remoteObject) async {
 
     var actualString =
@@ -85,7 +83,7 @@ class InstanceHelper extends Domain {
       return _stringInstanceFor(remoteObject);
     }
     var metaData =
-        await ClassMetaData.metaDataFor(_remoteDebugger, remoteObject);
+        await ClassMetaData.metaDataFor(_remoteDebugger, remoteObject, inspector);
     if (metaData.name == 'Function') {
       return _closureInstanceFor(remoteObject);
     } else {
@@ -139,7 +137,7 @@ class InstanceHelper extends Domain {
       return nonSymbolNames.concat(publicFieldNames).join(',');
     }
     ''';
-    var allNames = (await _debugger.inspector
+    var allNames = (await inspector
             .jsCallFunctionOn(remoteObject, fieldNameExpression, []))
         .value as String;
     var names = allNames.split(',');
@@ -172,7 +170,7 @@ class InstanceHelper extends Domain {
           return _primitiveInstance(InstanceKind.kNull, remoteObject);
         }
         var metaData =
-            await ClassMetaData.metaDataFor(_remoteDebugger, remoteObject);
+            await ClassMetaData.metaDataFor(_remoteDebugger, remoteObject, inspector);
         if (metaData == null) return null;
         return InstanceRef(
             kind: InstanceKind.kPlainInstance,

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -14,15 +14,14 @@ import 'inspector.dart';
 import 'metadata.dart';
 import 'remote_debugger.dart';
 
-
-
 /// Creates an [InstanceRef] for a primitive [RemoteObject].
 InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
   var classRef = ClassRef(
       // TODO(grouma) - is this ID correct?
       id: 'dart:core:${remoteObject?.type}',
       name: kind);
-  return InstanceRef(kind: kind, classRef: classRef, id: dartIdFor(remoteObject?.value))
+  return InstanceRef(
+      kind: kind, classRef: classRef, id: dartIdFor(remoteObject?.value))
     ..valueAsString = '${remoteObject?.value}';
 }
 
@@ -44,9 +43,7 @@ class InstanceHelper extends Domain {
       : super(provider);
 
   Future<Instance> _stringInstanceFor(RemoteObject remoteObject) async {
-
-    var actualString =
-         stringFromDartId(remoteObject.objectId);
+    var actualString = stringFromDartId(remoteObject.objectId);
     return Instance(
         kind: InstanceKind.kString,
         classRef: _classRefForString,
@@ -82,8 +79,8 @@ class InstanceHelper extends Domain {
     if (isStringId(remoteObject.objectId)) {
       return _stringInstanceFor(remoteObject);
     }
-    var metaData =
-        await ClassMetaData.metaDataFor(_remoteDebugger, remoteObject, inspector);
+    var metaData = await ClassMetaData.metaDataFor(
+        _remoteDebugger, remoteObject, inspector);
     if (metaData.name == 'Function') {
       return _closureInstanceFor(remoteObject);
     } else {
@@ -155,9 +152,9 @@ class InstanceHelper extends Domain {
     switch (remoteObject.type) {
       case 'string':
         return InstanceRef(
-           id: dartIdFor(remoteObject.value),
-          classRef: _classRefForString,
-          kind: InstanceKind.kString)
+            id: dartIdFor(remoteObject.value),
+            classRef: _classRefForString,
+            kind: InstanceKind.kString)
           ..valueAsString = remoteObject.value as String;
       case 'number':
         return _primitiveInstance(InstanceKind.kDouble, remoteObject);
@@ -169,8 +166,8 @@ class InstanceHelper extends Domain {
         if (remoteObject.type == 'object' && remoteObject.objectId == null) {
           return _primitiveInstance(InstanceKind.kNull, remoteObject);
         }
-        var metaData =
-            await ClassMetaData.metaDataFor(_remoteDebugger, remoteObject, inspector);
+        var metaData = await ClassMetaData.metaDataFor(
+            _remoteDebugger, remoteObject, inspector);
         if (metaData == null) return null;
         return InstanceRef(
             kind: InstanceKind.kPlainInstance,

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -140,7 +140,7 @@ class InstanceHelper extends Domain {
     }
     ''';
     var allNames = (await _debugger.inspector
-            .callFunctionOn(remoteObject, fieldNameExpression, []))
+            .jsCallFunctionOn(remoteObject, fieldNameExpression, []))
         .value as String;
     var names = allNames.split(',');
     return allJsProperties

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -2,12 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
+import 'package:dwds/src/utilities/domain.dart';
 import 'package:dwds/src/utilities/shared.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../utilities/objects.dart';
 import 'debugger.dart';
+import 'inspector.dart';
 import 'metadata.dart';
 import 'remote_debugger.dart';
 
@@ -19,6 +21,10 @@ import 'remote_debugger.dart';
 /// opaque, but are JSON serialized objects of the form
 /// "{\"injectedScriptId\":1,\"id\":1}".
 const _prefixForStringIds = '#StringInstanceRef#';
+
+const _prefixForIntIds = 'objects/int-';
+const _prefixForBoolIds = 'objects/bool-';
+const _nullId = 'objects/null';
 
 /// Creates an [InstanceRef] for a primitive [RemoteObject].
 InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
@@ -44,15 +50,56 @@ final _classRefForClosure = ClassRef()
   ..id = createId();
 
 /// Contains a set of methods for getting [Instance]s and [InstanceRef]s.
-class InstanceHelper {
+class InstanceHelper extends Domain {
   final Debugger _debugger;
   final RemoteDebugger _remoteDebugger;
 
-  InstanceHelper(this._debugger, this._remoteDebugger);
+  InstanceHelper(
+      this._debugger, this._remoteDebugger, AppInspector Function() provider)
+      : super(provider);
+
+  /// Create a Chrome reference from a Dart object Id.
+  ///
+  /// We expect Dart object Ids to be one of the following forms.
+  ///   * Chrome objectId - e.g. '{"injectedScriptId":1,"id":1}'
+  ///   * Our fabricated string Id - e.g. '#StringInstanceRef#actualString'
+  ///   * Dart fabricated IDs - e.g.  objects/int-8765
+  ///   * ##### NOT A Dart library URI
+  ///
+  /// We return either a RemoteObject or a serializable value.
+  Future<RemoteObject> remoteObjectFor(String dartId) async {
+    var data = <String, Object>{};
+    if (dartId.startsWith(_prefixForStringIds)) {
+      data['type'] = 'string';
+      data['value'] = _stringFromDartId(dartId);
+    } else if (dartId.startsWith(_prefixForIntIds)) {
+      data['type'] = 'number';
+      data['value'] = _intFromDartId(dartId);
+    } else if (dartId.startsWith(_prefixForBoolIds)) {
+      data['type'] = 'boolean';
+      data['value'] = dartId.endsWith('true');
+    } else if (dartId == _nullId) {
+      data['type'] = 'undefined';
+      data['value'] = null;
+    } else {
+      data['type'] = 'object';
+      data['objectId'] = dartId;
+    }
+    return RemoteObject(data);
+  }
+
+  Map<String, dynamic> remoteObjectMapFor(RemoteObject remote) {
+//    ###
+  }
+
+  String _stringFromDartId(String dartIdForString) =>
+      dartIdForString.substring(_prefixForStringIds.length);
+
+  int _intFromDartId(String dartIdForInt) =>
+      int.tryParse(dartIdForInt.substring(_prefixForIntIds.length));
 
   Future<Instance> _stringInstanceFor(RemoteObject remoteObject) async {
-    var actualString =
-        remoteObject.objectId.substring(_prefixForStringIds.length);
+    var actualString = _stringFromDartId(remoteObject.objectId);
     return Instance()
       ..kind = InstanceKind.kString
       ..classRef = _classRefForString

--- a/dwds/lib/src/debugging/metadata.dart
+++ b/dwds/lib/src/debugging/metadata.dart
@@ -6,7 +6,6 @@ import 'package:dwds/src/utilities/shared.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../services/chrome_proxy_service.dart';
-import '../debugging/inspector.dart';
  import 'remote_debugger.dart';
 
 /// Meta data for a remote Dart class in Chrome.

--- a/dwds/lib/src/debugging/metadata.dart
+++ b/dwds/lib/src/debugging/metadata.dart
@@ -6,7 +6,8 @@ import 'package:dwds/src/utilities/shared.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../services/chrome_proxy_service.dart';
-import 'remote_debugger.dart';
+import '../debugging/inspector.dart';
+ import 'remote_debugger.dart';
 
 /// Meta data for a remote Dart class in Chrome.
 class ClassMetaData {
@@ -38,8 +39,8 @@ class ClassMetaData {
       var arguments = [
         {'objectId': remoteObject.objectId}
       ];
-      var result =
-          await remoteDebugger.sendCommand('Runtime.callFunctionOn', params: {
+      // var result = inspector.callFunctionOn(remoteObject, evalExpression, arguments);
+      var result = await remoteDebugger.sendCommand('Runtime.callFunctionOn', params: {
         'functionDeclaration': evalExpression,
         'arguments': arguments,
         'objectId': remoteObject.objectId,

--- a/dwds/lib/src/debugging/metadata.dart
+++ b/dwds/lib/src/debugging/metadata.dart
@@ -24,8 +24,8 @@ class ClassMetaData {
   /// Returns the [ClassMetaData] for the Chrome [remoteObject].
   ///
   /// Returns null if the [remoteObject] is not a Dart class.
-  static Future<ClassMetaData> metaDataFor(
-      RemoteDebugger remoteDebugger, RemoteObject remoteObject, AppInspector inspector) async {
+  static Future<ClassMetaData> metaDataFor(RemoteDebugger remoteDebugger,
+      RemoteObject remoteObject, AppInspector inspector) async {
     try {
       var evalExpression = '''
       function(arg) {
@@ -37,10 +37,12 @@ class ClassMetaData {
         return result;
       }
     ''';
-      var result = await inspector.jsCallFunctionOn(remoteObject, evalExpression, [remoteObject], returnByValue: true);
+      var result = await inspector.jsCallFunctionOn(
+          remoteObject, evalExpression, [remoteObject],
+          returnByValue: true);
       var metadata = result.value as Map;
-      return ClassMetaData(metadata['name'] as String,
-          metadata['libraryId'] as String);
+      return ClassMetaData(
+          metadata['name'] as String, metadata['libraryId'] as String);
     } on ChromeDebugException {
       return null;
     }

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -110,15 +110,11 @@ class ChromeProxyService implements VmServiceInterface {
           'Cannot create multiple isolates for the same app');
     }
 
-    var instanceHelper = InstanceHelper(_debugger, remoteDebugger, appInspectorProvider);
+    var instanceHelper =
+        InstanceHelper(_debugger, remoteDebugger, appInspectorProvider);
 
     _inspector = await AppInspector.initialize(
-      remoteDebugger,
-      _assetHandler,
-      _debugger,
-      uri,
-      instanceHelper
-    );
+        remoteDebugger, _assetHandler, _debugger, uri, instanceHelper);
 
     var isolateRef = _inspector.isolateRef;
     var timestamp = DateTime.now().millisecondsSinceEpoch;
@@ -318,9 +314,8 @@ $loadModule("dart_sdk").developer.invokeExtension(
   Future invoke(
       String isolateId, String targetId, String selector, List argumentIds,
       {bool disableBreakpoints}) async {
-
-    
-    var remote = await _inspector?.invoke(isolateId, targetId, selector, argumentIds);
+    var remote =
+        await _inspector?.invoke(isolateId, targetId, selector, argumentIds);
     return _inspector?.instanceHelper?.instanceRefFor(remote);
   }
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -314,9 +314,18 @@ $loadModule("dart_sdk").developer.invokeExtension(
   Future invoke(
       String isolateId, String targetId, String selector, List argumentIds,
       {bool disableBreakpoints}) async {
+    if (disableBreakpoints != null) {
+      throw UnimplementedError(
+          'The "disableBreakpoints" parameter to "invoke" is not supported');
+    }
     var remote =
         await _inspector?.invoke(isolateId, targetId, selector, argumentIds);
-    return _inspector?.instanceHelper?.instanceRefFor(remote);
+    var result = _inspector?.instanceHelper?.instanceRefFor(remote);
+    if (result == null) {
+      throw ChromeDebugException(
+          {'text': 'null result from invoke of $selector'});
+    }
+    return result;
   }
 
   @override

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -313,8 +313,11 @@ $loadModule("dart_sdk").developer.invokeExtension(
   @override
   Future invoke(
       String isolateId, String targetId, String selector, List argumentIds,
-      {bool disableBreakpoints}) {
-    throw UnimplementedError();
+      {bool disableBreakpoints}) async {
+
+    
+    var remote = await _inspector?.invoke(isolateId, targetId, selector, argumentIds);
+    return _inspector?.instanceHelper?.instanceRefFor(remote);
   }
 
   @override

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dwds/src/debugging/instance.dart';
 import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
@@ -109,11 +110,14 @@ class ChromeProxyService implements VmServiceInterface {
           'Cannot create multiple isolates for the same app');
     }
 
+    var instanceHelper = InstanceHelper(_debugger, remoteDebugger, appInspectorProvider);
+
     _inspector = await AppInspector.initialize(
       remoteDebugger,
       _assetHandler,
       _debugger,
       uri,
+      instanceHelper
     );
 
     var isolateRef = _inspector.isolateRef;

--- a/dwds/lib/src/utilities/conversions.dart
+++ b/dwds/lib/src/utilities/conversions.dart
@@ -12,19 +12,22 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 /// be passed through the protocol directly.
 ///
 /// Note that this doesn't agree with the Chrome Protocol type CallArgument -
-/// it's just a Map corresponding to a RemoteObject.
+/// it's just a Map corresponding to a RemoteObject. But this seems to work
+/// consistently where the callArgument format doesn't, at least if we're 
+/// using the `arguments` pseudo-variable in JS instead of passing directly
+/// as real arguments.
 Map<String, Object> callArgumentFor(Object argument) {
   if (argument is RemoteObject) {
     return argument.objectId == null
-        ? _mapForPrimitive(argument.value)
-        : _mapForRemote(argument);
+        ? _callArgumentForPrimitive(argument.value)
+        : _callArgumentForRemote(argument);
   } else {
-    return _mapForPrimitive(argument);
+    return _callArgumentForPrimitive(argument);
   }
 }
 
 /// A List of Chrome RemoteObjects from Dart object Ids [dartIds].
-/// 
+///
 /// See [remoteObjectFor] for the accepted ID format.
 List<RemoteObject> remoteObjectsFor(Iterable<String> dartIds) {
   return dartIds.map(remoteObjectFor).toList();
@@ -129,12 +132,12 @@ bool isDoubleId(String dartId) => dartId.startsWith(_prefixForDoubleIds);
 bool isLibraryId(String dartId) => _uriPrefixes.any(dartId.startsWith);
 
 /// A Map representing a RemoteObject for a primitive object.
-Map<String, Object> _mapForPrimitive(Object primitive) {
+Map<String, Object> _callArgumentForPrimitive(Object primitive) {
   return {'type': _jsTypeOf(primitive), 'value': primitive};
 }
 
 /// A Map representing a RemoteObject from an actual RemoteObject.
-Map<String, Object> _mapForRemote(RemoteObject remote) {
+Map<String, Object> _callArgumentForRemote(RemoteObject remote) {
   return {'type': 'object', 'objectId': remote.objectId};
 }
 

--- a/dwds/lib/src/utilities/conversions.dart
+++ b/dwds/lib/src/utilities/conversions.dart
@@ -45,16 +45,16 @@ List<RemoteObject> remoteObjectsFor(Iterable<String> dartIds) {
 /// must be handled separately.
 RemoteObject remoteObjectFor(String dartId) {
   var data = <String, Object>{};
-  if (dartId.startsWith(_prefixForStringIds)) {
+  if (isStringId(dartId)) {
     data['type'] = 'string';
     data['value'] = _stringFromDartId(dartId);
-  } else if (dartId.startsWith(_prefixForDoubleIds)) {
+  } else if (isDoubleId(dartId)) {
     data['type'] = 'number';
     data['value'] = _doubleFromDartId(dartId);
-  } else if (dartId.startsWith(_prefixForIntIds)) {
+  } else if (isIntId(dartId)) {
     data['type'] = 'number';
     data['value'] = _intFromDartId(dartId);
-  } else if (dartId.startsWith(_prefixForBoolIds)) {
+  } else if (isBoolId(dartId)) {
     data['type'] = 'boolean';
     data['value'] = _boolFromDartId(dartId);
   } else if (dartId == _nullId) {

--- a/dwds/lib/src/utilities/conversions.dart
+++ b/dwds/lib/src/utilities/conversions.dart
@@ -1,0 +1,177 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Functions for converting between the different object references we use.
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+/// A Map representing a RemoteObject for a primitive object.
+Map<String, Object> _mapForPrimitive(Object primitive) {
+  return {'type': jsTypeOf(primitive), 'value': primitive};
+}
+
+/// A Map representing a RemoteObject from an actual RemoteObject.
+Map<String, Object> _mapForRemote(RemoteObject remote) {
+  return {'type': 'object', 'objectId': remote.objectId};
+}
+
+/// The JS type name to use in a RemoteObject reference to [object].
+String jsTypeOf(Object object) {
+  if (object == null) return 'undefined';
+  if (object is String) return 'string';
+  if (object is num) return 'num';
+  if (object is bool) return 'bool';
+  return 'object';
+}
+
+/// Convert [argument] to a form usable in WIP evaluation calls.
+///
+/// The [argument] should be either a RemoteObject or a simple
+/// object that can be passed through the protocol directly.
+Map<String, Object> mapForObject(Object argument) {
+  if (argument is RemoteObject) {
+    return argument.objectId == null
+        ? _mapForPrimitive(argument.value)
+        : _mapForRemote(argument);
+  } else {
+    return _mapForPrimitive(argument);
+  }
+}
+
+/// A Chrome RemoteObject from a Dart object Id.
+///
+/// We expect Dart object Ids to be one of the following forms.
+///   * Chrome objectId - e.g. '{"injectedScriptId":1,"id":1}'
+///   * Our fabricated string Id - e.g. '#StringInstanceRef#actualString'
+///   * Dart fabricated IDs - e.g.  objects/int-8765
+/// ##### NOT Library IDs Where are those handled?
+///
+/// We return either a RemoteObject or a serializable value.
+Future<RemoteObject> remoteObjectFor(String dartId) async {
+  var data = <String, Object>{};
+  if (dartId.startsWith(_prefixForStringIds)) {
+    data['type'] = 'string';
+    data['value'] = _stringFromDartId(dartId);
+  } else if (dartId.startsWith(_prefixForIntIds)) {
+    data['type'] = 'number';
+    data['value'] = _intFromDartId(dartId);
+  } else if (dartId.startsWith(_prefixForBoolIds)) {
+    data['type'] = 'boolean';
+    data['value'] = dartId.endsWith('true');
+  } else if (dartId == _nullId) {
+    data['type'] = 'undefined';
+    data['value'] = null;
+  } else {
+    data['type'] = 'object';
+    data['objectId'] = dartId;
+  }
+  return RemoteObject(data);
+}
+
+/// A dart object Id appropriate for [argument].
+///
+/// This will work for simple values, RemoteObject, and Maps 
+/// representing RemoteObjects.
+String dartIdFor(Object argument) {
+  if (argument == null) {
+    return '$_nullId';
+  }
+  if (argument is String) {
+    return '$_prefixForStringIds$argument';
+  }
+  if (argument is int) {
+    return '$_prefixForIntIds$argument';
+  }
+  if (argument is bool) {
+    return '$_prefixForBoolIds$argument';
+  }
+  if (argument is String) {
+    return '$_prefixForStringIds$argument';
+  }
+  if (argument is RemoteObject) {
+    return argument.objectId;
+  }
+  if (argument is Map<String, dynamic>) {
+    var id = argument['objectId'] as String;
+    if (id == null) {
+      throw ArgumentError.value(argument, 'objectId', 'No objectId found');
+    }
+    return id;
+  }
+  throw ArgumentError.value(argument, 'objectId', 'No objectId found');
+}
+
+/// Given a Dart object Id for a String, return the String.
+///
+/// If the ID is not for a String, throws ArgumentError. If you don't know what
+/// the ID represents, use a more general API like [remoteObjectFor] and if it
+/// is a primitive, you can get the value.
+String stringFromDartId(String dartId) {
+  if (!isStringId(dartId)) {
+    throw ArgumentError.value(
+        dartId, 'dart object ID', 'Expected a valid ID for a String');
+  }
+  return _stringFromDartId(dartId);
+}
+
+/// Given a Dart object Id for a boolean, return the boolean.
+///
+/// If the ID is not for a boolean, throws ArgumentError. If you don't know what
+/// the ID represents, use a more general API like [remoteObjectFor] and if it
+/// is a primitive, you can get the value.
+bool boolFromDartId(String dartId) {
+  if (!isBoolId(dartId)) {
+    throw ArgumentError.value(
+        dartId, 'dart object ID', 'Expected a valid ID for a boolean');
+  }
+  return _boolFromDartId(dartId);
+}
+
+/// Given a Dart object Id for an int, return the int.
+///
+/// If the ID is not for an int, throws ArgumentError. If you don't know what
+/// the ID represents, use a more general API like [remoteObjectFor] and if it
+/// is a primitive, you can get the value.
+int intFromDartId(String dartId) {
+  if (!isIntId(dartId)) {
+    throw ArgumentError.value(
+        dartId, 'dart object ID', 'Expected a valid ID for an int');
+  }
+  return _intFromDartId(dartId);
+}
+
+bool isStringId(String dartId) => dartId.startsWith(_prefixForStringIds);
+bool isBoolId(String dartId) => dartId.startsWith(_prefixForBoolIds);
+bool isIntId(String dartId) => dartId.startsWith(_prefixForIntIds);
+bool isLibraryId(String dartId) => _uriPrefixes.any(dartId.startsWith);
+
+/// Prefixes we use to identify if a Dart ID is a library URI.
+const _uriPrefixes = ['dart:', 'package:', 'org-dartlang-app:'];
+
+String _stringFromDartId(String dartIdForString) =>
+    dartIdForString.substring(_prefixForStringIds.length);
+
+int _intFromDartId(String dartIdForInt) =>
+    int.tryParse(dartIdForInt.substring(_prefixForIntIds.length));
+
+bool _boolFromDartId(String dartId) =>
+    dartId.substring(_prefixForIntIds.length) == 'true';
+
+/// Chrome doesn't give us an objectId for a String. So we use the string
+/// as its own ID, with a prefix.
+///
+/// This should not be confused with any
+/// other object Ids, as those will be Chrome objectIds, which are
+/// opaque, but are JSON serialized objects of the form
+/// "{\"injectedScriptId\":1,\"id\":1}".
+const _prefixForStringIds = '#StringInstanceRef#';
+
+/// The prefix the Dart VM uses for ints, followed by a string representation of
+/// the number.
+const _prefixForIntIds = 'objects/int-';
+
+/// The prefix the Dart VM uses for booleans, followed by 'true' or 'false'.
+const _prefixForBoolIds = 'objects/bool-';
+
+/// The object id the Dart VM uses for null.
+const _nullId = 'objects/null';

--- a/dwds/lib/src/utilities/conversions.dart
+++ b/dwds/lib/src/utilities/conversions.dart
@@ -13,7 +13,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 ///
 /// Note that this doesn't agree with the Chrome Protocol type CallArgument -
 /// it's just a Map corresponding to a RemoteObject. But this seems to work
-/// consistently where the callArgument format doesn't, at least if we're 
+/// consistently where the callArgument format doesn't, at least if we're
 /// using the `arguments` pseudo-variable in JS instead of passing directly
 /// as real arguments.
 Map<String, Object> callArgumentFor(Object argument) {

--- a/dwds/lib/src/utilities/conversions.dart
+++ b/dwds/lib/src/utilities/conversions.dart
@@ -54,13 +54,16 @@ Future<RemoteObject> remoteObjectFor(String dartId) async {
 }
 
 /// Convert a RemoteObject to a Chrome CallArgument.
-///  ###### Should this just replace mapFor???
+/// 
+/// Note that this returns the value if it's JS serializable, rather
+/// than wrapping it as described in the link below, because that's
+/// what seems to work.
+/// 
 /// https://chromedevtools.github.io/devtools-protocol/tot/Runtime#type-CallArgument
 Object callArgumentFor(RemoteObject remote) {
   if (remote == null) return null;
   if (remote.type == 'object') return { 'objectId' : remote.objectId};
   return remote.value;
-  //return {'value' :remote.value};
 }
 
 /// A dart object Id appropriate for [argument].

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -673,6 +673,8 @@ void main() {
             const TypeMatcher<InstanceRef>()
                 .having((instance) => instance.kind, 'kind', 'String'));
       });
+
+      // #### Test private.
     });
 
     test('kill', () {

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -623,9 +623,9 @@ void main() {
                 .having((instance) => instance.kind, 'kind', 'String'));
       });
 
-            test('null argument', () async {
-        var remote = await service.invoke(isolate.id, isolate.rootLib.id,
-            'helloString', ['objects/null']);
+      test('null argument', () async {
+        var remote = await service.invoke(
+            isolate.id, isolate.rootLib.id, 'helloString', ['objects/null']);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
@@ -637,8 +637,8 @@ void main() {
       });
 
       test('helloBool', () async {
-        var remote = await service.invoke(isolate.id, isolate.rootLib.id,
-            'helloBool', ['objects/bool-true']);
+        var remote = await service.invoke(
+            isolate.id, isolate.rootLib.id, 'helloBool', ['objects/bool-true']);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
@@ -649,9 +649,9 @@ void main() {
                 .having((instance) => instance.kind, 'kind', 'Bool'));
       });
 
-            test('helloNum', () async {
-        var remote = await service.invoke(isolate.id, isolate.rootLib.id,
-            'helloNum', ['objects/int-123']);
+      test('helloNum', () async {
+        var remote = await service.invoke(
+            isolate.id, isolate.rootLib.id, 'helloNum', ['objects/int-123']);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
@@ -662,14 +662,15 @@ void main() {
                 .having((instance) => instance.kind, 'kind', 'Double'));
       });
 
-
       test('two object arguments', () async {
         var remote = await service.invoke(isolate.id, isolate.rootLib.id,
             'messagesCombined', [testInstance.id, testInstance.id]);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
-                (instance) => instance.valueAsString, 'messagesCombined', 'worldworld'));
+                (instance) => instance.valueAsString,
+                'messagesCombined',
+                'worldworld'));
         expect(
             remote,
             const TypeMatcher<InstanceRef>()

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -663,7 +663,7 @@ void main() {
       });
 
 
-      test('two arguments', () async {
+      test('two object arguments', () async {
         var remote = await service.invoke(isolate.id, isolate.rootLib.id,
             'messagesCombined', [testInstance.id, testInstance.id]);
         expect(

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -576,9 +576,103 @@ void main() {
       expect(version.major, greaterThan(0));
     });
 
-    test('invoke', () {
-      expect(() => service.invoke(null, null, null, null),
-          throwsUnimplementedError);
+    group('invoke', () {
+      VM vm;
+      Isolate isolate;
+      InstanceRef testInstance;
+
+      setUp(() async {
+        vm = await service.getVM();
+        isolate = await service.getIsolate(vm.isolates.first.id);
+        testInstance = await service.evaluate(
+            isolate.id, isolate.rootLib.id, 'myInstance') as InstanceRef;
+      });
+
+      test('toString()', () async {
+        var remote =
+            await service.invoke(isolate.id, testInstance.id, 'toString', []);
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>().having(
+                (instance) => instance.valueAsString,
+                'toString()',
+                "Instance of 'MyTestClass'"));
+      });
+
+      test('hello()', () async {
+        var remote =
+            await service.invoke(isolate.id, testInstance.id, 'hello', []);
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>().having(
+                (instance) => instance.valueAsString, 'hello()', 'world'));
+      });
+
+      test('helloString', () async {
+        var remote = await service.invoke(isolate.id, isolate.rootLib.id,
+            'helloString', ['#StringInstanceRef#abc']);
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>().having(
+                (instance) => instance.valueAsString, 'helloString', 'abc'));
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>()
+                .having((instance) => instance.kind, 'kind', 'String'));
+      });
+
+            test('null argument', () async {
+        var remote = await service.invoke(isolate.id, isolate.rootLib.id,
+            'helloString', ['objects/null']);
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>().having(
+                (instance) => instance.valueAsString, 'helloString', 'null'));
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>()
+                .having((instance) => instance.kind, 'kind', 'Null'));
+      });
+
+      test('helloBool', () async {
+        var remote = await service.invoke(isolate.id, isolate.rootLib.id,
+            'helloBool', ['objects/bool-true']);
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>().having(
+                (instance) => instance.valueAsString, 'helloBool', 'true'));
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>()
+                .having((instance) => instance.kind, 'kind', 'Bool'));
+      });
+
+            test('helloNum', () async {
+        var remote = await service.invoke(isolate.id, isolate.rootLib.id,
+            'helloNum', ['objects/int-123']);
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>().having(
+                (instance) => instance.valueAsString, 'helloNum', '123'));
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>()
+                .having((instance) => instance.kind, 'kind', 'Double'));
+      });
+
+
+      test('two arguments', () async {
+        var remote = await service.invoke(isolate.id, isolate.rootLib.id,
+            'messagesCombined', [testInstance.id, testInstance.id]);
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>().having(
+                (instance) => instance.valueAsString, 'messagesCombined', 'worldworld'));
+        expect(
+            remote,
+            const TypeMatcher<InstanceRef>()
+                .having((instance) => instance.kind, 'kind', 'String'));
+      });
     });
 
     test('kill', () {

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -675,8 +675,6 @@ void main() {
             const TypeMatcher<InstanceRef>()
                 .having((instance) => instance.kind, 'kind', 'String'));
       });
-
-      // #### Test private.
     });
 
     test('kill', () {

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -55,10 +55,19 @@ class FakeInspector extends Domain implements AppInspector {
       throw UnsupportedError('This is a fake');
   @override
   Debugger get debugger => throw UnsupportedError('This is a fake');
+
   @override
   Future<RemoteObject> callJsFunctionOn(
-          Library library, Map<String, String> scope, String expression) =>
-      null;
+      Library library, String expression, List<RemoteObject> arguments) {
+    throw UnsupportedError('This is a fake');
+  }
+
+  @override
+  Future<RemoteObject> evaluateWithJsScope(
+      Library library, Map<String, String> scope, String expression) {
+    throw UnsupportedError('This is a fake');
+  }
+
   @override
   Future<RemoteObject> evaluateJsExpression(String expression) =>
       throw UnsupportedError('This is a fake');
@@ -74,11 +83,12 @@ class FakeInspector extends Domain implements AppInspector {
       RemoteObject receiver, String evalExpression, List arguments) {
     throw UnsupportedError('This is a fake');
   }
+
   @override
-  Future<RemoteObject> invoke(String isolateId, String targetId, String selector, List arguments) {
+  Future<RemoteObject> invoke(
+      String isolateId, String targetId, String selector, List arguments) {
     throw UnsupportedError('This is a fake');
   }
-
 }
 
 class FakeSseConnection implements SseConnection {

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -63,7 +63,7 @@ class FakeInspector extends Domain implements AppInspector {
   }
 
   @override
-  Future<RemoteObject> evaluateWithJsScope(
+  Future<RemoteObject> evaluateWithScope(
       Library library, Map<String, String> scope, String expression) {
     throw UnsupportedError('This is a fake');
   }

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -28,6 +28,7 @@ class FakeInspector extends Domain implements AppInspector {
   Object noSuchMethod(Invocation invocation) {
     throw UnsupportedError('This is a fake');
   }
+
   @override
   Future<RemoteObject> evaluate(
           String isolateId, String targetId, String expression,

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:async/src/stream_sink_transformer.dart';
-import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/debugging/instance.dart';
 import 'package:dwds/src/debugging/webkit_debugger.dart';

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -52,42 +52,7 @@ class FakeInspector extends Domain implements AppInspector {
   @override
   IsolateRef get isolateRef => null;
   @override
-  Future<RemoteObject> loadField(RemoteObject receiver, String fieldName) =>
-      throw UnsupportedError('This is a fake');
-  @override
-  Future<RemoteObject> invokeMethod(RemoteObject receiver, String methodName,
-          [List positionalArgs = const [], Map namedArgs = const {}]) =>
-      throw UnsupportedError('This is a fake');
-  @override
-  Debugger get debugger => throw UnsupportedError('This is a fake');
-
-  @override
-  Future<RemoteObject> evaluateInLibrary(
-      Library library, Map<String, String> scope, String expression) {
-    throw UnsupportedError('This is a fake');
-  }
-
-  @override
-  Future<RemoteObject> jsEvaluate(String expression) =>
-      throw UnsupportedError('This is a fake');
-  @override
-  Future<RemoteObject> evaluateJsExpressionOnLibrary(
-          String expression, String libraryUri) =>
-      throw UnsupportedError('This is a fake');
-
-  @override
   InstanceHelper get instanceHelper => InstanceHelper(null, null, null);
-  @override
-  Future<RemoteObject> jsCallFunctionOn(
-      RemoteObject receiver, String evalExpression, List arguments) {
-    throw UnsupportedError('This is a fake');
-  }
-
-  @override
-  Future<RemoteObject> invoke(
-      String isolateId, String targetId, String selector, List arguments) {
-    throw UnsupportedError('This is a fake');
-  }
 }
 
 class FakeSseConnection implements SseConnection {

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -23,6 +23,11 @@ import 'debugger_data.dart';
 
 class FakeInspector extends Domain implements AppInspector {
   FakeInspector() : super.forInspector();
+
+  @override
+  Object noSuchMethod(Invocation invocation) {
+    throw UnsupportedError('This is a fake');
+  }
   @override
   Future<RemoteObject> evaluate(
           String isolateId, String targetId, String expression,
@@ -50,26 +55,20 @@ class FakeInspector extends Domain implements AppInspector {
   Future<RemoteObject> loadField(RemoteObject receiver, String fieldName) =>
       throw UnsupportedError('This is a fake');
   @override
-  Future<RemoteObject> sendMessage(RemoteObject receiver, String methodName,
+  Future<RemoteObject> invokeMethod(RemoteObject receiver, String methodName,
           [List positionalArgs = const [], Map namedArgs = const {}]) =>
       throw UnsupportedError('This is a fake');
   @override
   Debugger get debugger => throw UnsupportedError('This is a fake');
 
   @override
-  Future<RemoteObject> callJsFunctionOn(
-      Library library, String expression, List<RemoteObject> arguments) {
-    throw UnsupportedError('This is a fake');
-  }
-
-  @override
-  Future<RemoteObject> evaluateWithScope(
+  Future<RemoteObject> evaluateInLibrary(
       Library library, Map<String, String> scope, String expression) {
     throw UnsupportedError('This is a fake');
   }
 
   @override
-  Future<RemoteObject> evaluateJsExpression(String expression) =>
+  Future<RemoteObject> jsEvaluate(String expression) =>
       throw UnsupportedError('This is a fake');
   @override
   Future<RemoteObject> evaluateJsExpressionOnLibrary(
@@ -79,7 +78,7 @@ class FakeInspector extends Domain implements AppInspector {
   @override
   InstanceHelper get instanceHelper => InstanceHelper(null, null, null);
   @override
-  Future<RemoteObject> callFunctionOn(
+  Future<RemoteObject> jsCallFunctionOn(
       RemoteObject receiver, String evalExpression, List arguments) {
     throw UnsupportedError('This is a fake');
   }

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -68,12 +68,17 @@ class FakeInspector extends Domain implements AppInspector {
       throw UnsupportedError('This is a fake');
 
   @override
-  InstanceHelper get instanceHelper => InstanceHelper(null, null);
+  InstanceHelper get instanceHelper => InstanceHelper(null, null, null);
   @override
   Future<RemoteObject> callFunctionOn(
       RemoteObject receiver, String evalExpression, List arguments) {
     throw UnsupportedError('This is a fake');
   }
+  @override
+  Future<RemoteObject> invoke(String isolateId, String targetId, String selector, List arguments) {
+    throw UnsupportedError('This is a fake');
+  }
+
 }
 
 class FakeSseConnection implements SseConnection {

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -4,6 +4,7 @@
 
 @TestOn('vm')
 import 'package:dwds/src/connections/debug_connection.dart';
+import 'package:dwds/src/utilities/conversions.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/utilities/shared.dart';
 import 'package:test/test.dart';
@@ -76,4 +77,32 @@ void main() {
     names.sort();
     expect(names, expected);
   });
+
+  // We test these here because the test fixture has private members.
+  test('invoke top-level private', () async {
+    var remote = await inspector.invoke(
+        inspector.isolate.id,
+        inspector.isolate.rootLib.id,
+        '_libraryPrivateFunction',
+        [dartIdFor(2), dartIdFor(3)]);
+    expect(
+        remote,
+        const TypeMatcher<RemoteObject>()
+            .having((instance) => instance.value, 'result', 5));
+  });
+
+  test('invoke instance private', () async {
+    // We test these here because the test fixture has private members.
+    var instance = await inspector.evaluate(inspector.isolate.id,
+        inspector.isolate.rootLib.id, 'libraryPublicFinal');
+
+    var remote = await inspector.invoke(inspector.isolate.id, instance.objectId,
+        'privateMethod', [dartIdFor('some string')]);
+    expect(
+        remote,
+        const TypeMatcher<RemoteObject>().having((instance) => instance.value,
+            'result', 'some string : a private field'));
+  });
+
+  // #### You also need to test with an object argument
 }

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -119,10 +119,11 @@ void main() {
           const TypeMatcher<RemoteObject>()
               .having((instance) => instance.value, 'result', true));
     });
-        test('invoke instance method with object parameter 2', () async {
-      var libraryPrivateList = await inspector.evaluate(isolateId, libraryId, '_libraryPrivate');
-      var remote = await inspector
-          .invoke(isolateId, instance.objectId, 'equals', [libraryPrivateList.objectId]);
+    test('invoke instance method with object parameter 2', () async {
+      var libraryPrivateList =
+          await inspector.evaluate(isolateId, libraryId, '_libraryPrivate');
+      var remote = await inspector.invoke(isolateId, instance.objectId,
+          'equals', [libraryPrivateList.objectId]);
       expect(
           remote,
           const TypeMatcher<RemoteObject>()

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -38,11 +38,11 @@ void main() {
       '$loadModule("dart_sdk").dart.getModuleLibraries("web/scopes_main")["$url"]["$variable"];';
 
   Future<RemoteObject> libraryPublicFinal() => inspector
-      .evaluateJsExpression(libraryVariableExpression('libraryPublicFinal'));
+      .jsEvaluate(libraryVariableExpression('libraryPublicFinal'));
 
   test('send toString', () async {
     var remoteObject = await libraryPublicFinal();
-    var toString = await inspector.sendMessage(remoteObject, 'toString', []);
+    var toString = await inspector.invokeMethod(remoteObject, 'toString', []);
     expect(toString.value, 'A test class with message world');
   });
 

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -72,7 +72,8 @@ void main() {
       'count',
       'message',
       'myselfField',
-      'notFinal'
+      'notFinal',
+      'tornOff',
     ];
     names.sort();
     expect(names, expected);
@@ -128,6 +129,25 @@ void main() {
           remote,
           const TypeMatcher<RemoteObject>()
               .having((instance) => instance.value, 'result', false));
+    });
+
+    test('invoke closure stored in an instance field', () async {
+      var remote =
+          await inspector.invoke(isolateId, instance.objectId, 'closure', []);
+      expect(
+          remote,
+          const TypeMatcher<RemoteObject>()
+              .having((instance) => instance.value, 'result', null));
+    });
+
+    test('invoke a torn-off method', () async {
+      var toString = await inspector.loadField(instance, 'tornOff');
+      var result =
+          await inspector.invoke(isolateId, toString.objectId, 'call', []);
+      expect(
+          result,
+          const TypeMatcher<RemoteObject>().having((instance) => instance.value,
+              'toString', 'A test class with message world'));
     });
   });
 }

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -31,7 +31,8 @@ void main() {
     inspector = chromeProxyService.appInspectorProvider();
     remoteDebugger = chromeProxyService.remoteDebugger;
     debugger = inspector.debugger;
-    instanceHelper = InstanceHelper(debugger, remoteDebugger, chromeProxyService.appInspectorProvider);
+    instanceHelper = InstanceHelper(
+        debugger, remoteDebugger, chromeProxyService.appInspectorProvider);
   });
 
   tearDownAll(() async {
@@ -44,8 +45,8 @@ void main() {
       '$loadModule("dart_sdk").dart.getModuleLibraries("web/scopes_main")'
       '["$url"]["$variable"];';
 
-  Future<RemoteObject> libraryPublicFinal() => inspector
-      .jsEvaluate(libraryVariableExpression('libraryPublicFinal'));
+  Future<RemoteObject> libraryPublicFinal() =>
+      inspector.jsEvaluate(libraryVariableExpression('libraryPublicFinal'));
 
   group('instanceRef', () {
     test('for a null', () async {

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -108,7 +108,8 @@ void main() {
         'count',
         'message',
         'myselfField',
-        'notFinal'
+        'notFinal',
+        'tornOff',
       ]);
       for (var field in instance.fields) {
         expect(field.decl.declaredType, isNotNull);

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -45,7 +45,7 @@ void main() {
       '["$url"]["$variable"];';
 
   Future<RemoteObject> libraryPublicFinal() => inspector
-      .evaluateJsExpression(libraryVariableExpression('libraryPublicFinal'));
+      .jsEvaluate(libraryVariableExpression('libraryPublicFinal'));
 
   group('instanceRef', () {
     test('for a null', () async {

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -31,7 +31,7 @@ void main() {
     inspector = chromeProxyService.appInspectorProvider();
     remoteDebugger = chromeProxyService.remoteDebugger;
     debugger = inspector.debugger;
-    instanceHelper = InstanceHelper(debugger, remoteDebugger);
+    instanceHelper = InstanceHelper(debugger, remoteDebugger, chromeProxyService.appInspectorProvider);
   });
 
   tearDownAll(() async {

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -81,7 +81,7 @@ void main() {
     });
 
     test('variables in closure nested in method', () async {
-      stack = await breakAt(78);
+      stack = await breakAt(80);
       var frame = stack.frames.first;
       var variableNames = frame.vars.map((variable) => variable.name).toList()
         ..sort();
@@ -90,7 +90,7 @@ void main() {
     });
 
     test('variables in method', () async {
-      stack = await breakAt(92);
+      stack = await breakAt(94);
       var frame = stack.frames.first;
       var variableNames = frame.vars.map((variable) => variable.name).toList()
         ..sort();

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -93,8 +93,10 @@ class MyTestClass {
     libraryFunction('abc');
   }
 
-  // ignore: unused_field
   final _privateField = 'a private field';
+
+  // ignore: unused_element
+  String privateMethod(String s) => '$s : $_privateField';
 
   @override
   String toString() => 'A test class with message $message';
@@ -103,3 +105,6 @@ class MyTestClass {
 }
 
 Function someFunction() => null;
+
+// ignore: unused_element
+int _libraryPrivateFunction(int a, int b) => a + b;

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -65,6 +65,7 @@ class MyTestClass {
 
   MyTestClass({this.message = 'world'}) {
     myselfField = this;
+    tornOff = toString;
   }
 
   String hello() => message;
@@ -107,6 +108,8 @@ class MyTestClass {
   }
 
   Function closure = someFunction;
+
+  String Function() tornOff;
 }
 
 Function someFunction() => null;

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -105,7 +105,7 @@ class MyTestClass {
     if (other is MyTestClass) return message == other.hello();
     return false;
   }
-  
+
   Function closure = someFunction;
 }
 

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -101,6 +101,11 @@ class MyTestClass {
   @override
   String toString() => 'A test class with message $message';
 
+  bool equals(Object other) {
+    if (other is MyTestClass) return message == other.hello();
+    return false;
+  }
+  
   Function closure = someFunction;
 }
 


### PR DESCRIPTION
This ended up being a fairly substantial refactoring as well 

- Made InstanceHelper into a domain. 
- Renamed lots of the methods doing calls/evals to try to be more consistent and to make fewer direct calls to the Chrome APIs. So invoke splits into invokeMethod and invokeFunction, and direct calls to Chrome APIs are prefixed with "js" and named like what they call, e.g. jsCallFunctionOn.
- Added a noSuchMethod handler to FakeInspector so anything that just throws can be omitted.
- Created a conversions library for converting back and forth between the different representations we're using.
- Because JavaScript, there's something strange going on with how we pass arguments in callFunctionOn that expects them differently if we try to pass an array of the positional arguments (what we did before) vs. using the arguments pseudo-variable. The second one seems to work better, so doing that for both function and method invokes now.
- Added support for the Dart VM special objectIds for primitives 
- Simplified getLibrarySnippet
- Implemented invoke

Fixes: #591