### PR TITLE
Expose AssetHandler

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.7.0-dev
+
+- `DWDS.start` now requires an `AssetHandler` instead of `applicationPort`,
+  `assetServerPort` and `applicationTarget`.
+- Expose a `BuildRunnerAssetHandler` which proxies request to the asset server
+  running within build runner.
+
 ## 0.6.2
 
 - Capture any errors that happen when handling SSE requests in the DevHandler

--- a/dwds/lib/asset_handler.dart
+++ b/dwds/lib/asset_handler.dart
@@ -8,8 +8,6 @@ import 'package:shelf/shelf.dart';
 import 'package:shelf_proxy/shelf_proxy.dart';
 
 /// A handler for a build target's assets.
-///
-/// Proxies requests to the build daemon asset server.
 abstract class AssetHandler {
   Handler get handler;
 

--- a/dwds/lib/asset_handler.dart
+++ b/dwds/lib/asset_handler.dart
@@ -10,7 +10,20 @@ import 'package:shelf_proxy/shelf_proxy.dart';
 /// A handler for a build target's assets.
 ///
 /// Proxies requests to the build daemon asset server.
-class AssetHandler {
+abstract class AssetHandler {
+  Handler get handler;
+
+  /// Returns the asset from a relative [path].
+  ///
+  /// For example the path `main.dart` should return the raw text value of that
+  /// corresponding file.
+  Future<Response> getRelativeAsset(String path);
+}
+
+/// A handler for a build target's assets.
+///
+/// Proxies requests to the build runner's asset server.
+class BuildRunnerAssetHandler implements AssetHandler {
   final int _assetServerPort;
   final String _target;
   final int _applicationPort;
@@ -18,16 +31,14 @@ class AssetHandler {
 
   Handler _handler;
 
-  AssetHandler(this._assetServerPort, this._target, this._applicationHost,
-      this._applicationPort);
+  BuildRunnerAssetHandler(this._assetServerPort, this._target,
+      this._applicationHost, this._applicationPort);
 
+  @override
   Handler get handler =>
       _handler ??= proxyHandler('http://localhost:$_assetServerPort/$_target/');
 
-  /// Returns the asset from a relative [path].
-  ///
-  /// For example the path `main.dart` should return the raw text value of that
-  /// corresponding file.
+  @override
   Future<Response> getRelativeAsset(String path) async => handler(Request(
       'GET', Uri.parse('http://$_applicationHost:$_applicationPort/$path')));
 }

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -11,9 +11,9 @@ import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import 'asset_handler.dart';
 import 'src/connections/app_connection.dart';
 import 'src/connections/debug_connection.dart';
-import 'src/handlers/asset_handler.dart';
 import 'src/handlers/dev_handler.dart';
 import 'src/handlers/injected_handler.dart';
 import 'src/servers/devtools.dart';
@@ -54,9 +54,7 @@ class Dwds {
   }
 
   static Future<Dwds> start({
-    @required int applicationPort,
-    @required int assetServerPort,
-    @required String applicationTarget,
+    @required AssetHandler assetHandler,
     @required Stream<BuildResult> buildResults,
     @required ConnectionProvider chromeConnection,
     @required bool enableDebugging,
@@ -78,12 +76,7 @@ class Dwds {
     logWriter ??= (level, message) => print(message);
     verbose ??= false;
     globalModuleStrategy = moduleStrategy ?? ModuleStrategy.requireJS;
-    var assetHandler = AssetHandler(
-      assetServerPort,
-      applicationTarget,
-      hostname,
-      applicationPort,
-    );
+
     var cascade = Cascade();
     var pipeline = const Pipeline();
 

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../../asset_handler.dart';
 import '../../dwds.dart' show LogWriter;
-import '../handlers/asset_handler.dart';
 import '../services/chrome_proxy_service.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/domain.dart';

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -8,7 +8,7 @@ import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:path/path.dart' as p;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import '../handlers/asset_handler.dart';
+import '../../asset_handler.dart';
 import '../services/chrome_proxy_service.dart';
 import '../utilities/conversions.dart';
 import '../utilities/dart_uri.dart';

--- a/dwds/lib/src/debugging/sources.dart
+++ b/dwds/lib/src/debugging/sources.dart
@@ -11,8 +11,8 @@ import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../../asset_handler.dart';
 import '../../dwds.dart' show LogWriter;
-import '../handlers/asset_handler.dart';
 import '../utilities/dart_uri.dart';
 import 'location.dart';
 import 'remote_debugger.dart';

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -19,13 +19,13 @@ import 'package:shelf/shelf.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../../asset_handler.dart';
 import '../../data/connect_request.dart';
 import '../../data/devtools_request.dart';
 import '../../data/isolate_events.dart';
 import '../../data/serializers.dart';
 import '../connections/app_connection.dart';
 import '../dwds_vm_client.dart';
-import '../handlers/asset_handler.dart';
 import '../servers/devtools.dart';
 import '../services/app_debug_services.dart';
 import '../services/debug_service.dart';

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -10,11 +10,11 @@ import 'package:dwds/src/debugging/instance.dart';
 import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../../asset_handler.dart';
 import '../../dwds.dart' show LogWriter;
 import '../debugging/debugger.dart';
 import '../debugging/inspector.dart';
 import '../debugging/remote_debugger.dart';
-import '../handlers/asset_handler.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -19,7 +19,7 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
-import '../handlers/asset_handler.dart';
+import '../../asset_handler.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
 import 'chrome_proxy_service.dart';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.6.2
+version: 0.7.0-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-

--- a/dwds/test/debugging/sources_test.dart
+++ b/dwds/test/debugging/sources_test.dart
@@ -2,13 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dwds/asset_handler.dart';
+import 'package:dwds/src/debugging/sources.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import 'package:dwds/src/debugging/sources.dart';
-import 'package:dwds/src/handlers/asset_handler.dart';
 
 void main() {
   test('Gracefully handles missing source maps', () async {

--- a/dwds/test/fixtures/server.dart
+++ b/dwds/test/fixtures/server.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:build_daemon/data/build_status.dart';
+import 'package:dwds/asset_handler.dart';
 import 'package:dwds/dwds.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:shelf/shelf.dart';
@@ -58,9 +59,8 @@ class TestServer {
         results.results.firstWhere((result) => result.target == target));
 
     var dwds = await Dwds.start(
-      applicationPort: port,
-      applicationTarget: target,
-      assetServerPort: assetServerPort,
+      assetHandler:
+          BuildRunnerAssetHandler(assetServerPort, target, 'localhost', port),
       buildResults: filteredBuildResults,
       chromeConnection: chromeConnection,
       logWriter: (level, message) => printOnFailure(message),

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.2-dev
+
+- Depend on the latest `package:dwds`.
+
 ## 2.5.1
 
 - Depend on the latest `package:dwds`.

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:build_daemon/data/build_status.dart';
+import 'package:dwds/asset_handler.dart';
 import 'package:dwds/dwds.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:shelf/shelf.dart';
@@ -87,9 +88,12 @@ class WebDevServer {
     if (options.configuration.enableInjectedClient) {
       dwds = await Dwds.start(
         hostname: options.configuration.hostname,
-        applicationPort: options.port,
-        applicationTarget: options.target,
-        assetServerPort: options.daemonPort,
+        assetHandler: BuildRunnerAssetHandler(
+          options.daemonPort,
+          options.target,
+          options.configuration.hostname,
+          options.port,
+        ),
         buildResults: filteredBuildResults,
         chromeConnection: () async =>
             (await Chrome.connectedInstance).chromeConnection,

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.5.1';
+const packageVersion = '2.5.2-dev';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.5.1
+version: 2.5.2-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-
@@ -15,7 +15,7 @@ dependencies:
   async: ^2.2.0
   build_daemon: ^2.0.0
   crypto: ^2.0.6
-  dwds: ^0.6.0
+  dwds: ^0.7.0
   http: ^0.12.0
   http_multi_server: ^2.1.0
   io: ^0.3.2+1


### PR DESCRIPTION
- Expose `AssetHandler` abstraction
- Also provide a default implementation for external users
- Update `Dwds.start` to now take a required `AssetHandler`
