### PR TITLE
when handling pause events, catch app not loaded errors and log a warning

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Instead we log a warning with the attempted request message and return.
 - Make all `close` methods more robust by allowing them to be called more than
   once and returning the cached future from previous calls.
+- Add explicit handling of app not loaded errors when handling chrome pause
+  events.
 
 ## 0.7.0
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/697

This is a general fix for handling the require js is not loaded errors - in response to chrome pause events which could explicitly happen at any time.

These are all indications of race conditions or other things outside of our control.

I did add a warning log though.