### PR TITLE
Always bind to localhost for the local debug workflow

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.5
+
+- Always bind to `localhost` for the local debug workflow.
+
 ## 0.8.4
 
 - Support using WebSockets for the debug (VM Service) proxy by passing

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.8.4';
+const packageVersion = '0.8.5';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 0.8.4
+version: 0.8.5
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-


### PR DESCRIPTION
The goal is to allow users to enable both the debug extension and local debugging through `Alt + D` with a single configuration. Before this change, this was infeasible when the user provided a non `localhost` `hostname`.