### PR TITLE
Tolerate trailing slash in base URI for SSE handler

### DIFF
--- a/dwds/lib/src/injected/client.js
+++ b/dwds/lib/src/injected/client.js
@@ -23699,7 +23699,7 @@
                 t1 = F.Uuid$().v1$0();
                 self.$dartAppInstanceId = t1;
               }
-              client = M.SseClient$(D._fixProtocol(H.S(self.$dartUriBase) + "/$sseHandler"));
+              client = M.SseClient$(D._fixProtocol(J.endsWith$1$s(self.$dartUriBase, "/") ? H.S(self.$dartUriBase) + "$sseHandler" : H.S(self.$dartUriBase) + "/$sseHandler"));
               t1 = new W._EventStream(client._eventSource, "open", false, [W.Event]);
               $async$goto = 2;
               return P._asyncAwait(t1.get$first(t1), $async$call$0);

--- a/dwds/web/client.dart
+++ b/dwds/web/client.dart
@@ -33,7 +33,9 @@ Future<void> main() {
     // Test apps may already have this set.
     dartAppInstanceId ??= Uuid().v1();
 
-    var client = SseClient(_fixProtocol('$dartUriBase/\$sseHandler'));
+    var client = SseClient(_fixProtocol(dartUriBase.endsWith('/')
+        ? '$dartUriBase\$sseHandler'
+        : '$dartUriBase/\$sseHandler'));
     // Ensure the SSE connection is established before proceeding.
     // Note that `onOpen` is a broadcast stream so we must listen for this
     // immediately.


### PR DESCRIPTION
I don't know if this is the best place for this, but I was having weird issues testing this with VS Code when running the base URI through their URL tunnelling. The URL that comes out has a trailing slash and this code would insert another (and the SSE Handler fails if it's `//$sseHandler`).

I could strip it in VS Code, but I think this URI will need to be run through the url-encoder anyway, so it would be better to handle it here than ensure all url-encoders don't introduce trailing slashes on the URIs (it's my understanding that for an otherwise-pathless URI they're the equivalent).

Note: The JS file has way more changes than just this, even though I ran it with v2.7-dev.0.0 as the header said it was previously run with - I'm not sure why (though I can strip the other changes from the PR, or the whole JS file if that's better and you can re-generate it).