### PR TITLE
Roll dwds and webdev to vm_service 1.2.0

### DIFF
--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -53,21 +53,22 @@ class InstanceHelper extends Domain {
   }
 
   Future<Instance> _closureInstanceFor(RemoteObject remoteObject) async {
-    var functionMetaData =
-        await FunctionMetaData.metaDataFor(_remoteDebugger, remoteObject);
+    // var functionMetaData =
+    //     await FunctionMetaData.metaDataFor(_remoteDebugger, remoteObject);
     var result = Instance(
         kind: InstanceKind.kClosure,
         id: remoteObject.objectId,
-        classRef: _classRefForClosure)
-      ..closureFunction = (FuncRef(
-          name: functionMetaData.name,
-          id: createId(),
-          // TODO(grouma) - fill these in properly.
-          owner: null,
-          isConst: false,
-          isStatic: false))
-      // TODO(grouma) - construct a valid context.
-      ..closureContext = (ContextRef()..length = 0);
+        classRef: _classRefForClosure);
+      // TODO: These are only part of instanceRef in the new version of vmservice.
+      // ..closureFunction = (FuncRef(
+      //     name: functionMetaData.name,
+      //     id: createId(),
+      //     // TODO(grouma) - fill these in properly.
+      //     owner: null,
+      //     isConst: false,
+      //     isStatic: false))
+      // // TODO(grouma) - construct a valid context.
+      // ..closureContext = (ContextRef()..length = 0);
     return result;
   }
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -563,6 +563,16 @@ $loadModule("dart_sdk").developer.invokeExtension(
   Future<Success> requestHeapSnapshot(String isolateId) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<Success> clearCpuSamples(String isolateId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<CpuSamples> getCpuSamples(String isolateId, int timeOriginMicros, int timeExtentMicros) {
+    throw UnimplementedError();
+  }
 }
 
 /// The `type`s of [ConsoleAPIEvent]s that are treated as `stderr` logs.

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.6.0
+version: 0.6.1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
@@ -28,7 +28,7 @@ dependencies:
   shelf_web_socket: ^0.2.0
   source_maps: ^0.10.0
   sse: ^2.0.2
-  vm_service: 1.1.1
+  vm_service: ^1.2.0
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: '>=0.4.0 <0.6.0'
 

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.5.1
+version: 2.5.2
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-
@@ -15,7 +15,8 @@ dependencies:
   async: ^2.2.0
   build_daemon: ^2.0.0
   crypto: ^2.0.6
-  dwds: ^0.6.0
+  dwds:
+    path: ../dwds
   http: ^0.12.0
   http_multi_server: ^2.1.0
   io: ^0.3.2+1
@@ -29,7 +30,7 @@ dependencies:
   shelf_proxy: ^0.1.0+5
   shelf_static: ^0.2.8
   sse: ^2.0.0
-  vm_service: ^1.1.0
+  vm_service: ^1.2.0
   webkit_inspection_protocol: '>=0.4.0 <0.6.0'
   yaml: ^2.1.13
 


### PR DESCRIPTION
Not ready to merge as-is: see TODOs in instance.dart.

These are the issues with making it run on 1.2.0

cc @grouma 