### PR TITLE
Refactor AppInspector

### DIFF
--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -1,0 +1,158 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.import 'dart:async';
+
+import '../utilities/domain.dart';
+import '../utilities/shared.dart';
+import '../utilities/wrapped_service.dart';
+import 'inspector.dart';
+import 'metadata.dart';
+
+/// A hard-coded ClassRef for the String class.
+final classRefForString = classRefFor('dart:core', InstanceKind.kString);
+
+/// A hard-coded ClassRef for the Closure class.
+final classRefForClosure = classRefFor('dart:core', 'Closure');
+
+/// A hard-coded ClassRef for a (non-existent) class called Unknown.
+final classRefForUnknown = classRefFor('dart:core', 'Unknown');
+
+/// Returns a [ClassRef] for the provided library ID and class name.
+ClassRef classRefFor(String libraryId, String name) =>
+    ClassRef(id: 'classes\$$libraryId\$$name', name: name);
+
+/// Keeps track of Dart classes available in the running application.
+class ClassHelper extends Domain {
+  /// Map of class ID to [Class].
+  final _classes = <String, Class>{};
+
+  ClassHelper(AppInspector Function() provider) : super(provider) {
+    var staticClasses = [
+      classRefForClosure,
+      classRefForString,
+      classRefForUnknown
+    ];
+    for (var classRef in staticClasses) {
+      _classes[classRef.id] = Class(
+          name: classRef.name,
+          isAbstract: false,
+          isConst: false,
+          library: null,
+          interfaces: [],
+          fields: [],
+          functions: [],
+          subclasses: [],
+          id: classRef.id);
+    }
+  }
+
+  Future<Class> forObjectId(String objectId) async {
+    if (!objectId.startsWith('classes\$')) return null;
+    var clazz = _classes[objectId];
+    if (clazz != null) return clazz;
+    var splitId = objectId.split('\$');
+    var libraryId = splitId[1];
+    var libraryRef = await inspector.libraryHelper.libraryRefFor(libraryId);
+    var classRef = classRefFor(libraryId, splitId.last);
+    clazz = await _getClass(libraryRef, classRef);
+    return _classes[objectId] = clazz;
+  }
+
+  Future<Class> _getClass(LibraryRef libraryRef, ClassRef classRef) async {
+    // Fetch information about all the classes in this library.
+    var expression = '''
+    (function() {
+      ${getLibrarySnippet(libraryRef.uri)}
+      var result = {};
+      var clazz = library["${classRef.name}"];
+      var descriptor = {
+          'name': clazz.name,
+          'dartName': sdkUtils.typeName(clazz)
+        };
+      // TODO(jakemac): static methods once ddc supports them
+      var methods = sdkUtils.getMethods(clazz);
+      var methodNames = methods ? Object.keys(methods) : [];
+      descriptor['methods'] = {};
+      for (var name of methodNames) {
+        var method = methods[name];
+        descriptor['methods'][name] = {
+          // TODO(jakemac): how can we get actual const info?
+          "isConst": false,
+          "isStatic": false,
+        }
+      }
+      // TODO(jakemac): static fields once ddc supports them
+      var fields = sdkUtils.getFields(clazz);
+      var fieldNames = fields ? Object.keys(fields) : [];
+      descriptor['fields'] = {};
+      for (var name of fieldNames) {
+        var field = fields[name];
+        var libraryUri = Object.getOwnPropertySymbols(fields[name]["type"])
+        .find(x => x.description == "libraryUri");
+        descriptor['fields'][name] = {
+          // TODO(jakemac): how can we get actual const info?
+          "isConst": false,
+          "isFinal": field.isFinal,
+          "isStatic": false,
+          "classRefName": fields[name]["type"]["name"],
+          "classRefDartName": sdkUtils.typeName(fields[name]["type"]),
+          "classRefLibraryId" : field["type"][libraryUri],
+        }
+      }
+      return descriptor;
+    })()
+    ''';
+    var result = await inspector.remoteDebugger.sendCommand('Runtime.evaluate',
+        params: {'expression': expression, 'returnByValue': true});
+    handleErrorIfPresent(result, evalContents: expression);
+    var classDescriptor = result.result['result']['value'];
+    var classMetaData = ClassMetaData(
+        jsName: classDescriptor['name'] as String,
+        libraryId: libraryRef.id,
+        dartName: classDescriptor['dartName'] as String);
+
+    var methodRefs = <FuncRef>[];
+    var methodDescriptors = classDescriptor['methods'] as Map<String, dynamic>;
+    methodDescriptors.forEach((name, descriptor) {
+      var methodId = '${classMetaData.id}:$name';
+      methodRefs.add(FuncRef(
+          id: methodId,
+          name: name,
+          owner: classRef,
+          isConst: descriptor['isConst'] as bool,
+          isStatic: descriptor['isStatic'] as bool));
+    });
+    var fieldRefs = <FieldRef>[];
+    var fieldDescriptors = classDescriptor['fields'] as Map<String, dynamic>;
+    fieldDescriptors.forEach((name, descriptor) async {
+      var classMetaData = ClassMetaData(
+          jsName: descriptor['classRefName'],
+          libraryId: descriptor['classRefLibraryId'],
+          dartName: descriptor['classRefDartName']);
+      fieldRefs.add(FieldRef(
+          name: name,
+          owner: classRef,
+          declaredType: InstanceRef(
+              id: createId(),
+              kind: InstanceKind.kType,
+              classRef: classMetaData.classRef),
+          isConst: descriptor['isConst'] as bool,
+          isFinal: descriptor['isFinal'] as bool,
+          isStatic: descriptor['isStatic'] as bool,
+          id: createId()));
+    });
+
+    // TODO: Implement the rest of these
+    // https://github.com/dart-lang/webdev/issues/176.
+    return Class(
+        name: classMetaData.jsName,
+        isAbstract: false,
+        isConst: false,
+        library: libraryRef,
+        interfaces: [],
+        fields: fieldRefs,
+        functions: methodRefs,
+        subclasses: [],
+        id: classMetaData.id);
+  }
+}

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -8,11 +8,11 @@ import '../utilities/wrapped_service.dart';
 import 'inspector.dart';
 import 'metadata.dart';
 
-/// A hard-coded ClassRef for the String class.
-final classRefForString = classRefFor('dart:core', InstanceKind.kString);
-
 /// A hard-coded ClassRef for the Closure class.
 final classRefForClosure = classRefFor('dart:core', 'Closure');
+
+/// A hard-coded ClassRef for the String class.
+final classRefForString = classRefFor('dart:core', InstanceKind.kString);
 
 /// A hard-coded ClassRef for a (non-existent) class called Unknown.
 final classRefForUnknown = classRefFor('dart:core', 'Unknown');

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -19,7 +19,7 @@ final classRefForUnknown = classRefFor('dart:core', 'Unknown');
 
 /// Returns a [ClassRef] for the provided library ID and class name.
 ClassRef classRefFor(String libraryId, String name) =>
-    ClassRef(id: 'classes\$$libraryId\$$name', name: name);
+    ClassRef(id: 'classes|$libraryId|$name', name: name);
 
 /// Keeps track of Dart classes available in the running application.
 class ClassHelper extends Domain {
@@ -47,10 +47,10 @@ class ClassHelper extends Domain {
   }
 
   Future<Class> forObjectId(String objectId) async {
-    if (!objectId.startsWith('classes\$')) return null;
+    if (!objectId.startsWith('classes|')) return null;
     var clazz = _classes[objectId];
     if (clazz != null) return clazz;
-    var splitId = objectId.split('\$');
+    var splitId = objectId.split('|');
     var libraryId = splitId[1];
     var libraryRef = await inspector.libraryHelper.libraryRefFor(libraryId);
     var classRef = classRefFor(libraryId, splitId.last);

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -79,7 +79,7 @@ class AppInspector extends Domain {
   AppInspector get inspector => this;
 
   Future<void> _initialize() async {
-    var libraries = await libraryHelper.getLibraryRefs();
+    var libraries = await libraryHelper.libraryRefs;
     isolate.libraries.addAll(libraries);
     await DartUri.recordAbsoluteUris(libraries.map((lib) => lib.uri));
 

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -6,22 +6,23 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dwds/src/connections/app_connection.dart';
-import 'package:dwds/src/debugging/location.dart';
-import 'package:dwds/src/debugging/remote_debugger.dart';
+import 'package:dwds/src/debugging/debugger.dart';
 import 'package:path/path.dart' as p;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../../asset_handler.dart';
-import '../services/chrome_proxy_service.dart';
+import '../connections/app_connection.dart';
+import '../debugging/location.dart';
+import '../debugging/remote_debugger.dart';
 import '../utilities/conversions.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/domain.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
+import 'classes.dart';
 import 'exceptions.dart';
 import 'instance.dart';
-import 'metadata.dart';
+import 'libraries.dart';
 
 /// An inspector for a running Dart application contained in the
 /// [WipConnection].
@@ -29,13 +30,9 @@ import 'metadata.dart';
 /// Provides information about currently loaded scripts and objects and support
 /// for eval.
 class AppInspector extends Domain {
-  /// Map of class ID to [Class].
-  final _classes = <String, Class>{};
-
   Future<List<ScriptRef>> _cachedScriptRefs;
 
-  Future<List<ScriptRef>> get _scriptRefs =>
-      _cachedScriptRefs ??= _getScripts();
+  Future<List<ScriptRef>> get scriptRefs => _cachedScriptRefs ??= _getScripts();
 
   /// Map of scriptRef ID to [ScriptRef].
   final _scriptRefsById = <String, ScriptRef>{};
@@ -43,22 +40,21 @@ class AppInspector extends Domain {
   /// Map of Dart server path to [ScriptRef].
   final _serverPathToScriptRef = <String, ScriptRef>{};
 
-  /// Map of library ID to [Library].
-  final _libraries = <String, Library>{};
-
-  /// Map of libraryRef ID to [LibraryRef].
-  final _libraryRefs = <String, LibraryRef>{};
-
   /// Map of [ScriptRef] id to containing [LibraryRef] id.
   final _scriptIdToLibraryId = <String, String>{};
 
-  final RemoteDebugger _remoteDebugger;
-  final AssetHandler _assetHandler;
-  final Locations _locations;
+  final RemoteDebugger remoteDebugger;
+  final Debugger debugger;
   final Isolate isolate;
   final IsolateRef isolateRef;
-  final InstanceHelper instanceHelper;
   final AppConnection appConnection;
+
+  final LibraryHelper libraryHelper;
+  final ClassHelper classHelper;
+  final InstanceHelper instanceHelper;
+
+  final AssetHandler _assetHandler;
+  final Locations _locations;
 
   /// The root URI from which the application is served.
   final String _root;
@@ -66,11 +62,14 @@ class AppInspector extends Domain {
   AppInspector._(
     this.appConnection,
     this.isolate,
+    this.remoteDebugger,
+    this.debugger,
+    this.libraryHelper,
+    this.classHelper,
+    this.instanceHelper,
     this._assetHandler,
     this._locations,
     this._root,
-    this._remoteDebugger,
-    this.instanceHelper,
   )   : isolateRef = _toIsolateRef(isolate),
         super.forInspector();
 
@@ -80,7 +79,7 @@ class AppInspector extends Domain {
   AppInspector get inspector => this;
 
   Future<void> _initialize() async {
-    var libraries = await _getLibraryRefs();
+    var libraries = await libraryHelper.getLibraryRefs();
     isolate.libraries.addAll(libraries);
     await DartUri.recordAbsoluteUris(libraries.map((lib) => lib.uri));
 
@@ -95,13 +94,13 @@ class AppInspector extends Domain {
       IsolateRef(id: isolate.id, name: isolate.name, number: isolate.number);
 
   static Future<AppInspector> initialize(
-      AppConnection appConnection,
-      RemoteDebugger remoteDebugger,
-      AssetHandler assetHandler,
-      Locations locations,
-      String root,
-      InstanceHelper instanceHelper,
-      String pauseMode) async {
+    AppConnection appConnection,
+    RemoteDebugger remoteDebugger,
+    AssetHandler assetHandler,
+    Locations locations,
+    String root,
+    Debugger debugger,
+  ) async {
     var id = createId();
     var time = DateTime.now().millisecondsSinceEpoch;
     var name = '$root:main()';
@@ -119,19 +118,27 @@ class AppInspector extends Domain {
         livePorts: 0,
         libraries: [],
         breakpoints: [],
-        exceptionPauseMode: pauseMode)
+        exceptionPauseMode: debugger.pauseState)
       ..extensionRPCs = [];
-    var inspector = AppInspector._(
+    AppInspector appInspector;
+    var provider = () => appInspector;
+    var libraryHelper = LibraryHelper(provider);
+    var classHelper = ClassHelper(provider);
+    var instanceHelper = InstanceHelper(provider);
+    appInspector = AppInspector._(
       appConnection,
       isolate,
+      remoteDebugger,
+      debugger,
+      libraryHelper,
+      classHelper,
+      instanceHelper,
       assetHandler,
       locations,
       root,
-      remoteDebugger,
-      instanceHelper,
     );
-    await inspector._initialize();
-    return inspector;
+    await appInspector._initialize();
+    return appInspector;
   }
 
   /// Get the value of the field named [fieldName] from [receiver].
@@ -173,7 +180,7 @@ class AppInspector extends Domain {
       {bool returnByValue = false}) async {
     var jsArguments = arguments.map(callArgumentFor).toList();
     var result =
-        await _remoteDebugger.sendCommand('Runtime.callFunctionOn', params: {
+        await remoteDebugger.sendCommand('Runtime.callFunctionOn', params: {
       'functionDeclaration': evalExpression,
       'arguments': jsArguments,
       'objectId': receiver.objectId,
@@ -239,7 +246,7 @@ class AppInspector extends Domain {
       String expression, String libraryUri) {
     var evalExpression = '''
 (function() {
-  ${_getLibrarySnippet(libraryUri)};
+  ${getLibrarySnippet(libraryUri)};
   return library.$expression;
 })();
 ''';
@@ -250,7 +257,7 @@ class AppInspector extends Domain {
   Future<RemoteObject> jsEvaluate(String expression) async {
     // TODO(alanknight): Support a version with arguments if needed.
     WipResponse result;
-    result = await _remoteDebugger
+    result = await remoteDebugger
         .sendCommand('Runtime.evaluate', params: {'expression': expression});
     handleErrorIfPresent(result, evalContents: expression, additionalDetails: {
       'Dart expression': expression,
@@ -264,7 +271,7 @@ class AppInspector extends Domain {
       Library library, String jsFunction, List<RemoteObject> arguments) async {
     var findLibrary = '''
 (function() {
-  ${_getLibrarySnippet(library.uri)};
+  ${getLibrarySnippet(library.uri)};
   return library;
 })();
 ''';
@@ -280,7 +287,7 @@ class AppInspector extends Domain {
     var arguments = scope.values.map(remoteObjectFor).toList();
     var evalExpression = '''
 function($argsString) {
-  ${_getLibrarySnippet(library.uri)};
+  ${getLibrarySnippet(library.uri)};
   return library.$expression;
 }
     ''';
@@ -289,20 +296,16 @@ function($argsString) {
 
   Future<Library> _getLibrary(String isolateId, String objectId) async {
     if (isolateId != isolate.id) return null;
-    var libraryRef = _libraryRefs[objectId];
+    var libraryRef = await libraryHelper.libraryRefFor(objectId);
     if (libraryRef == null) return null;
-    var library = _libraries[objectId];
-    if (library != null) return library;
-    library = await _constructLibrary(libraryRef);
-    _libraries[objectId] = library;
-    return library;
+    return libraryHelper.libraryFor(libraryRef);
   }
 
   Future getObject(String isolateId, String objectId,
       {int offset, int count}) async {
     var library = await _getLibrary(isolateId, objectId);
     if (library != null) return library;
-    var clazz = _classes[objectId];
+    var clazz = await classHelper.forObjectId(objectId);
     if (clazz != null) return clazz;
     var scriptRef = _scriptRefsById[objectId];
     if (scriptRef != null) return await _getScript(isolateId, scriptRef);
@@ -311,132 +314,6 @@ function($argsString) {
     if (instance != null) return instance;
     throw UnsupportedError('Only libraries, instances, classes, and scripts '
         'are supported for getObject');
-  }
-
-  Future<Library> _constructLibrary(LibraryRef libraryRef) async {
-    // Fetch information about all the classes in this library.
-    var expression = '''
-    (function() {
-      ${_getLibrarySnippet(libraryRef.uri)}
-      var result = {};
-      var classes = Object.values(Object.getOwnPropertyDescriptors(library))
-        .filter((p) => 'value' in p)
-        .map((p) => p.value)
-        .filter((l) => l && sdkUtils.isType(l));
-      var classList = classes.map(function(clazz) {
-        var descriptor = {
-          'name': clazz.name, 
-          'dartName': sdkUtils.typeName(clazz)
-        };
-        // TODO(jakemac): static methods once ddc supports them
-        var methods = sdkUtils.getMethods(clazz);
-        var methodNames = methods ? Object.keys(methods) : [];
-        descriptor['methods'] = {};
-        for (var name of methodNames) {
-          var method = methods[name];
-          descriptor['methods'][name] = {
-            // TODO(jakemac): how can we get actual const info?
-            "isConst": false,
-            "isStatic": false,
-          }
-        }
-
-        // TODO(jakemac): static fields once ddc supports them
-        var fields = sdkUtils.getFields(clazz);
-        var fieldNames = fields ? Object.keys(fields) : [];
-        descriptor['fields'] = {};
-        for (var name of fieldNames) {
-          var field = fields[name];
-          var libraryUri = Object.getOwnPropertySymbols(fields[name]["type"])
-          .find(x => x.description == "libraryUri");
-          descriptor['fields'][name] = {
-            // TODO(jakemac): how can we get actual const info?
-            "isConst": false,
-            "isFinal": field.isFinal,
-            "isStatic": false,
-            "classRefName": fields[name]["type"]["name"],
-            "classRefDartName": sdkUtils.typeName(fields[name]["type"]),
-            "classRefLibraryId" : field["type"][libraryUri],
-          }
-        }
-
-        return descriptor;
-      });
-      result['classes'] = classList;
-      return result;
-    })()
-    ''';
-    var result = await _remoteDebugger.sendCommand('Runtime.evaluate',
-        params: {'expression': expression, 'returnByValue': true});
-    handleErrorIfPresent(result, evalContents: expression);
-    var classDescriptors = (result.result['result']['value']['classes'] as List)
-        .cast<Map<String, Object>>();
-    var classRefs = <ClassRef>[];
-    for (var classDescriptor in classDescriptors) {
-      var classMetaData = ClassMetaData(
-          jsName: classDescriptor['name'] as String,
-          libraryId: libraryRef.id,
-          dartName: classDescriptor['dartName'] as String);
-      var classRef = ClassRef(name: classMetaData.jsName, id: classMetaData.id);
-      classRefs.add(classRef);
-
-      var methodRefs = <FuncRef>[];
-      var methodDescriptors =
-          classDescriptor['methods'] as Map<String, dynamic>;
-      methodDescriptors.forEach((name, descriptor) {
-        var methodId = '${classMetaData.id}:$name';
-        methodRefs.add(FuncRef(
-            id: methodId,
-            name: name,
-            owner: classRef,
-            isConst: descriptor['isConst'] as bool,
-            isStatic: descriptor['isStatic'] as bool));
-      });
-
-      var fieldRefs = <FieldRef>[];
-      var fieldDescriptors = classDescriptor['fields'] as Map<String, dynamic>;
-      fieldDescriptors.forEach((name, descriptor) async {
-        var classMetaData = ClassMetaData(
-            jsName: descriptor['classRefName'],
-            libraryId: descriptor['classRefLibraryId'],
-            dartName: descriptor['classRefDartName']);
-        fieldRefs.add(FieldRef(
-            name: name,
-            owner: classRef,
-            declaredType: InstanceRef(
-                id: createId(),
-                kind: InstanceKind.kType,
-                classRef:
-                    ClassRef(name: classMetaData.jsName, id: classMetaData.id)),
-            isConst: descriptor['isConst'] as bool,
-            isFinal: descriptor['isFinal'] as bool,
-            isStatic: descriptor['isStatic'] as bool,
-            id: createId()));
-      });
-
-      // TODO: Implement the rest of these
-      // https://github.com/dart-lang/webdev/issues/176.
-      _classes[classMetaData.id] = Class(
-          name: classMetaData.jsName,
-          isAbstract: false,
-          isConst: false,
-          library: libraryRef,
-          interfaces: [],
-          fields: fieldRefs,
-          functions: methodRefs,
-          subclasses: [],
-          id: classMetaData.id);
-    }
-    return Library(
-        name: libraryRef.name,
-        uri: libraryRef.uri,
-        debuggable: true,
-        dependencies: [],
-        scripts: await _scriptRefs,
-        variables: [],
-        functions: [],
-        classes: classRefs,
-        id: libraryRef.id);
   }
 
   Future<Script> _getScript(String isolateId, ScriptRef scriptRef) async {
@@ -448,10 +325,9 @@ function($argsString) {
     }
     var script = await response.readAsString();
     return Script(
-      uri: scriptRef.uri,
-      library: _libraryRefs[libraryId],
-      id: scriptRef.id,
-    )
+        uri: scriptRef.uri,
+        library: await libraryHelper.libraryRefFor(libraryId),
+        id: scriptRef.id)
       ..tokenPosTable = await _locations.tokenPosTableFor(serverPath)
       ..source = script;
   }
@@ -468,7 +344,7 @@ function($argsString) {
   /// All the scripts in the isolate.
   Future<ScriptList> getScripts(String isolateId) async {
     checkIsolate(isolateId);
-    return ScriptList()..scripts = await _scriptRefs;
+    return ScriptList()..scripts = await scriptRefs;
   }
 
   Future<List<ScriptRef>> _getScripts() async {
@@ -498,7 +374,7 @@ function($argsString) {
       return allScripts;
     })()
     ''';
-    var result = await _remoteDebugger.sendCommand('Runtime.evaluate',
+    var result = await remoteDebugger.sendCommand('Runtime.evaluate',
         params: {'expression': expression, 'returnByValue': true});
     handleErrorIfPresent(result, evalContents: expression);
     var allScripts = result.result['result']['value'];
@@ -514,7 +390,7 @@ function($argsString) {
         for (var part in parts)
           ScriptRef(uri: p.url.join(parent, part), id: createId())
       ];
-      var libraryRef = _libraryRefs[uri];
+      var libraryRef = await libraryHelper.libraryRefFor(uri);
       for (var scriptRef in scriptRefs) {
         _scriptRefsById[scriptRef.id] = scriptRef;
         _scriptIdToLibraryId[scriptRef.id] = libraryRef.id;
@@ -528,56 +404,13 @@ function($argsString) {
   Future<ScriptRef> scriptWithId(String scriptId) async =>
       _scriptRefsById[scriptId];
 
-  /// Returns all libraryRefs in the app.
-  ///
-  /// Note this can return a cached result.
-  Future<List<LibraryRef>> _getLibraryRefs() async {
-    if (_libraryRefs.isNotEmpty) return _libraryRefs.values.toList();
-    var expression = '''
-      (function() {
-        $getLibraries
-        return libs;
-      })()
-     ''';
-    var librariesResult = await _remoteDebugger.sendCommand('Runtime.evaluate',
-        params: {'expression': expression, 'returnByValue': true});
-    handleErrorIfPresent(librariesResult, evalContents: expression);
-    var libraries =
-        List<String>.from(librariesResult.result['result']['value'] as List);
-    // Filter out any non-Dart libraries, which basically means the .bootstrap
-    // library from build_web_runners.
-    var dartLibraries = libraries
-        .where((name) => name.startsWith('dart:') || name.endsWith('.dart'));
-    for (var library in dartLibraries) {
-      var ref = LibraryRef(id: library, name: library, uri: library);
-      _libraryRefs[ref.id] = ref;
-    }
-    return _libraryRefs.values.toList();
-  }
-
   /// Runs an eval on the page to compute all existing registered extensions.
   Future<List<String>> _getExtensionRpcs() async {
     var expression =
         "$loadModule('dart_sdk').developer._extensions.keys.toList();";
-    var extensionsResult = await _remoteDebugger.sendCommand('Runtime.evaluate',
+    var extensionsResult = await remoteDebugger.sendCommand('Runtime.evaluate',
         params: {'expression': expression, 'returnByValue': true});
     handleErrorIfPresent(extensionsResult, evalContents: expression);
     return List.from(extensionsResult.result['result']['value'] as List);
   }
 }
-
-/// Creates a snippet of JS code that initializes a `library` variable that has
-/// the actual library object in DDC for [libraryUri].
-///
-/// In DDC we have module libraries indexed by names of the form
-/// 'packages/package/mainFile' with no .dart suffix on the file, or
-/// 'directory/packageName/mainFile', also with no .dart suffix, and relative to
-/// the serving root, normally /web within the package. These modules have a map
-/// from the URI with a Dart-specific scheme (package: or org-dartlang-app:) to
-/// the library objects. The [libraryUri] parameter should be one of these
-/// Dart-specific scheme URIs, and we set `library` the corresponding library.
-String _getLibrarySnippet(String libraryUri) => '''
-   var sdkUtils = $loadModule('dart_sdk').dart;
-   var library = sdkUtils.getLibrary('$libraryUri');
-   if (!library) throw 'cannot find library for $libraryUri';
-  ''';

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -15,7 +15,7 @@ import 'metadata.dart';
 
 /// Creates an [InstanceRef] for a primitive [RemoteObject].
 InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
-  var classRef = classRefFor('dart:core', remoteObject?.type);
+  var classRef = classRefFor('dart:core', kind);
   return InstanceRef(
       kind: kind, classRef: classRef, id: dartIdFor(remoteObject?.value))
     ..valueAsString = '${remoteObject?.value}';

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -13,6 +13,14 @@ import 'classes.dart';
 import 'inspector.dart';
 import 'metadata.dart';
 
+/// Creates an [InstanceRef] for a primitive [RemoteObject].
+InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
+  var classRef = classRefFor('dart:core', remoteObject?.type);
+  return InstanceRef(
+      kind: kind, classRef: classRef, id: dartIdFor(remoteObject?.value))
+    ..valueAsString = '${remoteObject?.value}';
+}
+
 /// Contains a set of methods for getting [Instance]s and [InstanceRef]s.
 class InstanceHelper extends Domain {
   InstanceHelper(AppInspector Function() provider) : super(provider);
@@ -293,13 +301,5 @@ class InstanceHelper extends Domain {
         // Return null for an unsupported type. This is likely a JS construct.
         return null;
     }
-  }
-
-  /// Creates an [InstanceRef] for a primitive [RemoteObject].
-  InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
-    var classRef = classRefFor('dart:core', remoteObject?.type);
-    return InstanceRef(
-        kind: kind, classRef: classRef, id: dartIdFor(remoteObject?.value))
-      ..valueAsString = '${remoteObject?.value}';
   }
 }

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -9,48 +9,18 @@ import '../utilities/domain.dart';
 import '../utilities/objects.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
-import 'debugger.dart';
+import 'classes.dart';
 import 'inspector.dart';
 import 'metadata.dart';
-import 'remote_debugger.dart';
-
-/// Creates an [InstanceRef] for a primitive [RemoteObject].
-InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
-  var classRef = ClassRef(
-      // TODO(grouma) - is this ID correct?
-      id: 'dart:core:${remoteObject?.type}',
-      name: kind);
-  return InstanceRef(
-      kind: kind, classRef: classRef, id: dartIdFor(remoteObject?.value))
-    ..valueAsString = '${remoteObject?.value}';
-}
-
-/// A hard-coded ClassRef for the String class.
-final _classRefForString =
-    ClassRef(id: 'dart:core:String', name: InstanceKind.kString);
-
-/// A hard-coded ClassRef for the Closure class.
-// TODO(grouma) - orgnaize our static classRefs better.
-final _classRefForClosure = ClassRef(name: 'Closure', id: createId());
-
-/// A hard-coded ClassRef for a (non-existent) class called Unknown.
-final _classRefForUnknown = ClassRef(name: 'Unknown', id: createId());
 
 /// Contains a set of methods for getting [Instance]s and [InstanceRef]s.
 class InstanceHelper extends Domain {
-  final Debugger _debugger;
-  final RemoteDebugger _remoteDebugger;
-
-  InstanceHelper(
-      this._debugger, this._remoteDebugger, AppInspector Function() provider)
-      : super(provider);
+  InstanceHelper(AppInspector Function() provider) : super(provider);
 
   Future<Instance> _stringInstanceFor(RemoteObject remoteObject) async {
     var actualString = stringFromDartId(remoteObject.objectId);
     return Instance(
-        kind: InstanceKind.kString,
-        classRef: _classRefForString,
-        id: createId())
+        kind: InstanceKind.kString, classRef: classRefForString, id: createId())
       ..valueAsString = actualString
       ..length = actualString.length;
   }
@@ -59,7 +29,7 @@ class InstanceHelper extends Domain {
     var result = Instance(
         kind: InstanceKind.kClosure,
         id: remoteObject.objectId,
-        classRef: _classRefForClosure);
+        classRef: classRefForClosure);
     return result;
   }
 
@@ -72,12 +42,13 @@ class InstanceHelper extends Domain {
       return _stringInstanceFor(remoteObject);
     }
     var metaData = await ClassMetaData.metaDataFor(
-        _remoteDebugger, remoteObject, inspector);
+        inspector.remoteDebugger, remoteObject, inspector);
     var classRef = metaData.classRef;
     if (metaData.jsName == 'Function') {
       return _closureInstanceFor(remoteObject);
     }
-    var properties = await _debugger.getProperties(remoteObject.objectId);
+    var properties =
+        await inspector.debugger.getProperties(remoteObject.objectId);
     if (metaData.jsName == 'JSArray') {
       return await _listInstanceFor(classRef, remoteObject, properties);
     } else if (metaData.jsName == 'LinkedMap' ||
@@ -215,12 +186,12 @@ class InstanceHelper extends Domain {
       const sdk = $loadModule("dart_sdk");
       const sdk_utils = sdk.dart;
       const fields = sdk_utils.getFields(sdk_utils.getType(this)) || [];
-      if (!fields && (dart_sdk._interceptors.JSArray.is(this) || 
+      if (!fields && (dart_sdk._interceptors.JSArray.is(this) ||
           dart_sdk._js_helper.InternalMap.is(this))) {
         // Trim off the 'length' property.
         const fields = allJsProperties.slice(0, allJsProperties.length -1);
         return fields.join(',');
-      } 
+      }
       const privateFields = sdk_utils.getOwnPropertySymbols(fields);
       const nonSymbolNames = privateFields.map(sym => sym.description);
       const publicFieldNames = sdk_utils.getOwnPropertyNames(fields);
@@ -267,7 +238,7 @@ class InstanceHelper extends Domain {
       case 'string':
         return InstanceRef(
             id: dartIdFor(remoteObject.value),
-            classRef: _classRefForString,
+            classRef: classRefForString,
             kind: InstanceKind.kString)
           ..valueAsString = remoteObject.value as String;
       case 'number':
@@ -281,7 +252,7 @@ class InstanceHelper extends Domain {
           return _primitiveInstance(InstanceKind.kNull, remoteObject);
         }
         var metaData = await ClassMetaData.metaDataFor(
-            _remoteDebugger, remoteObject, inspector);
+            inspector.remoteDebugger, remoteObject, inspector);
         if (metaData == null) return null;
         if (metaData.jsName == 'JSArray') {
           return InstanceRef(
@@ -303,18 +274,18 @@ class InstanceHelper extends Domain {
             id: remoteObject.objectId,
             classRef: metaData.classRef);
       case 'function':
-        var functionMetaData =
-            await FunctionMetaData.metaDataFor(_remoteDebugger, remoteObject);
+        var functionMetaData = await FunctionMetaData.metaDataFor(
+            inspector.remoteDebugger, remoteObject);
         return InstanceRef(
             kind: InstanceKind.kClosure,
             id: remoteObject.objectId,
-            classRef: _classRefForClosure)
+            classRef: classRefForClosure)
           // TODO(grouma) - fill this in properly.
           ..closureFunction = FuncRef(
               name: functionMetaData.name,
               id: createId(),
               // TODO(alanknight): The right ClassRef
-              owner: _classRefForUnknown,
+              owner: classRefForUnknown,
               isConst: false,
               isStatic: false)
           ..closureContext = (ContextRef()..length = 0);
@@ -322,5 +293,13 @@ class InstanceHelper extends Domain {
         // Return null for an unsupported type. This is likely a JS construct.
         return null;
     }
+  }
+
+  /// Creates an [InstanceRef] for a primitive [RemoteObject].
+  InstanceRef _primitiveInstance(String kind, RemoteObject remoteObject) {
+    var classRef = classRefFor('dart:core', remoteObject?.type);
+    return InstanceRef(
+        kind: kind, classRef: classRef, id: dartIdFor(remoteObject?.value))
+      ..valueAsString = '${remoteObject?.value}';
   }
 }

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -12,50 +12,48 @@ import 'metadata.dart';
 /// Keeps track of Dart libraries available in the running application.
 class LibraryHelper extends Domain {
   /// Map of library ID to [Library].
-  final _libraries = <String, Library>{};
+  final _librariesById = <String, Library>{};
 
   /// Map of libraryRef ID to [LibraryRef].
-  final _libraryRefs = <String, LibraryRef>{};
+  final _libraryRefsById = <String, LibraryRef>{};
 
   LibraryHelper(AppInspector Function() provider) : super(provider);
 
   /// Returns all libraryRefs in the app.
   ///
   /// Note this can return a cached result.
-  Future<List<LibraryRef>> getLibraryRefs() async {
-    if (_libraryRefs.isNotEmpty) return _libraryRefs.values.toList();
+  Future<List<LibraryRef>> get libraryRefs async {
+    if (_libraryRefsById.isNotEmpty) return _libraryRefsById.values.toList();
     var expression = '''
       (function() {
         $getLibraries
         return libs;
       })()
      ''';
-    var librariesResult = await inspector.remoteDebugger.sendCommand(
-        'Runtime.evaluate',
+    var result = await inspector.remoteDebugger.sendCommand('Runtime.evaluate',
         params: {'expression': expression, 'returnByValue': true});
-    handleErrorIfPresent(librariesResult, evalContents: expression);
-    var libraries =
-        List<String>.from(librariesResult.result['result']['value'] as List);
+    handleErrorIfPresent(result, evalContents: expression);
+    var libraries = List<String>.from(result.result['result']['value'] as List);
     // Filter out any non-Dart libraries, which basically means the .bootstrap
     // library from build_web_runners.
     var dartLibraries = libraries
         .where((name) => name.startsWith('dart:') || name.endsWith('.dart'));
     for (var library in dartLibraries) {
       var ref = LibraryRef(id: library, name: library, uri: library);
-      _libraryRefs[ref.id] = ref;
+      _libraryRefsById[ref.id] = ref;
     }
-    return _libraryRefs.values.toList();
+    return _libraryRefsById.values.toList();
   }
 
   Future<Library> libraryFor(LibraryRef libraryRef) async {
-    var library = _libraries[libraryRef.id];
+    var library = _librariesById[libraryRef.id];
     if (library != null) return library;
-    return _libraries[libraryRef.id] = await _constructLibrary(libraryRef);
+    return _librariesById[libraryRef.id] = await _constructLibrary(libraryRef);
   }
 
   Future<LibraryRef> libraryRefFor(String objectId) async {
-    if (_libraryRefs.isEmpty) await getLibraryRefs();
-    return _libraryRefs[objectId];
+    if (_libraryRefsById.isEmpty) await libraryRefs;
+    return _libraryRefsById[objectId];
   }
 
   Future<Library> _constructLibrary(LibraryRef libraryRef) async {
@@ -86,9 +84,9 @@ class LibraryHelper extends Domain {
         .cast<Map<String, Object>>();
     var classRefs = classDescriptors.map<ClassRef>((classDescriptor) {
       var classMetaData = ClassMetaData(
-          jsName: classDescriptor['name'] as String,
+          jsName: classDescriptor['name'],
           libraryId: libraryRef.id,
-          dartName: classDescriptor['dartName'] as String);
+          dartName: classDescriptor['dartName']);
       return classMetaData.classRef;
     }).toList();
     return Library(

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -19,11 +19,6 @@ class LibraryHelper extends Domain {
 
   LibraryHelper(AppInspector Function() provider) : super(provider);
 
-  Future<LibraryRef> libraryRefFor(String objectId) async {
-    if (_libraryRefs.isEmpty) await getLibraryRefs();
-    return _libraryRefs[objectId];
-  }
-
   /// Returns all libraryRefs in the app.
   ///
   /// Note this can return a cached result.
@@ -56,6 +51,11 @@ class LibraryHelper extends Domain {
     var library = _libraries[libraryRef.id];
     if (library != null) return library;
     return _libraries[libraryRef.id] = await _constructLibrary(libraryRef);
+  }
+
+  Future<LibraryRef> libraryRefFor(String objectId) async {
+    if (_libraryRefs.isEmpty) await getLibraryRefs();
+    return _libraryRefs[objectId];
   }
 
   Future<Library> _constructLibrary(LibraryRef libraryRef) async {

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.import 'dart:async';
+
+import 'package:dwds/src/debugging/inspector.dart';
+
+import '../utilities/domain.dart';
+import '../utilities/shared.dart';
+import '../utilities/wrapped_service.dart';
+import 'metadata.dart';
+
+/// Keeps track of Dart libraries available in the running application.
+class LibraryHelper extends Domain {
+  /// Map of library ID to [Library].
+  final _libraries = <String, Library>{};
+
+  /// Map of libraryRef ID to [LibraryRef].
+  final _libraryRefs = <String, LibraryRef>{};
+
+  LibraryHelper(AppInspector Function() provider) : super(provider);
+
+  Future<LibraryRef> libraryRefFor(String objectId) async {
+    if (_libraryRefs.isEmpty) await getLibraryRefs();
+    return _libraryRefs[objectId];
+  }
+
+  /// Returns all libraryRefs in the app.
+  ///
+  /// Note this can return a cached result.
+  Future<List<LibraryRef>> getLibraryRefs() async {
+    if (_libraryRefs.isNotEmpty) return _libraryRefs.values.toList();
+    var expression = '''
+      (function() {
+        $getLibraries
+        return libs;
+      })()
+     ''';
+    var librariesResult = await inspector.remoteDebugger.sendCommand(
+        'Runtime.evaluate',
+        params: {'expression': expression, 'returnByValue': true});
+    handleErrorIfPresent(librariesResult, evalContents: expression);
+    var libraries =
+        List<String>.from(librariesResult.result['result']['value'] as List);
+    // Filter out any non-Dart libraries, which basically means the .bootstrap
+    // library from build_web_runners.
+    var dartLibraries = libraries
+        .where((name) => name.startsWith('dart:') || name.endsWith('.dart'));
+    for (var library in dartLibraries) {
+      var ref = LibraryRef(id: library, name: library, uri: library);
+      _libraryRefs[ref.id] = ref;
+    }
+    return _libraryRefs.values.toList();
+  }
+
+  Future<Library> libraryFor(LibraryRef libraryRef) async {
+    var library = _libraries[libraryRef.id];
+    if (library != null) return library;
+    return _libraries[libraryRef.id] = await _constructLibrary(libraryRef);
+  }
+
+  Future<Library> _constructLibrary(LibraryRef libraryRef) async {
+    // Fetch information about all the classes in this library.
+    var expression = '''
+    (function() {
+      ${getLibrarySnippet(libraryRef.uri)}
+      var result = {};
+      var classes = Object.values(Object.getOwnPropertyDescriptors(library))
+        .filter((p) => 'value' in p)
+        .map((p) => p.value)
+        .filter((l) => l && sdkUtils.isType(l));
+      var classList = classes.map(function(clazz) {
+        var descriptor = {
+          'name': clazz.name,
+          'dartName': sdkUtils.typeName(clazz)
+        };
+        return descriptor;
+      });
+      result['classes'] = classList;
+      return result;
+    })()
+    ''';
+    var result = await inspector.remoteDebugger.sendCommand('Runtime.evaluate',
+        params: {'expression': expression, 'returnByValue': true});
+    handleErrorIfPresent(result, evalContents: expression);
+    var classDescriptors = (result.result['result']['value']['classes'] as List)
+        .cast<Map<String, Object>>();
+    var classRefs = classDescriptors.map<ClassRef>((classDescriptor) {
+      var classMetaData = ClassMetaData(
+          jsName: classDescriptor['name'] as String,
+          libraryId: libraryRef.id,
+          dartName: classDescriptor['dartName'] as String);
+      return classMetaData.classRef;
+    }).toList();
+    return Library(
+        name: libraryRef.name,
+        uri: libraryRef.uri,
+        debuggable: true,
+        dependencies: [],
+        scripts: await inspector.scriptRefs,
+        variables: [],
+        functions: [],
+        classes: classRefs,
+        id: libraryRef.id);
+  }
+}

--- a/dwds/lib/src/debugging/metadata.dart
+++ b/dwds/lib/src/debugging/metadata.dart
@@ -4,6 +4,7 @@
 
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../debugging/classes.dart';
 import '../debugging/inspector.dart';
 import '../services/chrome_proxy_service.dart';
 import '../utilities/shared.dart';
@@ -54,7 +55,7 @@ class ClassMetaData {
         const classObject = sdkUtils.getReifiedType(arg);
         const isFunction = sdkUtils.AbstractFunctionType.is(classObject);
         const result = {};
-        result['name'] = isFunction ? 'Function' : classObject.name;        
+        result['name'] = isFunction ? 'Function' : classObject.name;
         result['dartName'] = sdkUtils.typeName(classObject);
         result['length'] = arg['length'];
         result['libraryId'] = sdkUtils.getLibraryUri(classObject);
@@ -76,7 +77,7 @@ class ClassMetaData {
   }
 
   /// Return a [ClassRef] appropriate to this metadata.
-  ClassRef get classRef => ClassRef(name: dartName, id: id);
+  ClassRef get classRef => classRefFor(libraryId, dartName);
 }
 
 /// Meta data for a remote Dart function in Chrome.

--- a/dwds/lib/src/debugging/modules.dart
+++ b/dwds/lib/src/debugging/modules.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:path/path.dart' as p;
 
-import '../services/chrome_proxy_service.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/shared.dart';
 import 'remote_debugger.dart';

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -53,7 +53,7 @@ class ChromeProxyService implements VmServiceInterface {
   final RemoteDebugger remoteDebugger;
 
   /// Provides debugger-related functionality.
-  Future<Debugger> get debugger => _debuggerCompleter.future;
+  Future<Debugger> get _debugger => _debuggerCompleter.future;
 
   final AssetHandler _assetHandler;
 
@@ -127,7 +127,7 @@ class ChromeProxyService implements VmServiceInterface {
 
     _locations.clearCache();
     _modules.initialize();
-    (await debugger).notifyPausedAtStart();
+    (await _debugger).notifyPausedAtStart();
 
     _inspector = await AppInspector.initialize(
       appConnection,
@@ -135,11 +135,11 @@ class ChromeProxyService implements VmServiceInterface {
       _assetHandler,
       _locations,
       uri,
-      await debugger,
+      await _debugger,
     );
 
     unawaited(appConnection.onStart.then((_) async {
-      await (await debugger).resumeFromStart();
+      await (await _debugger).resumeFromStart();
     }));
 
     var isolateRef = _inspector.isolateRef;
@@ -201,7 +201,8 @@ class ChromeProxyService implements VmServiceInterface {
   @override
   Future<Breakpoint> addBreakpoint(String isolateId, String scriptId, int line,
           {int column}) async =>
-      (await debugger).addBreakpoint(isolateId, scriptId, line, column: column);
+      (await _debugger)
+          .addBreakpoint(isolateId, scriptId, line, column: column);
 
   @override
   Future<Breakpoint> addBreakpointAtEntry(String isolateId, String functionId) {
@@ -214,7 +215,7 @@ class ChromeProxyService implements VmServiceInterface {
       {int column}) async {
     var dartUri = DartUri(scriptUri, uri);
     var ref = await _inspector.scriptRefFor(dartUri.serverPath);
-    return (await debugger)
+    return (await _debugger)
         .addBreakpoint(isolateId, ref.id, line, column: column);
   }
 
@@ -324,7 +325,7 @@ $loadModule("dart_sdk").developer.invokeExtension(
   /// Returns null if the corresponding isolate is not paused.
   @override
   Future<Stack> getStack(String isolateId) async =>
-      (await debugger).getStack(isolateId);
+      (await _debugger).getStack(isolateId);
 
   @override
   Future<VM> getVM() async {
@@ -404,7 +405,7 @@ $loadModule("dart_sdk").developer.invokeExtension(
   }
 
   @override
-  Future<Success> pause(String isolateId) async => (await debugger).pause();
+  Future<Success> pause(String isolateId) async => (await _debugger).pause();
 
   @override
   Future<Success> registerService(String service, String alias) async {
@@ -420,13 +421,13 @@ $loadModule("dart_sdk").developer.invokeExtension(
   @override
   Future<Success> removeBreakpoint(
           String isolateId, String breakpointId) async =>
-      (await debugger).removeBreakpoint(isolateId, breakpointId);
+      (await _debugger).removeBreakpoint(isolateId, breakpointId);
 
   @override
   Future<Success> resume(String isolateId,
       {String step, int frameIndex}) async {
     if (_inspector.appConnection.isStarted) {
-      return await (await debugger)
+      return await (await _debugger)
           .resume(isolateId, step: step, frameIndex: frameIndex);
     } else {
       _inspector.appConnection.runMain();
@@ -436,7 +437,7 @@ $loadModule("dart_sdk").developer.invokeExtension(
 
   @override
   Future<Success> setExceptionPauseMode(String isolateId, String mode) async =>
-      (await debugger).setExceptionPauseMode(isolateId, mode);
+      (await _debugger).setExceptionPauseMode(isolateId, mode);
 
   @override
   Future<Success> setFlag(String name, String value) {

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -15,7 +15,6 @@ import '../../dwds.dart' show LogWriter;
 import '../connections/app_connection.dart';
 import '../debugging/debugger.dart';
 import '../debugging/inspector.dart';
-import '../debugging/instance.dart';
 import '../debugging/location.dart';
 import '../debugging/modules.dart';
 import '../debugging/remote_debugger.dart';
@@ -130,17 +129,13 @@ class ChromeProxyService implements VmServiceInterface {
     _modules.initialize();
     (await debugger).notifyPausedAtStart();
 
-    var instanceHelper =
-        InstanceHelper(await debugger, remoteDebugger, appInspectorProvider);
-
     _inspector = await AppInspector.initialize(
       appConnection,
       remoteDebugger,
       _assetHandler,
       _locations,
       uri,
-      instanceHelper,
-      (await debugger).pauseState,
+      await debugger,
     );
 
     unawaited(appConnection.onStart.then((_) async {
@@ -633,19 +628,6 @@ const _stderrTypes = ['error'];
 
 /// The `type`s of [ConsoleAPIEvent]s that are treated as `stdout` logs.
 const _stdoutTypes = ['log', 'info', 'warning'];
-
-/// Throws an [ExceptionDetails] object if `exceptionDetails` is present on the
-/// result.
-void handleErrorIfPresent(WipResponse response,
-    {String evalContents, Object additionalDetails}) {
-  if (response == null) return;
-  if (response.result.containsKey('exceptionDetails')) {
-    throw ChromeDebugException(
-        response.result['exceptionDetails'] as Map<String, dynamic>,
-        evalContents: evalContents,
-        additionalDetails: additionalDetails);
-  }
-}
 
 class ChromeDebugException extends ExceptionDetails implements Exception {
   /// Optional, additional information about the exception.

--- a/dwds/lib/src/utilities/shared.dart
+++ b/dwds/lib/src/utilities/shared.dart
@@ -4,8 +4,9 @@
 
 import 'dart:io';
 
-import 'package:dwds/dwds.dart' show ModuleStrategy;
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../../dwds.dart' show ChromeDebugException, ModuleStrategy;
 import '../utilities/wrapped_service.dart';
 
 VMRef toVMRef(VM vm) => VMRef()..name = vm.name;
@@ -56,4 +57,33 @@ String get getLibraries {
   }
   return expression +=
       "let libs = $loadModule('dart_sdk').dart.getLibraries();\n";
+}
+
+/// Creates a snippet of JS code that initializes a `library` variable that has
+/// the actual library object in DDC for [libraryUri].
+///
+/// In DDC we have module libraries indexed by names of the form
+/// 'packages/package/mainFile' with no .dart suffix on the file, or
+/// 'directory/packageName/mainFile', also with no .dart suffix, and relative to
+/// the serving root, normally /web within the package. These modules have a map
+/// from the URI with a Dart-specific scheme (package: or org-dartlang-app:) to
+/// the library objects. The [libraryUri] parameter should be one of these
+/// Dart-specific scheme URIs, and we set `library` the corresponding library.
+String getLibrarySnippet(String libraryUri) => '''
+   var sdkUtils = $loadModule('dart_sdk').dart;
+   var library = sdkUtils.getLibrary('$libraryUri');
+   if (!library) throw 'cannot find library for $libraryUri';
+  ''';
+
+/// Throws an [ExceptionDetails] object if `exceptionDetails` is present on the
+/// result.
+void handleErrorIfPresent(WipResponse response,
+    {String evalContents, Object additionalDetails}) {
+  if (response == null) return;
+  if (response.result.containsKey('exceptionDetails')) {
+    throw ChromeDebugException(
+        response.result['exceptionDetails'] as Map<String, dynamic>,
+        evalContents: evalContents,
+        additionalDetails: additionalDetails);
+  }
 }

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -69,7 +69,7 @@ class FakeInspector extends Domain implements AppInspector {
   @override
   IsolateRef get isolateRef => null;
   @override
-  InstanceHelper get instanceHelper => InstanceHelper(null, null, null);
+  InstanceHelper get instanceHelper => InstanceHelper(null);
 }
 
 class FakeSseConnection implements SseConnection {

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -25,8 +25,8 @@ void main() {
   setUpAll(() async {
     await context.setUp();
     var service = fetchChromeProxyService(context.debugConnection);
-    debugger = await service.debugger;
     inspector = service.appInspectorProvider();
+    debugger = inspector.debugger;
   });
 
   tearDownAll(() async {

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -27,7 +27,7 @@ void main() {
     await context.setUp();
     var chromeProxyService = fetchChromeProxyService(context.debugConnection);
     inspector = chromeProxyService.appInspectorProvider();
-    debugger = await chromeProxyService.debugger;
+    debugger = inspector.debugger;
     instanceHelper = InstanceHelper(chromeProxyService.appInspectorProvider);
   });
 

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -28,7 +28,7 @@ void main() {
     var chromeProxyService = fetchChromeProxyService(context.debugConnection);
     inspector = chromeProxyService.appInspectorProvider();
     debugger = inspector.debugger;
-    instanceHelper = InstanceHelper(chromeProxyService.appInspectorProvider);
+    instanceHelper = inspector.instanceHelper;
   });
 
   tearDownAll(() async {
@@ -59,7 +59,7 @@ void main() {
       expect(ref.kind, InstanceKind.kNull);
       var classRef = ref.classRef;
       expect(classRef.name, 'Null');
-      expect(classRef.id, 'dart:core:object');
+      expect(classRef.id, 'classes\$dart:core\$Null');
     });
 
     test('for a double', () async {
@@ -70,7 +70,7 @@ void main() {
       expect(ref.kind, InstanceKind.kDouble);
       var classRef = ref.classRef;
       expect(classRef.name, 'Double');
-      expect(classRef.id, 'dart:core:number');
+      expect(classRef.id, 'classes\$dart:core\$Double');
     });
 
     test('for a class', () async {
@@ -80,8 +80,8 @@ void main() {
       expect(ref.kind, InstanceKind.kPlainInstance);
       var classRef = ref.classRef;
       expect(classRef.name, 'MyTestClass');
-      expect(
-          classRef.id, 'org-dartlang-app:///web/scopes_main.dart:MyTestClass');
+      expect(classRef.id,
+          'classes\$org-dartlang-app:///web/scopes_main.dart\$MyTestClass');
     });
 
     test('for closure', () async {

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -59,7 +59,7 @@ void main() {
       expect(ref.kind, InstanceKind.kNull);
       var classRef = ref.classRef;
       expect(classRef.name, 'Null');
-      expect(classRef.id, 'classes\$dart:core\$Null');
+      expect(classRef.id, 'classes|dart:core|Null');
     });
 
     test('for a double', () async {
@@ -70,7 +70,7 @@ void main() {
       expect(ref.kind, InstanceKind.kDouble);
       var classRef = ref.classRef;
       expect(classRef.name, 'Double');
-      expect(classRef.id, 'classes\$dart:core\$Double');
+      expect(classRef.id, 'classes|dart:core|Double');
     });
 
     test('for a class', () async {
@@ -81,7 +81,7 @@ void main() {
       var classRef = ref.classRef;
       expect(classRef.name, 'MyTestClass');
       expect(classRef.id,
-          'classes\$org-dartlang-app:///web/scopes_main.dart\$MyTestClass');
+          'classes|org-dartlang-app:///web/scopes_main.dart|MyTestClass');
     });
 
     test('for closure', () async {

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -6,7 +6,6 @@ import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/debugging/instance.dart';
-import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:dwds/src/utilities/shared.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
@@ -21,7 +20,6 @@ WipConnection get tabConnection => context.tabConnection;
 
 void main() {
   AppInspector inspector;
-  RemoteDebugger remoteDebugger;
   Debugger debugger;
   InstanceHelper instanceHelper;
 
@@ -29,10 +27,8 @@ void main() {
     await context.setUp();
     var chromeProxyService = fetchChromeProxyService(context.debugConnection);
     inspector = chromeProxyService.appInspectorProvider();
-    remoteDebugger = chromeProxyService.remoteDebugger;
     debugger = await chromeProxyService.debugger;
-    instanceHelper = InstanceHelper(
-        debugger, remoteDebugger, chromeProxyService.appInspectorProvider);
+    instanceHelper = InstanceHelper(chromeProxyService.appInspectorProvider);
   });
 
   tearDownAll(() async {

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -101,7 +101,8 @@ void main() {
 
     test('evaluateJsOnCallFrame', () async {
       stack = await breakAt('nestedFunction', mainScript);
-      var debugger = await service.debugger;
+      var inspector = service.appInspectorProvider();
+      var debugger = inspector.debugger;
       var parameter = await debugger.evaluateJsOnCallFrameIndex(0, 'parameter');
       expect(parameter.value, matches(RegExp(r'\d+ world')));
       var ticks = await debugger.evaluateJsOnCallFrameIndex(1, 'ticks');


### PR DESCRIPTION
- Move `getLibrarySnippet` and `handleErrorIfPresent` into `shared.dart`
- Create new abstraction:
  - `libraries.dart` for working with Dart libraries
  - `classes.dart` for working with Dart classes
- Update `constructLibrary` (now within `libraries.dart`) to only construct the library and not cache any class information
- Update the `getClass` logic to lazily construct the class abstraction
- Update `AppInspector` to expose `debugger`, `remoteDebugger`, `instanceHelper`, `librariesHelper` and `classesHelper`
- Update `getObject` in `AppInspector` to now use all of the helpers

Closes https://github.com/dart-lang/webdev/issues/773