### PR TITLE
Allow overriding SSE to WS when using debug extension

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.8.4
 
 - Support using WebSockets for the debug (VM Service) proxy by passing
-  `useSseForDebugProxy: true` to `Dwds.start()`
+  `useSseForDebugProxy: false` to `Dwds.start()`
 
 ## 0.8.3
 

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.4
+
+- Support using WebSockets for the debug (VM Service) proxy by passing
+  `useSseForDebugProxy: true` to `Dwds.start()`
+
 ## 0.8.3
 
 - Support nesting Dart applications in iframes.

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -63,7 +63,7 @@ class Dwds {
     @required bool enableDebugging,
     String hostname,
     ReloadConfiguration reloadConfiguration,
-    bool useSse,
+    bool useSseForDebugProxy,
     bool serveDevTools,
     LogWriter logWriter,
     bool verbose,
@@ -76,7 +76,7 @@ class Dwds {
     reloadConfiguration ??= ReloadConfiguration.none;
     enableDebugging ??= true;
     enableDebugExtension ??= false;
-    useSse ??= true;
+    useSseForDebugProxy ??= true;
     serveDevTools ??= true;
     logWriter ??= (level, message) => print(message);
     verbose ??= false;
@@ -123,7 +123,7 @@ class Dwds {
       extensionBackend,
       urlEncoder,
       restoreBreakpoints,
-      useSse,
+      useSseForDebugProxy,
       serveDevTools,
     );
     cascade = cascade.add(devHandler.handler).add(assetHandler.handler);

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -63,6 +63,7 @@ class Dwds {
     @required bool enableDebugging,
     String hostname,
     ReloadConfiguration reloadConfiguration,
+    bool useSse,
     bool serveDevTools,
     LogWriter logWriter,
     bool verbose,
@@ -75,6 +76,7 @@ class Dwds {
     reloadConfiguration ??= ReloadConfiguration.none;
     enableDebugging ??= true;
     enableDebugExtension ??= false;
+    useSse ??= true;
     serveDevTools ??= true;
     logWriter ??= (level, message) => print(message);
     verbose ??= false;
@@ -121,6 +123,7 @@ class Dwds {
       extensionBackend,
       urlEncoder,
       restoreBreakpoints,
+      useSse,
       serveDevTools,
     );
     cascade = cascade.add(devHandler.handler).add(assetHandler.handler);

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -54,7 +54,7 @@ class DevHandler {
       StreamController<DebugConnection>();
   final UrlEncoder _urlEncoder;
   final bool _restoreBreakpoints;
-  final bool _useSse;
+  final bool _useSseForDebugProxy;
   final bool _serveDevTools;
 
   /// Null until [close] is called.
@@ -75,7 +75,7 @@ class DevHandler {
     this._extensionBackend,
     this._urlEncoder,
     this._restoreBreakpoints,
-    this._useSse,
+    this._useSseForDebugProxy,
     this._serveDevTools,
   ) {
     _sub = buildResults.listen(_emitBuildResults);
@@ -380,7 +380,7 @@ class DevHandler {
                       'VmService proxy responded with an error:\n$response');
                 }
               : null,
-          useSse: _useSse,
+          useSse: _useSseForDebugProxy,
         );
         var appServices =
             await _createAppDebugServices(devToolsRequest.appId, debugService);

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -54,6 +54,7 @@ class DevHandler {
       StreamController<DebugConnection>();
   final UrlEncoder _urlEncoder;
   final bool _restoreBreakpoints;
+  final bool _useSse;
   final bool _serveDevTools;
 
   /// Null until [close] is called.
@@ -74,6 +75,7 @@ class DevHandler {
     this._extensionBackend,
     this._urlEncoder,
     this._restoreBreakpoints,
+    this._useSse,
     this._serveDevTools,
   ) {
     _sub = buildResults.listen(_emitBuildResults);
@@ -378,7 +380,7 @@ class DevHandler {
                       'VmService proxy responded with an error:\n$response');
                 }
               : null,
-          useSse: true,
+          useSse: _useSse,
         );
         var appServices =
             await _createAppDebugServices(devToolsRequest.appId, debugService);

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.8.3';
+const packageVersion = '0.8.4';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.8.3
+version: 0.8.4
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-


### PR DESCRIPTION
@grouma this was included in https://github.com/dart-lang/webdev/pull/823 but not the PR that landed (https://github.com/dart-lang/webdev/pull/825). Is it possible to support this so we can control which protocol to use from Flutter?

Right the VS Code debugger can't talk SSE (this may change in future) so this will be required to connect VS Code to the proxy. It already uses WS when launching Chrome (it's hard-coded `useSse: false` elsewhere in this file), but forces SSE when using the debug extension.