### PR TITLE
Multiple breakpoints

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.7.6
+## 0.7.6-dev
 
 - Fix issue with source map logic for the legacy module system.
+- Allow setting breakpoints multiple times and just return the old breakpoint.
 
 ## 0.7.5
 

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -250,8 +250,7 @@ class Debugger extends Domain {
   Future<Breakpoint> addBreakpoint(String isolateId, String scriptId, int line,
       {int column}) async {
     checkIsolate(isolateId);
-    return _breakpoints.add(scriptId, line,
-        ifNew: (Breakpoint breakpoint) async {
+    return _breakpoints.add(scriptId, line, ifNew: (breakpoint) async {
       _streamNotify(
           'Debug',
           Event(

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -326,7 +326,7 @@ class Debugger extends Domain {
     return response.result['breakpointId'] as String;
   }
 
-  /// Call the Chrome protocol remove.
+  /// Call the Chrome protocol removeBreakpoint.
   Future<void> _removeBreakpoint(String breakpointId) async {
     var response = await _remoteDebugger.sendCommand(
         'Debugger.removeBreakpoint',

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -328,8 +328,9 @@ class Debugger extends Domain {
 
   /// Call the Chrome protocol remove.
   Future<void> _remove(String breakpointId) async {
-    var response = await _remoteDebugger
-        .sendCommand('Debugger.remove', params: {'breakpointId': breakpointId});
+    var response = await _remoteDebugger.sendCommand(
+        'Debugger.removeBreakpoint',
+        params: {'breakpointId': breakpointId});
     handleErrorIfPresent(response);
   }
 
@@ -576,7 +577,7 @@ class _Breakpoints extends Domain {
   Future<Breakpoint> add(String scriptId, int line,
       {Future<Breakpoint> Function(String) ifAbsent}) async {
     var id = 'bp/$scriptId#$line';
-    var bp = await _byId.putIfAbsent(id, () => ifAbsent('$scriptId&$line'));
+    var bp = await _byId.putIfAbsent(id, () => ifAbsent(id));
     assert(bp.id == id);
     return bp;
   }

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -307,7 +307,7 @@ class Debugger extends Domain {
             timestamp: DateTime.now().millisecondsSinceEpoch,
             isolate: inspector.isolateRef)
           ..breakpoint = bp);
-    await _remove(jsId);
+    await _removeBreakpoint(jsId);
     return Success();
   }
 
@@ -327,7 +327,7 @@ class Debugger extends Domain {
   }
 
   /// Call the Chrome protocol remove.
-  Future<void> _remove(String breakpointId) async {
+  Future<void> _removeBreakpoint(String breakpointId) async {
     var response = await _remoteDebugger.sendCommand(
         'Debugger.removeBreakpoint',
         params: {'breakpointId': breakpointId});

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     hide StackTrace;
 
@@ -38,8 +39,6 @@ class Debugger extends Domain {
 
   final RemoteDebugger _remoteDebugger;
 
-  /// The root URI from which the application is served.
-  final String _root;
   final StreamNotify _streamNotify;
   final Sources _sources;
   final Modules _modules;
@@ -52,8 +51,12 @@ class Debugger extends Domain {
     this._sources,
     this._modules,
     this._locations,
-    this._root,
-  )   : _breakpoints = _Breakpoints(provider),
+    String root,
+  )   : _breakpoints = _Breakpoints(
+            locations: _locations,
+            provider: provider,
+            remoteDebugger: _remoteDebugger,
+            root: root),
         super(provider);
 
   /// The breakpoints we have set so far, indexable by either
@@ -247,44 +250,16 @@ class Debugger extends Domain {
   Future<Breakpoint> addBreakpoint(String isolateId, String scriptId, int line,
       {int column}) async {
     checkIsolate(isolateId);
-    return _breakpoints.add(scriptId, line, ifAbsent: (String bpId) async {
-      var dartScript = await inspector.scriptWithId(scriptId);
-      var dartUri = DartUri(dartScript.uri, _root);
-      var location = await _locations.locationForDart(dartUri, line);
-      // TODO: Handle cases where a breakpoint can't be set exactly at that line.
-      if (location == null) {
-        // ignore: only_throw_errors
-        throw RPCError(
-            'addBreakpoint',
-            102,
-            'The VM is unable to add a breakpoint '
-                'at the specified line or function');
-      }
-
-      var dartBreakpoint = _dartBreakpoint(dartScript, location, bpId);
-      var jsBreakpointId = await _setBreakpoint(location);
-      _breakpoints.note(js: jsBreakpointId, bp: dartBreakpoint);
-      return dartBreakpoint;
+    return _breakpoints.add(scriptId, line,
+        ifNew: (Breakpoint breakpoint) async {
+      _streamNotify(
+          'Debug',
+          Event(
+              kind: EventKind.kBreakpointAdded,
+              timestamp: DateTime.now().millisecondsSinceEpoch,
+              isolate: inspector.isolateRef)
+            ..breakpoint = breakpoint);
     });
-  }
-
-  /// Create a Dart breakpoint at [location] in [dartScript] with [id].
-  Breakpoint _dartBreakpoint(
-      ScriptRef dartScript, Location location, String id) {
-    var breakpoint = Breakpoint()
-      ..resolved = true
-      ..id = id
-      ..location = (SourceLocation()
-        ..script = dartScript
-        ..tokenPos = location.tokenPos);
-    _streamNotify(
-        'Debug',
-        Event(
-            kind: EventKind.kBreakpointAdded,
-            timestamp: DateTime.now().millisecondsSinceEpoch,
-            isolate: inspector.isolateRef)
-          ..breakpoint = breakpoint);
-    return breakpoint;
   }
 
   /// Remove a Dart breakpoint.
@@ -309,21 +284,6 @@ class Debugger extends Domain {
           ..breakpoint = bp);
     await _removeBreakpoint(jsId);
     return Success();
-  }
-
-  /// Call the Chrome protocol setBreakpoint and return the breakpoint ID.
-  Future<String> _setBreakpoint(Location location) async {
-    // Location is 0 based according to:
-    // https://chromedevtools.github.io/devtools-protocol/tot/Debugger#type-Location
-    var response =
-        await _remoteDebugger.sendCommand('Debugger.setBreakpoint', params: {
-      'location': {
-        'scriptId': location.jsLocation.scriptId,
-        'lineNumber': location.jsLocation.line - 1,
-      }
-    });
-    handleErrorIfPresent(response);
-    return response.result['breakpointId'] as String;
   }
 
   /// Call the Chrome protocol removeBreakpoint.
@@ -562,36 +522,85 @@ class _Breakpoints extends Domain {
 
   final Map<String, Future<Breakpoint>> _bpByDartId = {};
 
-  _Breakpoints(AppInspectorProvider provider) : super(provider);
+  final Locations locations;
+  final RemoteDebugger remoteDebugger;
+
+  /// The root URI from which the application is served.
+  final String root;
+
+  _Breakpoints({
+    @required this.locations,
+    @required AppInspectorProvider provider,
+    @required this.remoteDebugger,
+    @required this.root,
+  }) : super(provider);
 
   /// Adds a breakpoint at [scriptId] and [line] or returns an existing one
   /// if present.
   ///
-  /// If a breakpoint does not exists then [ifAbsent] is invoked with an
-  /// specified ID for the breakpoint to create. This function must return
-  /// a [Breakpoint] with the specified ID.
-  ///
-  /// We delegate actual breakpoint creation for code simplification purposes,
-  /// as we need access to a lot of other objects and add events to streams
-  /// etc.
+  /// If a new breakpoint is created then [ifNew] is invoked with the
+  /// breakpoint.
   Future<Breakpoint> add(String scriptId, int line,
-      {Future<Breakpoint> Function(String) ifAbsent}) async {
+      {void Function(Breakpoint) ifNew}) async {
     var id = 'bp/$scriptId#$line';
-    var bp = await _bpByDartId.putIfAbsent(id, () => ifAbsent(id));
+    var bp = await _bpByDartId.putIfAbsent(id, () async {
+      var dartScript = await inspector.scriptWithId(scriptId);
+      var dartUri = DartUri(dartScript.uri, root);
+      var location = await locations.locationForDart(dartUri, line);
+      // TODO: Handle cases where a breakpoint can't be set exactly at that line.
+      if (location == null) {
+        // ignore: only_throw_errors
+        throw RPCError(
+            'addBreakpoint',
+            102,
+            'The VM is unable to add a breakpoint '
+                'at the specified line or function');
+      }
+
+      var dartBreakpoint = _dartBreakpoint(dartScript, location, id);
+      var jsBreakpointId = await _setJsBreakpoint(location);
+      _note(jsId: jsBreakpointId, bp: dartBreakpoint);
+      ifNew(dartBreakpoint);
+      return dartBreakpoint;
+    });
     assert(bp.id == id);
     return bp;
   }
 
-  /// Record the breakpoint.
-  ///
-  /// Either [dartId] or the Dart breakpoint [bp] must be provided.
-  void note({String js, String dartId, Breakpoint bp}) {
-    _dartIdByJsId[js] = dartId ?? bp?.id;
-    _jsIdByDartId[dartId ?? bp?.id] = js;
+  /// Create a Dart breakpoint at [location] in [dartScript] with [id].
+  Breakpoint _dartBreakpoint(
+      ScriptRef dartScript, Location location, String id) {
+    var breakpoint = Breakpoint()
+      ..resolved = true
+      ..id = id
+      ..location = (SourceLocation()
+        ..script = dartScript
+        ..tokenPos = location.tokenPos);
+    return breakpoint;
+  }
+
+  /// Calls the Chrome protocol setBreakpoint and returns the remote ID.
+  Future<String> _setJsBreakpoint(Location location) async {
+    // Location is 0 based according to:
+    // https://chromedevtools.github.io/devtools-protocol/tot/Debugger#type-Location
+    var response =
+        await remoteDebugger.sendCommand('Debugger.setBreakpoint', params: {
+      'location': {
+        'scriptId': location.jsLocation.scriptId,
+        'lineNumber': location.jsLocation.line - 1,
+      }
+    });
+    handleErrorIfPresent(response);
+    return response.result['breakpointId'] as String;
+  }
+
+  /// Records the internal Dart <=> JS breakpoint id mapping and adds the
+  /// breakpoint to the current isolates list of breakpoints.
+  void _note({Breakpoint bp, String jsId}) {
+    _dartIdByJsId[jsId] = bp.id;
+    _jsIdByDartId[bp.id] = jsId;
     var isolate = inspector.isolate;
-    if (bp != null) {
-      isolate?.breakpoints?.add(bp);
-    }
+    isolate?.breakpoints?.add(bp);
   }
 
   Future<Breakpoint> remove({String js, String dartId}) async {

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -52,10 +52,19 @@ void main() {
 
       test('addBreakpoint', () async {
         // TODO: Much more testing.
-        var bp = await service.addBreakpoint(isolate.id, mainScript.id, 23);
+        var firstBp =
+            await service.addBreakpoint(isolate.id, mainScript.id, 23);
+        expect(firstBp, isNotNull);
+        expect(firstBp.id, isNotNull);
+
+        // Set another breakpoint at the same place - should get the original.
+        var secondBp =
+            await service.addBreakpoint(isolate.id, mainScript.id, 23);
+        expect(secondBp.id, firstBp.id);
+
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id, bp.id);
-        expect(bp.id, isNotNull);
+        await service.removeBreakpoint(isolate.id, firstBp.id);
+        await service.removeBreakpoint(isolate.id, secondBp.id);
       });
 
       test('addBreakpoint in nonsense location throws', () async {

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -64,7 +64,9 @@ void main() {
 
         // Remove breakpoint so it doesn't impact other tests.
         await service.removeBreakpoint(isolate.id, firstBp.id);
-        await service.removeBreakpoint(isolate.id, secondBp.id);
+        // We shouldn't be able to remove it again.
+        expect(() => service.removeBreakpoint(isolate.id, secondBp.id),
+            throwsArgumentError);
       });
 
       test('addBreakpoint in nonsense location throws', () async {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/782

- Breakpoint ids are now a combination of script id and line number.
- If you ask for a breakpoint which is already set we just return the old one (cached by id)
- I also cleaned up some ugly apis that duplicated the class name in the methods