### PR TITLE
add a version.dart file check

### DIFF
--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.8.1-dev';
+const packageVersion = '0.8.1';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -38,13 +38,13 @@ dev_dependencies:
   args: ^1.0.0
   build: ^1.1.5
   build_runner: ^1.6.2
-  build_verify: ^1.0.0
   build_version: ^2.0.0
   build_web_compilers: '>=1.0.0 <3.0.0'
   built_collection: ^4.2.0
   built_value_generator: '>=6.4.0 <8.0.0'
   graphs: ^0.2.0
   js: ^0.6.1
+  pubspec_parse: ^0.1.5
   stream_channel: ^2.0.0
   test: ^1.6.0
   uuid: ^2.0.0

--- a/dwds/test/build/ensure_version_test.dart
+++ b/dwds/test/build/ensure_version_test.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+import 'dart:io';
+
+import 'package:dwds/src/version.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('dwds lib/src/version.dart matches the pubspec version', () {
+    var pubspec = Pubspec.parse(File('pubspec.yaml').readAsStringSync());
+    expect(Version.parse(packageVersion), pubspec.version,
+        reason: 'Please run `pub run build_runner build '
+            '--build-filter=lib/src/version.dart` to update the version.');
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/840

Technically this doesn't do a full build check because that actually gets complicated with respect to the client.js file - we need to run with `--delete-conflicting-outputs` which means we would have to regenerate all files including the JS file which would have a lot of unnecessary churn.