### PR TITLE
Url Encode $dartUriBase

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -4,6 +4,8 @@
   protocol will clearly define how breakpoints should be restored.
 - Depend on latest `package:sse` to get retry logic.
 - Don't spawn DevTools if `serveDevTools` is false.
+- `UrlEncoder` will also encode the base URI used by the injected client /
+  Dart Debug Extension.
 ** Breaking Change ** `serveDevTools` is not automatically considered true if
   `enableDebugExtension`is true.
 

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -98,8 +98,11 @@ class Dwds {
       if (urlEncoder != null) extensionUri = await urlEncoder(extensionUri);
     }
 
-    pipeline = pipeline.addMiddleware(
-        createInjectedHandler(reloadConfiguration, extensionUri: extensionUri));
+    pipeline = pipeline.addMiddleware(createInjectedHandler(
+      reloadConfiguration,
+      extensionUri: extensionUri,
+      urlEncoder: urlEncoder,
+    ));
 
     if (serveDevTools) {
       devTools = await DevTools.start(hostname);

--- a/dwds/lib/src/handlers/injected_handler.dart
+++ b/dwds/lib/src/handlers/injected_handler.dart
@@ -26,7 +26,8 @@ const _clientScript = 'dwds/src/injected/client';
 
 Handler Function(Handler) createInjectedHandler(
         ReloadConfiguration configuration,
-        {String extensionUri}) =>
+        {String extensionUri,
+        UrlEncoder urlEncoder}) =>
     (innerHandler) {
       return (Request request) async {
         if (request.url.path.endsWith('$_clientScript.js')) {
@@ -68,6 +69,9 @@ Handler Function(Handler) createInjectedHandler(
                 .trim();
             var requestedUriBase = '${request.requestedUri.scheme}'
                 '://${request.requestedUri.authority}';
+            if (urlEncoder != null) {
+              requestedUriBase = await urlEncoder(requestedUriBase);
+            }
             body += _injectedClientJs(
               configuration,
               appId,

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -62,9 +62,8 @@ void main() async {
     setUp(() async {
       await context.setUp(
           enableDebugExtension: true,
-          urlEncoder: (_) async {
-            return 'http://some-encoded-url:8081/';
-          });
+          urlEncoder: (url) async =>
+              url.endsWith(r'/$debug') ? 'http://some-encoded-url:8081/' : url);
     });
 
     tearDown(() async {


### PR DESCRIPTION
Some proxy servers don't rewrite the requestedUri, so allow the URL encoder to handle this scenario.

Also sneak in an update to a stale test expect. The logic has since changed and we should be checking for different embedded data.