### PR TITLE
Prevent server crash while using the extension after unsuccessfully trying to connect through a local debug instance

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -4,6 +4,8 @@
   to resolve breakpoint locations.
 - Remove dependency on `package:build_daemon`.
 - Add `FrontendServerAssetReader` for use with Frontend Server builds.
+- Fix an issue where trying to launch DevTools in a non-debug enabled Chrome
+  instance could crash your development server.
 
 **Breaking Changes:**
 - No longer use the `BuildResult` abstraction from `package:build_daemon` but

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -42,7 +42,7 @@ class DevHandler {
   final AssetReader _assetReader;
   final String _hostname;
   final _connectedApps = StreamController<AppConnection>.broadcast();
-  final _servicesByAppId = <String, Future<AppDebugServices>>{};
+  final _servicesByAppId = <String, AppDebugServices>{};
   final _appConnectionByAppId = <String, AppConnection>{};
   final Stream<BuildResult> buildResults;
   final bool _verbose;
@@ -93,8 +93,8 @@ class DevHandler {
         // connections.
         await Future.wait(_injectedConnections
             .map((injectedConnection) => injectedConnection.sink.close()));
-        await Future.wait(_servicesByAppId.values.map((futureServices) async {
-          await (await futureServices).close();
+        await Future.wait(_servicesByAppId.values.map((service) async {
+          await service.close();
         }));
         _servicesByAppId.clear();
       }();
@@ -175,23 +175,26 @@ class DevHandler {
     );
   }
 
-  Future<AppDebugServices> loadAppServices(AppConnection appConnection) =>
-      _servicesByAppId.putIfAbsent(appConnection.request.appId, () async {
-        var debugService = await _startLocalDebugService(
-            await _chromeConnection(), appConnection);
-        var appServices = await _createAppDebugServices(
-            appConnection.request.appId, debugService);
-        unawaited(appServices.chromeProxyService.remoteDebugger.onClose.first
-            .whenComplete(() {
-          appServices.close();
-          _servicesByAppId.remove(appConnection.request.appId);
-          _logWriter(
-              Level.INFO,
-              'Stopped debug service on '
-              'ws://${debugService.hostname}:${debugService.port}\n');
-        }));
-        return appServices;
-      });
+  Future<AppDebugServices> loadAppServices(AppConnection appConnection) async {
+    var appId = appConnection.request.appId;
+    if (_servicesByAppId[appId] == null) {
+      var debugService = await _startLocalDebugService(
+          await _chromeConnection(), appConnection);
+      var appServices = await _createAppDebugServices(
+          appConnection.request.appId, debugService);
+      unawaited(appServices.chromeProxyService.remoteDebugger.onClose.first
+          .whenComplete(() {
+        appServices.close();
+        _servicesByAppId.remove(appConnection.request.appId);
+        _logWriter(
+            Level.INFO,
+            'Stopped debug service on '
+            'ws://${debugService.hostname}:${debugService.port}\n');
+      }));
+      _servicesByAppId[appId] = appServices;
+    }
+    return _servicesByAppId[appId];
+  }
 
   void _handleConnection(SseConnection injectedConnection) {
     _injectedConnections.add(injectedConnection);
@@ -239,7 +242,7 @@ class DevHandler {
       _injectedConnections.remove(injectedConnection);
       if (appConnection != null) {
         _appConnectionByAppId.remove(appConnection.request.appId);
-        var services = await _servicesByAppId[appConnection.request.appId];
+        var services = _servicesByAppId[appConnection.request.appId];
         if (services != null) {
           if (services.connectedInstanceId == null ||
               services.connectedInstanceId ==
@@ -302,7 +305,7 @@ class DevHandler {
       ConnectRequest message, SseConnection sseConnection) async {
     // After a page refresh, reconnect to the same app services if they
     // were previously launched and create the new isolate.
-    var services = await _servicesByAppId[message.appId];
+    var services = _servicesByAppId[message.appId];
     var connection = AppConnection(message, sseConnection);
     if (services != null && services.connectedInstanceId == null) {
       // Reconnect to existing service.
@@ -315,14 +318,14 @@ class DevHandler {
   }
 
   Future<void> _handleIsolateExit(AppConnection appConnection) async {
-    (await _servicesByAppId[appConnection.request.appId])
+    _servicesByAppId[appConnection.request.appId]
         ?.chromeProxyService
         ?.destroyIsolate();
   }
 
   Future<void> _handleIsolateStart(
       AppConnection appConnection, SseConnection sseConnection) async {
-    await (await _servicesByAppId[appConnection.request.appId])
+    await _servicesByAppId[appConnection.request.appId]
         ?.chromeProxyService
         ?.createIsolate(appConnection);
     // [IsolateStart] events are the result of a Hot Restart.
@@ -364,8 +367,8 @@ class DevHandler {
         throw StateError(
             'Not connected to an app with id: ${devToolsRequest.appId}');
       }
-      var appServices =
-          await _servicesByAppId.putIfAbsent(devToolsRequest.appId, () async {
+      var appId = devToolsRequest.appId;
+      if (_servicesByAppId[appId] == null) {
         var debugService = await DebugService.start(
           _hostname,
           extensionDebugger,
@@ -397,9 +400,10 @@ class DevHandler {
               '${appServices.debugService.uri}\n');
         }));
         extensionDebugConnections.add(DebugConnection(appServices));
-        return appServices;
-      });
-      await _launchDevTools(extensionDebugger, appServices.debugService.uri);
+        _servicesByAppId[appId] = appServices;
+      }
+      await _launchDevTools(
+          extensionDebugger, _servicesByAppId[appId].debugService.uri);
     });
   }
 


### PR DESCRIPTION
There was no reason that `_servicesByAppId` should return a `Future<AppDebugServices>`. This was likely an artifact of a code refactor. Due to this, it was possible to cache a problematic future in the map which would result in unexpected failures when trying to connect through the Dart Debug Extension.