### PR TITLE
Add --launch-app command line option

### DIFF
--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -15,6 +15,7 @@ import 'package:dwds/src/utilities/shared.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart';
 import 'package:webdriver/io.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
@@ -206,5 +207,25 @@ class TestContext {
       }
     }
     throw StateError('No extension installed.');
+  }
+
+  /// Finds the line number in [scriptRef] matching [breakpointId].
+  ///
+  /// A breakpoint ID is found by looking for a line that ends with a comment
+  /// of exactly this form: `// Breakpoint: <id>`.
+  ///
+  /// Throws if it can't find the matching line.
+  Future<int> findBreakpointLine(
+      String breakpointId, String isolateId, ScriptRef scriptRef) async {
+    var script = await debugConnection.vmService
+        .getObject(isolateId, scriptRef.id) as Script;
+    var lines = LineSplitter.split(script.source).toList();
+    var lineNumber =
+        lines.indexWhere((l) => l.endsWith('// Breakpoint: $breakpointId'));
+    if (lineNumber == -1) {
+      throw StateError('Unable to find breakpoint in ${scriptRef.uri} with id '
+          '$breakpointId');
+    }
+    return lineNumber + 1;
   }
 }

--- a/dwds/test/refresh_test.dart
+++ b/dwds/test/refresh_test.dart
@@ -50,7 +50,9 @@ void main() {
       var refreshedScriptList = await service.getScripts(isolateId);
       var refreshedMain = refreshedScriptList.scripts
           .lastWhere((each) => each.uri.contains('main.dart'));
-      var bp = await service.addBreakpoint(isolateId, refreshedMain.id, 23);
+      var bpLine = await context.findBreakpointLine(
+          'printHelloWorld', isolateId, refreshedMain);
+      var bp = await service.addBreakpoint(isolateId, refreshedMain.id, bpLine);
       var isolate = await service.getIsolate(vm.isolates.first.id);
       expect(isolate.breakpoints, [bp]);
       expect(bp.id, isNotNull);

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -143,7 +143,9 @@ void main() {
       var scriptList = await client.getScripts(isolateId);
       var main = scriptList.scripts
           .firstWhere((script) => script.uri.contains('main.dart'));
-      await client.addBreakpoint(isolateId, main.id, 13);
+      var bpLine =
+          await context.findBreakpointLine('printCount', isolateId, main);
+      await client.addBreakpoint(isolateId, main.id, bpLine);
       await stream
           .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -65,7 +65,7 @@ void main() {
     });
 
     test('variables in function', () async {
-      stack = await breakAt(25);
+      stack = await breakAt(26);
       var frame = stack.frames.first;
       var variableNames = frame.vars.map((variable) => variable.name).toList()
         ..sort();
@@ -81,7 +81,7 @@ void main() {
     });
 
     test('variables in closure nested in method', () async {
-      stack = await breakAt(80);
+      stack = await breakAt(81);
       var frame = stack.frames.first;
       var variableNames = frame.vars.map((variable) => variable.name).toList()
         ..sort();
@@ -90,7 +90,7 @@ void main() {
     });
 
     test('variables in method', () async {
-      stack = await breakAt(94);
+      stack = await breakAt(95);
       var frame = stack.frames.first;
       var variableNames = frame.vars.map((variable) => variable.name).toList()
         ..sort();
@@ -98,7 +98,7 @@ void main() {
     });
 
     test('evaluateJsOnCallFrame', () async {
-      stack = await breakAt(25);
+      stack = await breakAt(26);
       var debugger = service.appInspectorProvider().debugger;
       var parameter = await debugger.evaluateJsOnCallFrameIndex(0, 'parameter');
       expect(parameter.value, matches(RegExp(r'\d+ world')));

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -24,7 +24,7 @@ void main() async {
 
   String nestedFunction(String parameter) {
     var another = int.tryParse(parameter);
-    return '$local: parameter, $another';
+    return '$local: parameter, $another'; // Breakpoint: nestedFunction
   }
 
   dynamic nestedWithClosure(String banana) {
@@ -78,7 +78,7 @@ class MyTestClass {
       // Be sure to use a field from this, so it isn't entirely optimized away.
       var closureLocalInsideMethod = '$message/$local/$parameter';
       print(closureLocalInsideMethod);
-      return closureLocalInsideMethod;
+      return closureLocalInsideMethod; // Breakpoint: nestedClosure
     };
   }
 
@@ -92,7 +92,7 @@ class MyTestClass {
   // An easy location to add a breakpoint.
   void printCount() {
     print('The count is ${++count}');
-    libraryFunction('abc');
+    libraryFunction('abc'); // Breakpoint: printMethod
   }
 
   final _privateField = 'a private field';

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -16,6 +16,7 @@ var libraryPublic = ['library', 'public', 'variable'];
 var _libraryPrivate = ['library', 'private', 'variable'];
 
 void main() async {
+  print('Initial print from scopes app');
   var local = 'local in main';
   var intLocalInMain = 42;
   var testClass = MyTestClass();

--- a/fixtures/_test/example/append_body/main.dart
+++ b/fixtures/_test/example/append_body/main.dart
@@ -10,7 +10,7 @@ void main() {
   var count = 0;
   // For setting breakpoints.
   Timer.periodic(const Duration(seconds: 1), (_) {
-    print('Count is: ${++count}');
+    print('Count is: ${++count}'); // Breakpoint: printCount
   });
 
   document.body.appendText('Hello World!');

--- a/fixtures/_test/example/hello_world/main.dart
+++ b/fixtures/_test/example/hello_world/main.dart
@@ -20,7 +20,7 @@ void main() async {
   // Long running so that we can test the pause / resume behavior.
   Timer.periodic(const Duration(seconds: 1), (_) {});
 
-  print(p.join('Hello', 'World'));
+  print(p.join('Hello', 'World')); // Breakpoint: printHelloWorld
 
   context['inspectInstance'] = () {
     inspect(myInstance);

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,5 +1,11 @@
-## 2.5.3-dev
+## 2.5.3
 
+- Added a new `--launch-app` command line option.
+  - Expects a package relative path to an html file, such as `web/app.html`.
+  - Launches the specified application in chrome on startup instead of the
+    server root.
+  - Allows multiple apps, and will launch all of them.
+  - Supported for the `daemon` and `serve` commands.
 - Depend on the latest `package:dwds`.
 
 ## 2.5.2

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -270,7 +270,10 @@ class Configuration {
         ? argResults[tlsCertKeyFlag] as String
         : defaultConfiguration.tlsCertKey;
 
-    var launchApps = argResults[launchAppOption] as List<String> ?? <String>[];
+    var launchApps = argResults.options.contains(launchAppOption) &&
+            argResults.wasParsed(launchAppOption)
+        ? argResults[launchAppOption] as List<String>
+        : defaultConfiguration.launchApps;
 
     var launchInChrome = argResults.options.contains(launchInChromeFlag) &&
             argResults.wasParsed(launchInChromeFlag)

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -318,6 +318,7 @@ class Configuration {
         : defaultConfiguration.verbose;
 
     return Configuration(
+        autoRun: defaultConfiguration.autoRun,
         chromeDebugPort: chromeDebugPort,
         debugExtension: debugExtension,
         debug: debug,

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -19,6 +19,7 @@ const tlsCertChainFlag = 'tls-cert-chain';
 const tlsCertKeyFlag = 'tls-cert-key';
 const hotReloadFlag = 'hot-reload';
 const hotRestartFlag = 'hot-restart';
+const launchAppOption = 'launch-app';
 const launchInChromeFlag = 'launch-in-chrome';
 const liveReloadFlag = 'live-reload';
 const logRequestsFlag = 'log-requests';
@@ -81,6 +82,7 @@ class Configuration {
   final String _hostname;
   final String _tlsCertChain;
   final String _tlsCertKey;
+  final List<String> _launchApps;
   final bool _launchInChrome;
   final bool _logRequests;
   final String _output;
@@ -100,6 +102,7 @@ class Configuration {
     String hostname,
     String tlsCertChain,
     String tlsCertKey,
+    List<String> launchApps,
     bool launchInChrome,
     bool logRequests,
     String output,
@@ -117,6 +120,7 @@ class Configuration {
         _hostname = hostname,
         _tlsCertChain = tlsCertChain,
         _tlsCertKey = tlsCertKey,
+        _launchApps = launchApps,
         _launchInChrome = launchInChrome,
         _logRequests = logRequests,
         _output = output,
@@ -157,7 +161,34 @@ class Configuration {
             'with --no-$enableInjectedClientFlag');
       }
     }
+
+    if (launchApps.isNotEmpty && !launchInChrome) {
+      throw InvalidConfiguration(
+          '--$launchAppOption can only be used with --$launchInChromeFlag');
+    }
   }
+
+  /// Creates a new [Configuration] with all non-null fields from
+  /// [other] overriding the values of `this`.
+  Configuration _override(Configuration other) => Configuration(
+      autoRun: other._autoRun ?? _autoRun,
+      chromeDebugPort: other._chromeDebugPort ?? _chromeDebugPort,
+      debugExtension: other._debugExtension ?? _debugExtension,
+      debug: other._debug ?? _debug,
+      enableInjectedClient:
+          other._enableInjectedClient ?? _enableInjectedClient,
+      hostname: other._hostname ?? _hostname,
+      tlsCertChain: other._tlsCertChain ?? _tlsCertChain,
+      tlsCertKey: other._tlsCertKey ?? _tlsCertKey,
+      launchApps: other._launchApps ?? _launchApps,
+      launchInChrome: other._launchInChrome ?? _launchInChrome,
+      logRequests: other._logRequests ?? _logRequests,
+      output: other._output ?? _output,
+      release: other._release ?? _release,
+      reload: other._reload ?? _reload,
+      requireBuildWebCompilers:
+          other._requireBuildWebCompilers ?? _requireBuildWebCompilers,
+      verbose: other._verbose ?? _verbose);
 
   factory Configuration.noInjectedClientDefaults() =>
       Configuration(autoRun: false, debug: false, debugExtension: false);
@@ -179,6 +210,8 @@ class Configuration {
 
   String get tlsCertKey => _tlsCertKey;
 
+  List<String> get launchApps => _launchApps ?? [];
+
   bool get launchInChrome => _launchInChrome ?? false;
 
   bool get logRequests => _logRequests ?? false;
@@ -194,8 +227,9 @@ class Configuration {
   bool get verbose => _verbose ?? false;
 
   /// Returns a new configuration with values updated from the parsed args.
-  static Configuration fromArgs(ArgResults argResults) {
-    var defaultConfiguration = Configuration();
+  static Configuration fromArgs(ArgResults argResults,
+      {Configuration defaultConfiguration}) {
+    defaultConfiguration ??= Configuration();
     if (argResults == null) return defaultConfiguration;
 
     var enableInjectedClient =
@@ -208,7 +242,8 @@ class Configuration {
     //
     // After parsing we check these defaults weren't overridden as well.
     if (!enableInjectedClient) {
-      defaultConfiguration = Configuration.noInjectedClientDefaults();
+      defaultConfiguration = defaultConfiguration
+          ._override(Configuration.noInjectedClientDefaults());
     }
 
     var chromeDebugPort = argResults.options.contains(chromeDebugPortFlag)
@@ -235,12 +270,16 @@ class Configuration {
         ? argResults[tlsCertKeyFlag] as String
         : defaultConfiguration.tlsCertKey;
 
+    var launchApps = argResults[launchAppOption] as List<String> ?? <String>[];
+
     var launchInChrome = argResults.options.contains(launchInChromeFlag) &&
             argResults.wasParsed(launchInChromeFlag)
         ? argResults[launchInChromeFlag] as bool
         // We want to default to launch chrome if the user provides just --debug
         // and not --chrome-debug-port.
-        : debug && !argResults.wasParsed(chromeDebugPortFlag)
+        : debug &&
+                !(argResults.options.contains(launchInChromeFlag) &&
+                    argResults.wasParsed(chromeDebugPortFlag))
             ? true
             : defaultConfiguration.launchInChrome;
 
@@ -286,6 +325,7 @@ class Configuration {
         hostname: hostname,
         tlsCertChain: tlsCertChain,
         tlsCertKey: tlsCertKey,
+        launchApps: launchApps,
         launchInChrome: launchInChrome,
         logRequests: logRequests,
         output: output,

--- a/webdev/lib/src/command/daemon_command.dart
+++ b/webdev/lib/src/command/daemon_command.dart
@@ -54,7 +54,7 @@ class DaemonCommand extends Command<int> {
     ..addMultiOption('launch-app', help: 'The html file to launch in chrome.');
 
   DaemonCommand() {
-    addSharedArgs(argParser);
+    addSharedArgs(argParser, releaseDefault: false);
   }
 
   @override
@@ -88,8 +88,11 @@ class DaemonCommand extends Command<int> {
       });
       daemon.registerDomain(daemonDomain);
       var configuration = Configuration.fromArgs(argResults,
-          defaultConfiguration:
-              Configuration(launchInChrome: true, debug: true, autoRun: false));
+          defaultConfiguration: Configuration(
+              launchInChrome: true,
+              debug: true,
+              autoRun: false,
+              release: false));
       // Globally trigger verbose logs.
       setVerbosity(configuration.verbose);
 

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.5.3-dev';
+const packageVersion = '2.5.3';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.5.3-dev
+version: 2.5.3
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-

--- a/webdev/test/daemon/app_domain_test.dart
+++ b/webdev/test/daemon/app_domain_test.dart
@@ -3,29 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Timeout(Duration(minutes: 2))
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:test/test.dart';
-import 'package:test_process/test_process.dart';
 
 import '../test_utils.dart';
 import 'utils.dart';
-
-Future<String> _getAppId(TestProcess webdev) async {
-  var appId = '';
-  while (await webdev.stdout.hasNext) {
-    var line = await webdev.stdout.next;
-    if (line.startsWith('[{"event":"app.started"')) {
-      line = line.substring(1, line.length - 1);
-      var message = json.decode(line) as Map<String, dynamic>;
-      appId = message['params']['appId'] as String;
-      break;
-    }
-  }
-  assert(appId.isNotEmpty);
-  return appId;
-}
 
 void main() {
   String exampleDirectory;
@@ -63,7 +46,7 @@ void main() {
       test('.log', () async {
         var webdev =
             await runWebDev(['daemon'], workingDirectory: exampleDirectory);
-        var appId = await _getAppId(webdev);
+        var appId = await waitForAppId(webdev);
         // The example app does an initial print.
         await expectLater(
             webdev.stdout,
@@ -78,7 +61,7 @@ void main() {
       test('.callServiceExtension', () async {
         var webdev =
             await runWebDev(['daemon'], workingDirectory: exampleDirectory);
-        var appId = await _getAppId(webdev);
+        var appId = await waitForAppId(webdev);
         var extensionCall = '[{"method":"app.callServiceExtension","id":0,'
             '"params" : { "appId" : "$appId", "methodName" : "ext.print"}}]';
         webdev.stdin.add(utf8.encode('$extensionCall\n'));
@@ -94,7 +77,7 @@ void main() {
       test('.reload', () async {
         var webdev =
             await runWebDev(['daemon'], workingDirectory: exampleDirectory);
-        var appId = await _getAppId(webdev);
+        var appId = await waitForAppId(webdev);
         var extensionCall = '[{"method":"app.restart","id":0,'
             '"params" : { "appId" : "$appId", "fullRestart" : false}}]';
         webdev.stdin.add(utf8.encode('$extensionCall\n'));
@@ -110,7 +93,7 @@ void main() {
       test('.restart', () async {
         var webdev =
             await runWebDev(['daemon'], workingDirectory: exampleDirectory);
-        var appId = await _getAppId(webdev);
+        var appId = await waitForAppId(webdev);
         var extensionCall = '[{"method":"app.restart","id":0,'
             '"params" : { "appId" : "$appId", "fullRestart" : true}}]';
         webdev.stdin.add(utf8.encode('$extensionCall\n'));
@@ -130,7 +113,7 @@ void main() {
       test('.stop', () async {
         var webdev =
             await runWebDev(['daemon'], workingDirectory: exampleDirectory);
-        var appId = await _getAppId(webdev);
+        var appId = await waitForAppId(webdev);
         var stopCall = '[{"method":"app.stop","id":0,'
             '"params" : { "appId" : "$appId"}}]';
         webdev.stdin.add(utf8.encode('$stopCall\n'));

--- a/webdev/test/daemon/launch_app_test.dart
+++ b/webdev/test/daemon/launch_app_test.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Timeout(Duration(minutes: 2))
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+import 'utils.dart';
+
+void main() {
+  String exampleDirectory;
+
+  setUpAll(() async {
+    exampleDirectory = await prepareWorkspace();
+  });
+
+  test('--launch-app launches the specified app', () async {
+    var webdev = await runWebDev(['daemon', '--launch-app=web/scopes.html'],
+        workingDirectory: exampleDirectory);
+    var appId = await waitForAppId(webdev);
+
+    // The example app does an initial print.
+    await expectLater(
+        webdev.stdout,
+        emitsThrough(
+            startsWith('[{"event":"app.log","params":{"appId":"$appId",'
+                '"log":"Initial print from scopes app\\n"}}')));
+    await exitWebdev(webdev);
+  });
+}

--- a/webdev/test/daemon/utils.dart
+++ b/webdev/test/daemon/utils.dart
@@ -16,6 +16,21 @@ Future<void> exitWebdev(TestProcess webdev) async {
   await webdev.exitCode;
 }
 
+Future<String> waitForAppId(TestProcess webdev) async {
+  var appId = '';
+  while (await webdev.stdout.hasNext) {
+    var line = await webdev.stdout.next;
+    if (line.startsWith('[{"event":"app.started"')) {
+      line = line.substring(1, line.length - 1);
+      var message = json.decode(line) as Map<String, dynamic>;
+      appId = message['params']['appId'] as String;
+      break;
+    }
+  }
+  assert(appId.isNotEmpty);
+  return appId;
+}
+
 Future<String> prepareWorkspace() async {
   var exampleDirectory = p.absolute(p.join(p.current, '..', 'example'));
 


### PR DESCRIPTION
Closes https://github.com/dart-lang/webdev/issues/744

  - Expects a package relative path to an html file, such as `web/app.html`.
  - Launches the specified application in chrome on startup instead of the server root.
  - Allows multiple apps, and will launch all of them.
  - Supported for the `daemon` and `serve` commands.

This also adds general arg parsing for the shared arguments for all commands, such as -v and -r, as well as actual support for trailing args in `<dir>:<port>` format (just like the serve command).

cc @alexander-doroshko @devoncarew @jwren 