### PR TITLE
Run request URI through url-encoder

### DIFF
--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -100,8 +100,8 @@ class Dwds {
       if (urlEncoder != null) extensionUri = await urlEncoder(extensionUri);
     }
 
-    pipeline = pipeline.addMiddleware(
-        createInjectedHandler(reloadConfiguration, extensionUri: extensionUri));
+    pipeline = pipeline.addMiddleware(createInjectedHandler(reloadConfiguration,
+        extensionUri: extensionUri, urlEncoder: urlEncoder));
 
     if (serveDevTools) {
       devTools = await DevTools.start(hostname);

--- a/dwds/lib/src/handlers/injected_handler.dart
+++ b/dwds/lib/src/handlers/injected_handler.dart
@@ -26,7 +26,8 @@ const _clientScript = 'dwds/src/injected/client';
 
 Handler Function(Handler) createInjectedHandler(
         ReloadConfiguration configuration,
-        {String extensionUri}) =>
+        {String extensionUri,
+        UrlEncoder urlEncoder}) =>
     (innerHandler) {
       return (Request request) async {
         if (request.url.path.endsWith('$_clientScript.js')) {
@@ -68,6 +69,9 @@ Handler Function(Handler) createInjectedHandler(
                 .trim();
             var requestedUriBase = '${request.requestedUri.scheme}'
                 '://${request.requestedUri.authority}';
+            if (urlEncoder != null) {
+              requestedUriBase = await urlEncoder(requestedUriBase);
+            }
             body += _injectedClientJs(
               configuration,
               appId,


### PR DESCRIPTION
@grouma this seems to be required when running through the VS Online proxy as the local request still seems to get `localhost` for the hostname (possibly it's done to specifically support services that are using host headers and expected `localhost`?).

I don't know if this will affect internal use - if so maybe we could make this one optional/opt-in?

I wasn't sure where tests for this should go - if you're otherwise happy to have this, could you point me in the right direction for where to add tests?