### PR TITLE
Add a guard for a closed sink before writing requests

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.1-dev
+
+- Don't attempt to write a vm service request to a closed connection.
+  - Instead we log a warning with the attempted request message and return.
+
 ## 0.7.0
 
 - `DWDS.start` now requires an `AssetHandler` instead of `applicationPort`,

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.7.0
+version: 0.7.1-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/694

This is a safeguard for when we get a request to the vm service but the request controller is already closed. Instead of crashing we log a warning with the request.