### PR TITLE
Preload libraries for legacy module system

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.4
+
+- Properly get all libraries with the `legacy` module system.
+
 ## 0.7.3
 
 - Correctly set `Isolate` state if debugging is initiated after the application

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -50,10 +50,9 @@ Future<Property> _findMissingThis(String callFrameId, Debugger debugger) async {
   // If 'this' is a library return null, otherwise
   // return 'this'.
   final findCurrent = '''
-        (function (THIS) { 
+        (function (THIS) {
            if (THIS === window) { return null; }
-           let dart = $loadModule('dart_sdk').dart
-           let libs = dart.getLibraries().map(dart.getLibrary);
+           $getLibraries
            for (let lib of libs) {
              if (lib === THIS) {
                 return null;

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -517,7 +517,12 @@ function($argsString) {
   /// Note this can return a cached result.
   Future<List<LibraryRef>> _getLibraryRefs() async {
     if (_libraryRefs.isNotEmpty) return _libraryRefs.values.toList();
-    var expression = "$loadModule('dart_sdk').dart.getLibraries();";
+    var expression = '''
+      (function() {
+              $getLibraries
+              return libs;
+      })()
+     ''';
     var librariesResult = await _remoteDebugger.sendCommand('Runtime.evaluate',
         params: {'expression': expression, 'returnByValue': true});
     handleErrorIfPresent(librariesResult, evalContents: expression);

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -519,8 +519,8 @@ function($argsString) {
     if (_libraryRefs.isNotEmpty) return _libraryRefs.values.toList();
     var expression = '''
       (function() {
-              $getLibraries
-              return libs;
+        $getLibraries
+        return libs;
       })()
      ''';
     var librariesResult = await _remoteDebugger.sendCommand('Runtime.evaluate',

--- a/dwds/lib/src/utilities/shared.dart
+++ b/dwds/lib/src/utilities/shared.dart
@@ -44,10 +44,16 @@ String _fetchModuleStrategy(ModuleStrategy config) {
   throw StateError('Unreachable code');
 }
 
-String _loadModule;
+ModuleStrategy globalModuleStrategy;
+String get loadModule => _fetchModuleStrategy(globalModuleStrategy);
 
-String get loadModule => _loadModule;
-
-set globalModuleStrategy(ModuleStrategy moduleStrategy) {
-  _loadModule = _fetchModuleStrategy(moduleStrategy);
+String get getLibraries {
+  var expression = '';
+  if (globalModuleStrategy == ModuleStrategy.legacy) {
+    expression += 'for(let module of dart_library.libraries()) {\n'
+        'dart_library.import(module)[module];\n'
+        '}\n';
+  }
+  return expression +=
+      "let libs = $loadModule('dart_sdk').dart.getLibraries();\n";
 }

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.7.3
+version: 0.7.4
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-


### PR DESCRIPTION
With the legacy module system, we must manually import all transitive modules. This work is a no-op the second time around. Therefore, it's fine to have a static preamble that is used while loading libraries.