### PR TITLE
Revert "Launch Chrome from the same directory (#764)"

### DIFF
--- a/webdev/lib/src/serve/chrome.dart
+++ b/webdev/lib/src/serve/chrome.dart
@@ -3,10 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:browser_launcher/browser_launcher.dart' as browser_launcher;
-import 'package:path/path.dart' as path;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 var _currentCompleter = Completer<Chrome>();
@@ -37,11 +35,8 @@ class Chrome {
   ///
   /// Each url in [urls] will be loaded in a separate tab.
   static Future<Chrome> start(List<String> urls, {int port}) async {
-    var dir = path.join(Directory.current.absolute.path, '.dart_tool', 'webdev',
-        'chrome_user_data');
-    Directory(dir).createSync(recursive: true);
-    var chrome = await browser_launcher.Chrome.startWithDebugPort(urls,
-        debugPort: port, userDataDir: dir);
+    var chrome =
+        await browser_launcher.Chrome.startWithDebugPort(urls, debugPort: port);
     return _connect(Chrome._(chrome.debugPort, chrome));
   }
 

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   args: ^1.5.0
   async: ^2.2.0
   build_daemon: ^2.0.0
-  browser_launcher: ^0.1.5
+  browser_launcher: ^0.1.3
   crypto: ^2.0.6
   dwds: ^0.7.0
   http: ^0.12.0


### PR DESCRIPTION
This reverts commit 7e2cf753971c5228bd3e08d87dad366f8009cad8.

This seems to be causing extra flakiness, particularly on Windows, possibly from tests interfering with each other, so reverting until that can be fixed.