### PR TITLE
Use hostname that's bound in order to support "any" via HttpMultiServer

### DIFF
--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -93,7 +93,7 @@ class Dwds {
       extensionBackend = await ExtensionBackend.start(hostname);
       extensionUri = Uri(
               scheme: 'http',
-              host: hostname,
+              host: extensionBackend.hostname,
               port: extensionBackend.port,
               path: r'$debug')
           .toString();

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -77,4 +77,34 @@ void main() async {
       expect(result.body.contains('http://some-encoded-url:8081/'), isTrue);
     });
   });
+
+  group('With "any" hostname', () {
+    final context = TestContext();
+    final uriPattern = RegExp(r'dartExtensionUri = "([^"]+)";');
+
+    setUp(() async {
+      await context.setUp(enableDebugExtension: true, hostname: 'any');
+    });
+
+    tearDown(() async {
+      await context.tearDown();
+    });
+
+    test('generates an extensionUri with a valid valid hostname', () async {
+      var result = await http.get(
+          'http://localhost:${context.port}/hello_world/main.dart$bootstrapJsExtension');
+      expect(result.body.contains('dartExtensionUri'), isTrue);
+      var extensionUri = Uri.parse(uriPattern.firstMatch(result.body).group(1));
+      expect(
+          extensionUri.host,
+          anyOf(
+            // The hostname should've been mapped from "any" to one of the local
+            // loopback addresses/IPs.
+            equals('localhost'),
+            equals('127.0.0.1'),
+            equals('::'),
+            equals('::1'),
+          ));
+    });
+  });
 }

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -70,6 +70,7 @@ class TestContext {
       bool enableDebugExtension,
       bool autoRun,
       bool enableDebugging,
+      String hostname,
       bool waitToDebug,
       UrlEncoder urlEncoder,
       bool restoreBreakpoints}) async {
@@ -135,6 +136,7 @@ class TestContext {
 
     port = await findUnusedPort();
     testServer = await TestServer.start(
+        hostname,
         port,
         daemonPort(workingDirectory),
         pathToServe,

--- a/dwds/test/fixtures/server.dart
+++ b/dwds/test/fixtures/server.dart
@@ -42,6 +42,7 @@ class TestServer {
   }
 
   static Future<TestServer> start(
+      String hostname,
       int port,
       int assetServerPort,
       String target,
@@ -69,6 +70,7 @@ class TestServer {
       serveDevTools: serveDevTools,
       enableDebugExtension: enableDebugExtension,
       enableDebugging: enableDebugging,
+      hostname: hostname,
       verbose: true,
       urlEncoder: urlEncoder,
       // ignore: deprecated_member_use_from_same_package


### PR DESCRIPTION
This switches to using the bound hostname (that comes from `HttpMultiServer`) when building the extension URI, so you can pass though the magic string `"any"` to bind to all local IPs (see #845).

It has a side-effect that binding to "localhost" may now also return `127.0.0.1` or `::1` (this is behaviour of `HttpMultiServer`) but it sounds like that shouldn't cause any issues.

@grouma I don't know if I put the test in the most appropriate place, so let me know if there's somewhere better. I also wasn't sure whether to test the hostname `!= 'any'` or against a reasonable set of expected values like this (I went with the latter assuming it's better to break on an unexpected value than checking only it wasn't "any"). 

Fixes #845.