### PR TITLE
Fix RTE when running with `--output=NONE`

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.4-dev
+
+- Fix support for `--output=NONE` when building.
+
 ## 2.5.3
 
 - Added a new `--launch-app` command line option.

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -132,7 +132,9 @@ class Configuration {
   }
 
   void _validateConfiguration() {
-    if (outputInput != null) ensureIsTopLevelDir(outputInput);
+    // Both null and an empty string are valid values for outputInput. For any
+    // other value, we need to ensure it's a top-level dir.
+    if (outputInput?.isNotEmpty ?? false) ensureIsTopLevelDir(outputInput);
 
     if ((tlsCertKey != null && tlsCertChain == null) ||
         (tlsCertKey == null && tlsCertChain != null)) {
@@ -296,9 +298,13 @@ class Configuration {
 
     String outputPath;
     String outputInput;
-    if (output != 'NONE') {
+    if (output == 'NONE') {
+      // The empty string means build everything.
+      outputInput = '';
+    } else {
       var splitOutput = output.split(':');
       if (splitOutput.length == 1) {
+        // The empty string means build everything.
         outputInput = '';
         outputPath = output;
       } else {

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -135,10 +135,13 @@ void _registerBuildTargets(
   // Empty string indicates we should build everything, register a corresponding
   // target.
   if (configuration.outputInput == '') {
-    var outputLocation = OutputLocation((b) => b
-      ..output = configuration.outputPath
-      ..useSymlinks = true
-      ..hoist = false);
+    OutputLocation outputLocation;
+    if (configuration.outputPath != null) {
+      outputLocation = OutputLocation((b) => b
+        ..output = configuration.outputPath
+        ..useSymlinks = true
+        ..hoist = false);
+    }
     client.registerBuildTarget(DefaultBuildTarget((b) => b
       ..target = ''
       ..outputLocation = outputLocation?.toBuilder()));

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.5.3';
+const packageVersion = '2.5.4-dev';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.5.3
+version: 2.5.4-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-

--- a/webdev/test/configuration_test.dart
+++ b/webdev/test/configuration_test.dart
@@ -50,7 +50,14 @@ void main() {
         throwsA(isA<InvalidConfiguration>()));
   });
 
-  test('only top level directories are allowed for outputInput', () {
+  test(
+      'only top level directories or an empty target are allowed for '
+      'outputInput', () {
+    // Valid
+    expect(() => Configuration(outputInput: ''), returnsNormally);
+    expect(() => Configuration(outputInput: 'foo/'), returnsNormally);
+
+    // Invalid
     expect(() => Configuration(outputInput: '.'),
         throwsA(isA<InvalidConfiguration>()));
     expect(() => Configuration(outputInput: '../'),

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -106,6 +106,26 @@ void main() {
     }
   });
 
+  group('should build with --output=NONE', () {
+    for (var withDDC in [true, false]) {
+      test(withDDC ? 'DDC' : 'dart2js', () async {
+        var args = ['build', '--output=NONE'];
+        if (withDDC) {
+          args.add('--no-release');
+        }
+
+        var process = await runWebDev(args, workingDirectory: exampleDirectory);
+
+        var expectedItems = <Object>['Succeeded'];
+
+        await checkProcessStdout(process, expectedItems);
+        await process.shouldExit(0);
+
+        await d.nothing('build').validate(exampleDirectory);
+      });
+    }
+  });
+
   group('should serve with valid configuration', () {
     for (var withDDC in [true, false]) {
       var type = withDDC ? 'DDC' : 'dart2js';


### PR DESCRIPTION
When `webdev build` is run with the `--output=NONE` option:
- Default the `outputInput` to an empty string (build everything)
  - I'm not sure if this is the desired behavior, but it matches `build_runner build`
- Fix validation logic that was disallowing an empty string `outputInput` value

fya @grouma 