### PR TITLE
make all close methods handle being called multiple times

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.1-dev
+
+- Make all `close` methods more robust by allowing them to be called more than
+  once and returning the cached future from previous calls.
+
 ## 0.7.0
 
 - `DWDS.start` now requires an `AssetHandler` instead of `applicationPort`,

--- a/dwds/lib/src/debugging/webkit_debugger.dart
+++ b/dwds/lib/src/debugging/webkit_debugger.dart
@@ -9,6 +9,11 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 class WebkitDebugger implements RemoteDebugger {
   final WipDebugger _wipDebugger;
 
+  /// Null until [close] is called.
+  ///
+  /// All subsequent calls to [close] will return this future.
+  Future<void> _closed;
+
   WebkitDebugger(this._wipDebugger);
 
   @override
@@ -25,7 +30,7 @@ class WebkitDebugger implements RemoteDebugger {
       _wipDebugger.sendCommand(command, params: params);
 
   @override
-  void close() => _wipDebugger.connection.close();
+  void close() => _closed ??= _wipDebugger.connection.close();
 
   @override
   Future<void> disable() => _wipDebugger.disable();

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -17,13 +17,18 @@ class DwdsVmClient {
   final StreamController<Map<String, Object>> _requestController;
   final StreamController<Map<String, Object>> _responseController;
 
+  /// Null until [close] is called.
+  ///
+  /// All subsequent calls to [close] will return this future.
+  Future<void> _closed;
+
   DwdsVmClient(this.client, this._requestController, this._responseController);
 
-  Future<void> close() async {
-    await _requestController.close();
-    await _responseController.close();
-    client.dispose();
-  }
+  Future<void> close() => _closed ??= () async {
+        await _requestController.close();
+        await _responseController.close();
+        client.dispose();
+      }();
 
   static Future<DwdsVmClient> create(DebugService debugService) async {
     // Set up hot restart as an extension.

--- a/dwds/lib/src/servers/devtools.dart
+++ b/dwds/lib/src/servers/devtools.dart
@@ -13,11 +13,14 @@ class DevTools {
   final int port;
   final HttpServer _server;
 
+  /// Null until [close] is called.
+  ///
+  /// All subsequent calls to [close] will return this future.
+  Future<void> _closed;
+
   DevTools._(this.hostname, this.port, this._server);
 
-  Future<void> close() async {
-    await _server.close();
-  }
+  Future<void> close() => _closed ??= _server.close();
 
   static Future<DevTools> start(String hostname) async {
     var server =

--- a/dwds/lib/src/servers/extension_backend.dart
+++ b/dwds/lib/src/servers/extension_backend.dart
@@ -21,6 +21,12 @@ class ExtensionBackend {
   final String hostname;
   final int port;
   final HttpServer _server;
+
+  /// Null until [close] is called.
+  ///
+  /// All subsequent calls to [close] will return this future.
+  Future<void> _closed;
+
   ExtensionBackend._(this.hostname, this.port, this._server);
 
   // Starts the backend on an open port.
@@ -30,7 +36,7 @@ class ExtensionBackend {
     return ExtensionBackend._(server.address.host, server.port, server);
   }
 
-  Future<void> close() async => await _server.close();
+  Future<void> close() => _closed ??= _server.close();
 
   StreamQueue<SseConnection> connections = _sseHandler.connections;
 

--- a/dwds/lib/src/services/app_debug_services.dart
+++ b/dwds/lib/src/services/app_debug_services.dart
@@ -16,6 +16,11 @@ class AppDebugServices {
   ChromeProxyService get chromeProxyService =>
       debugService.chromeProxyService as ChromeProxyService;
 
+  /// Null until [close] is called.
+  ///
+  /// All subsequent calls to [close] will return this future.
+  Future<void> _closed;
+
   /// The instance ID for the currently connected application, if there is one.
   ///
   /// We only allow a given app to be debugged in a single tab at a time.
@@ -24,5 +29,5 @@ class AppDebugServices {
   AppDebugServices(this.debugService, this.dwdsVmClient);
 
   Future<void> close() =>
-      Future.wait([debugService.close(), dwdsVmClient.close()]);
+      _closed ??= Future.wait([debugService.close(), dwdsVmClient.close()]);
 }

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -95,6 +95,11 @@ class DebugService {
   final String _authToken;
   final bool _useSse;
 
+  /// Null until [close] is called.
+  ///
+  /// All subsequent calls to [close] will return this future.
+  Future<void> _closed;
+
   DebugService._(
       this.chromeProxyService,
       this.hostname,
@@ -104,9 +109,7 @@ class DebugService {
       this._server,
       this._useSse);
 
-  Future<void> close() async {
-    await _server.close();
-  }
+  Future<void> close() => _closed ??= _server.close();
 
   String get uri => _useSse
       ? Uri(

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.7.0
+version: 0.7.1-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -175,9 +175,7 @@ class FakeWebkitDebugger implements WebkitDebugger {
   Stream<ExceptionThrownEvent> get onExceptionThrown => null;
 
   @override
-  void close() {
-    return;
-  }
+  void close() {}
 
   @override
   Stream<WipConnection> get onClose => null;


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/701.

Use a common strategy of caching the result of previous close methods and returning that on subsequent calls.

In investigating the linked issue I realized the logic for closing things is very convoluted and we almost certainly close some things repeatedly. It is easiest to simply allow this but handle it gracefully.
