### PR TITLE
Don't spawn DevTools if serverDevTools=false, and support WebSockets

### DIFF
--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -63,6 +63,7 @@ class Dwds {
     @required bool enableDebugging,
     String hostname,
     ReloadConfiguration reloadConfiguration,
+    bool useSse,
     bool serveDevTools,
     LogWriter logWriter,
     bool verbose,
@@ -75,9 +76,8 @@ class Dwds {
     reloadConfiguration ??= ReloadConfiguration.none;
     enableDebugging ??= true;
     enableDebugExtension ??= false;
+    useSse ??= true;
     serveDevTools ??= true;
-    // `serveDevTools` is true by default when the extension is enabled.
-    serveDevTools = serveDevTools || enableDebugExtension;
     logWriter ??= (level, message) => print(message);
     verbose ??= false;
     globalModuleStrategy = moduleStrategy ?? ModuleStrategy.requireJS;
@@ -119,6 +119,8 @@ class Dwds {
       extensionBackend,
       urlEncoder,
       restoreBreakpoints,
+      useSse,
+      serveDevTools,
     );
     cascade = cascade.add(devHandler.handler).add(assetHandler.handler);
 


### PR DESCRIPTION
This allows `useSse` to be passed through so we can force web sockets from Flutter for the debug service, and also makes code that spawns DevTools conditional based on the `serveDevTools` variable.

If this seems ok, let me know how best to test this - I've looked through the existing tests but couldn't find a good starting point.

Fixes #669.