### PR TITLE
Suppress type arguments on generic functions in stack frames

### DIFF
--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -29,8 +29,13 @@ Future<List<Property>> visibleProperties(
           await debugger.getProperties(scope['object']['objectId'] as String))
       .toList();
   var allProperties = [for (var list in propertyLists) ...await list];
-      // var typeParameters 
-      //   nestedFunction[dart._runtimeType].typeFormals
+  // We should never see a raw JS class. The only case where this happens is a
+  // Dart generic function, where the type arguments get passed in as
+  // parameters. Hide those. 
+  // TODO(#786) Handle these correctly rather than just suppressing them.
+  allProperties.removeWhere((each) =>
+      each.value.type == 'function' &&
+      each.value.description.startsWith('class '));
   var existingThis =
       allProperties.firstWhere((x) => x.name == 'this', orElse: () => null);
   if (existingThis == null) {

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -31,7 +31,7 @@ Future<List<Property>> visibleProperties(
   var allProperties = [for (var list in propertyLists) ...await list];
   // We should never see a raw JS class. The only case where this happens is a
   // Dart generic function, where the type arguments get passed in as
-  // parameters. Hide those. 
+  // parameters. Hide those.
   // TODO(#786) Handle these correctly rather than just suppressing them.
   allProperties.removeWhere((each) =>
       each.value.type == 'function' &&

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -29,6 +29,8 @@ Future<List<Property>> visibleProperties(
           await debugger.getProperties(scope['object']['objectId'] as String))
       .toList();
   var allProperties = [for (var list in propertyLists) ...await list];
+      // var typeParameters 
+      //   nestedFunction[dart._runtimeType].typeFormals
   var existingThis =
       allProperties.firstWhere((x) => x.name == 'this', orElse: () => null);
   if (existingThis == null) {

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -163,19 +163,6 @@ void main() {
       expect(instance.classRef.name, 'Closure');
     });
 
-    // test('for closure with type parameter', () async {
-    //   // var remote = await libraryPublicFinal();
-    //   var f = await inspector.evaluate(inspector.isolate.id, inspector.isolate.rootLib.id, 
-    //      'libraryPublicFinal.functionWithTypeParameter');
-    //   print(f);
-    //         var properties = await debugger.getProperties(f.objectId);
-    //   var closure =
-    //       properties.firstWhere((property) => property.name == 'closure');
-    //   var instance = await instanceHelper.instanceFor(closure.value);
-    //   expect(instance.kind, InstanceKind.kClosure);
-    //   expect(instance.classRef.name, 'Closure');
-    // });
-
     test('for a nested class', () async {
       var libraryRemoteObject = await libraryPublicFinal();
       var fieldRemoteObject =

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -163,6 +163,19 @@ void main() {
       expect(instance.classRef.name, 'Closure');
     });
 
+    // test('for closure with type parameter', () async {
+    //   // var remote = await libraryPublicFinal();
+    //   var f = await inspector.evaluate(inspector.isolate.id, inspector.isolate.rootLib.id, 
+    //      'libraryPublicFinal.functionWithTypeParameter');
+    //   print(f);
+    //         var properties = await debugger.getProperties(f.objectId);
+    //   var closure =
+    //       properties.firstWhere((property) => property.name == 'closure');
+    //   var instance = await instanceHelper.instanceFor(closure.value);
+    //   expect(instance.kind, InstanceKind.kClosure);
+    //   expect(instance.classRef.name, 'Closure');
+    // });
+
     test('for a nested class', () async {
       var libraryRemoteObject = await libraryPublicFinal();
       var fieldRemoteObject =

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -72,6 +72,7 @@ void main() {
       var variableNames = frame.vars.map((variable) => variable.name).toList()
         ..sort();
       expect(variableNames, [
+        'T',
         'another',
         'intLocalInMain',
         'local',
@@ -80,6 +81,10 @@ void main() {
         'parameter',
         'testClass'
       ]);
+      var typeParameter = frame.vars.firstWhere((v) => v.name == 'T');
+      expect(typeParameter.value, isA<TypeArgumentsRef>());
+      var other = frame.vars.firstWhere((v) => v.name != 'T');
+      expect(other.value, isA<InstanceRef>());
     });
 
     test('variables in closure nested in method', () async {

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -72,7 +72,7 @@ void main() {
       var variableNames = frame.vars.map((variable) => variable.name).toList()
         ..sort();
       expect(variableNames, [
-        'T',
+        'aClass',
         'another',
         'intLocalInMain',
         'local',
@@ -81,10 +81,6 @@ void main() {
         'parameter',
         'testClass'
       ]);
-      var typeParameter = frame.vars.firstWhere((v) => v.name == 'T');
-      expect(typeParameter.value, isA<TypeArgumentsRef>());
-      var other = frame.vars.firstWhere((v) => v.name != 'T');
-      expect(other.value, isA<InstanceRef>());
     });
 
     test('variables in closure nested in method', () async {

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -35,7 +35,6 @@ void main() async {
 
   String nestedFunction<T>(T parameter, Object aClass) {
     var another = int.tryParse('$parameter');
-    print(aClass);
     return '$local: parameter, $another'; // Breakpoint: nestedFunction
   }
 

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -34,7 +34,7 @@ void main() async {
   notAList.add(7);
 
   String nestedFunction<T>(T parameter, Object aClass) {
-    var another = int.tryParse(parameter as String);
+    var another = int.tryParse('$parameter');
     print(aClass);
     return '$local: parameter, $another'; // Breakpoint: nestedFunction
   }
@@ -49,7 +49,7 @@ void main() async {
     var closureLocal;
     libraryPublicFinal.printCount();
     print('ticking... $ticks (the answer is $intLocalInMain)');
-    print(nestedFunction('$ticks ${testClass.message}', Timer));
+    print(nestedFunction(libraryPublicFinal, Timer));
     print(localThatsNull);
     print(libraryNull);
     var localList = libraryPublic;

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -49,7 +49,7 @@ void main() async {
     var closureLocal;
     libraryPublicFinal.printCount();
     print('ticking... $ticks (the answer is $intLocalInMain)');
-    print(nestedFunction(libraryPublicFinal, Timer));
+    print(nestedFunction('$ticks ${testClass.message}', Timer));
     print(localThatsNull);
     print(libraryNull);
     var localList = libraryPublic;

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -32,8 +32,9 @@ void main() async {
   map['a'] = 1;
   notAList.add(7);
 
-  String nestedFunction(String parameter) {
-    var another = int.tryParse(parameter);
+  String nestedFunction<T>(T parameter, Object aClass) {
+    var another = int.tryParse(parameter as String);
+    print(aClass);
     return '$local: parameter, $another'; // Breakpoint: nestedFunction
   }
 
@@ -47,7 +48,7 @@ void main() async {
     var closureLocal;
     libraryPublicFinal.printCount();
     print('ticking... $ticks (the answer is $intLocalInMain)');
-    print(nestedFunction('$ticks ${testClass.message}'));
+    print(nestedFunction('$ticks ${testClass.message}', Timer));
     print(localThatsNull);
     print(libraryNull);
     var localList = libraryPublic;
@@ -59,7 +60,7 @@ void main() async {
 
   print(_libraryPrivateFinal);
   print(_libraryPrivate);
-  print(nestedFunction(_libraryPrivate.first));
+  print(nestedFunction(_libraryPrivate.first, Object));
   print(nestedWithClosure(_libraryPrivate.first)());
 }
 


### PR DESCRIPTION
Closes #760 

This just suppresses the type arguments. Handling them correctly is harder, and it's not clear anything uses them. See #786 