### PR TITLE
Fix concurrent modification

### DIFF
--- a/dwds/lib/src/debugging/execution_context.dart
+++ b/dwds/lib/src/debugging/execution_context.dart
@@ -18,7 +18,7 @@ class ExecutionContext {
   /// Returns the context ID that contains the running Dart application.
   Future<int> get id async {
     if (_id != null) return _id;
-    for (var context in _contexts) {
+    for (var context in _contexts.toList()) {
       var result =
           await _remoteDebugger.sendCommand('Runtime.evaluate', params: {
         'expression': r'window["$dartAppInstanceId"];',

--- a/dwds/lib/src/debugging/execution_context.dart
+++ b/dwds/lib/src/debugging/execution_context.dart
@@ -29,6 +29,9 @@ class ExecutionContext {
         break;
       }
     }
+    if (_id == null) {
+      throw StateError('No context with the running Dart application.');
+    }
     return _id;
   }
 


### PR DESCRIPTION
It's possible more execution contexts can be created while iterating through collected contexts. Also throw a state error if we can't find a context. This shouldn't happen in practice but will help us track down issues nonetheless.