### PR TITLE
Correct set the pause state

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.3
+
+- Correctly set `Isolate` state if debugging is initiated after the application
+  has already started.
+
 ## 0.7.2
 
 - Account for root directory path when using `package:` URIs with `DartUri`.

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -48,8 +48,7 @@ class Dwds {
 
   Future<DebugConnection> debugConnection(AppConnection appConnection) async {
     if (!_enableDebugging) throw StateError('Debugging is not enabled.');
-    var appDebugServices = await _devHandler.loadAppServices(
-        appConnection.request.appId, appConnection.request.instanceId);
+    var appDebugServices = await _devHandler.loadAppServices(appConnection);
     return DebugConnection(appDebugServices);
   }
 
@@ -107,7 +106,6 @@ class Dwds {
       verbose,
       logWriter,
       extensionBackend,
-      enableDebugging,
     );
     cascade = cascade.add(devHandler.handler).add(assetHandler.handler);
 

--- a/dwds/lib/src/connections/app_connection.dart
+++ b/dwds/lib/src/connections/app_connection.dart
@@ -20,6 +20,8 @@ class AppConnection {
 
   AppConnection(this.request, this._connection);
 
+  bool get isStarted => _isStarted;
+
   void runMain() {
     if (_isStarted) throw StateError('Main has already started.');
     _connection.sink.add(jsonEncode(serializers.serialize(RunRequest())));

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -48,7 +48,6 @@ class DevHandler {
   final ExtensionBackend _extensionBackend;
   final StreamController<DebugConnection> extensionDebugConnections =
       StreamController<DebugConnection>();
-  final bool _enableDebugging;
 
   /// Null until [close] is called.
   ///
@@ -66,7 +65,6 @@ class DevHandler {
     this._verbose,
     this._logWriter,
     this._extensionBackend,
-    this._enableDebugging,
   ) {
     _sub = buildResults.listen(_emitBuildResults);
     _listen();
@@ -142,15 +140,19 @@ class DevHandler {
     );
   }
 
-  Future<AppDebugServices> loadAppServices(String appId, String instanceId) =>
-      _servicesByAppId.putIfAbsent(appId, () async {
-        var debugService =
-            await startDebugService(await _chromeConnection(), instanceId);
-        var appServices = await _createAppDebugServices(appId, debugService);
+  Future<AppDebugServices> loadAppServices(AppConnection appConnection) =>
+      _servicesByAppId.putIfAbsent(appConnection.request.appId, () async {
+        var debugService = await startDebugService(
+            await _chromeConnection(), appConnection.request.instanceId);
+        var appServices = await _createAppDebugServices(
+            appConnection.request.appId, debugService);
+        if (appConnection.isStarted) {
+          await appServices.chromeProxyService.resumeFromStart();
+        }
         unawaited(appServices.chromeProxyService.remoteDebugger.onClose.first
             .whenComplete(() {
           appServices.close();
-          _servicesByAppId.remove(appId);
+          _servicesByAppId.remove(appConnection.request.appId);
           _logWriter(
               Level.INFO,
               'Stopped debug service on '
@@ -162,11 +164,15 @@ class DevHandler {
   void _handleConnection(SseConnection injectedConnection) {
     _injectedConnections.add(injectedConnection);
     String appId;
+    AppConnection appConnection;
     injectedConnection.stream.listen((data) async {
       try {
         var message = serializers.deserialize(jsonDecode(data));
         if (message is DevToolsRequest) {
-          await _handleDebugRequest(message, injectedConnection, appId);
+          if (appConnection == null) {
+            throw StateError('Not connected to an application.');
+          }
+          await _handleDebugRequest(message, injectedConnection, appConnection);
         } else if (message is ConnectRequest) {
           // We need to handle this error state synchronously and assign to
           // [appId] so we do it outside of the `_handleConnectRequest` method.
@@ -176,8 +182,8 @@ class DevHandler {
                 'https://github.com/dart-lang/webdev/issues/new.');
           }
           appId = message.appId;
-
-          await _handleConnectRequest(message, injectedConnection);
+          appConnection =
+              await _handleConnectRequest(message, injectedConnection);
         } else if (message is IsolateExit) {
           await _handleIsolateExit(message);
         } else if (message is IsolateStart) {
@@ -203,16 +209,18 @@ class DevHandler {
 
     unawaited(injectedConnection.sink.done.then((_) async {
       _injectedConnections.remove(injectedConnection);
-      if (appId != null) {
+      if (appId != null && appConnection != null) {
         var services = await _servicesByAppId[appId];
-        services?.connectedInstanceId = null;
-        services?.chromeProxyService?.destroyIsolate();
+        if (services?.connectedInstanceId == appConnection.request.instanceId) {
+          services?.connectedInstanceId = null;
+          services?.chromeProxyService?.destroyIsolate();
+        }
       }
     }));
   }
 
   Future<void> _handleDebugRequest(DevToolsRequest message,
-      SseConnection sseConnection, String connectedAppId) async {
+      SseConnection sseConnection, AppConnection appConnection) async {
     if (_devTools == null) {
       sseConnection.sink
           .add(jsonEncode(serializers.serialize(DevToolsResponse((b) => b
@@ -223,7 +231,7 @@ class DevHandler {
       return;
     }
 
-    if (connectedAppId != message.appId) {
+    if (appConnection.request.appId != message.appId) {
       sseConnection.sink.add(jsonEncode(serializers.serialize(DevToolsResponse(
           (b) => b
             ..success = false
@@ -236,7 +244,7 @@ class DevHandler {
 
     AppDebugServices appServices;
     try {
-      appServices = await loadAppServices(message.appId, message.instanceId);
+      appServices = await loadAppServices(appConnection);
     } catch (_) {
       sseConnection.sink
           .add(jsonEncode(serializers.serialize(DevToolsResponse((b) => b
@@ -266,7 +274,7 @@ class DevHandler {
         message.instanceId, appServices.chromeProxyService.remoteDebugger))) {
       unawaited(appServices.close());
       unawaited(_servicesByAppId.remove(message.appId));
-      appServices = await loadAppServices(message.appId, message.instanceId);
+      appServices = await loadAppServices(appConnection);
     }
 
     sseConnection.sink.add(jsonEncode(
@@ -284,7 +292,7 @@ class DevHandler {
     });
   }
 
-  Future<void> _handleConnectRequest(
+  Future<AppConnection> _handleConnectRequest(
       ConnectRequest message, SseConnection sseConnection) async {
     // After a page refresh, reconnect to the same app services if they
     // were previously launched and create the new isolate.
@@ -298,34 +306,31 @@ class DevHandler {
         await services.chromeProxyService.createIsolate();
       }
     }
-
-    _connectedApps.add(AppConnection(message, sseConnection));
+    var connection = AppConnection(message, sseConnection);
+    _connectedApps.add(connection);
+    return connection;
   }
 
   Future<void> _handleIsolateExit(IsolateExit message) async {
-    (await loadAppServices(message.appId, message.instanceId))
+    (await _servicesByAppId[message.appId])
         ?.chromeProxyService
         ?.destroyIsolate();
   }
 
   Future<void> _handleIsolateStart(
       IsolateStart message, SseConnection sseConnection) async {
-    if (_enableDebugging) {
-      await (await loadAppServices(message.appId, message.instanceId))
-          ?.chromeProxyService
-          ?.createIsolate();
-    }
+    await (await _servicesByAppId[message.appId])
+        ?.chromeProxyService
+        ?.createIsolate();
     // [IsolateStart] events are the result of a Hot Restart.
     // Run the application after the Isolate has been created.
     sseConnection.sink.add(jsonEncode(serializers.serialize(RunRequest())));
   }
 
   Future<void> _handleRunResponse(RunResponse message) async {
-    if (_enableDebugging) {
-      await (await loadAppServices(message.appId, message.instanceId))
-          ?.chromeProxyService
-          ?.resumeFromStart();
-    }
+    await (await _servicesByAppId[message.appId])
+        ?.chromeProxyService
+        ?.resumeFromStart();
   }
 
   void _listen() async {

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -211,9 +211,13 @@ class DevHandler {
       _injectedConnections.remove(injectedConnection);
       if (appId != null && appConnection != null) {
         var services = await _servicesByAppId[appId];
-        if (services?.connectedInstanceId == appConnection.request.instanceId) {
-          services?.connectedInstanceId = null;
-          services?.chromeProxyService?.destroyIsolate();
+        if (services != null) {
+          if (services.connectedInstanceId == null ||
+              services.connectedInstanceId ==
+                  appConnection.request.instanceId) {
+            services.connectedInstanceId = null;
+            services.chromeProxyService?.destroyIsolate();
+          }
         }
       }
     }));

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.7.2
+version: 0.7.3
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -68,12 +68,14 @@ class TestContext {
       bool serveDevTools,
       bool enableDebugExtension,
       bool autoRun,
-      bool enableDebugging}) async {
+      bool enableDebugging,
+      bool waitToDebug}) async {
     reloadConfiguration ??= ReloadConfiguration.none;
     serveDevTools ??= false;
     enableDebugExtension ??= false;
     autoRun ??= true;
     enableDebugging ??= true;
+    waitToDebug ??= false;
     var chromeDriverPort = await findUnusedPort();
     var chromeDriverUrlBase = 'wd/hub';
     try {
@@ -155,10 +157,14 @@ class TestContext {
     }
 
     appConnection = await testServer.dwds.connectedApps.first;
-    if (enableDebugging) {
-      debugConnection = await testServer.dwds.debugConnection(appConnection);
-      webkitDebugger = WebkitDebugger(WipDebugger(tabConnection));
+    if (enableDebugging && !waitToDebug) {
+      await startDebugging();
     }
+  }
+
+  Future<void> startDebugging() async {
+    debugConnection = await testServer.dwds.debugConnection(appConnection);
+    webkitDebugger = WebkitDebugger(WipDebugger(tabConnection));
   }
 
   Future<Null> tearDown() async {


### PR DESCRIPTION
Fix the following issues:
 - If you enable debugging, we eagerly set up the app services on a run request
 - If you initiate debugging while the application is already running the initial state is not valid
 - If you open an application in another tab while debugging, refresh events in this new tab cause the isolate to be destroyed