### PR TITLE
Gracefully handle debug request errors through the extension

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -4,6 +4,8 @@
   to resolve breakpoint locations.
 - Remove dependency on `package:build_daemon`.
 - Add `FrontendServerAssetReader` for use with Frontend Server builds.
+- Fix an issue where a failure to initiate debugging through the Dart Debug
+  Extension would cause your development server to crash.
 
 **Breaking Changes:**
 - No longer use the `BuildResult` abstraction from `package:build_daemon` but

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -361,8 +361,9 @@ class DevHandler {
     extensionDebugger.devToolsRequestStream.listen((devToolsRequest) async {
       var connection = _appConnectionByAppId[devToolsRequest.appId];
       if (connection == null) {
-        throw StateError(
+        _logWriter(Level.WARNING,
             'Not connected to an app with id: ${devToolsRequest.appId}');
+        return;
       }
       var appServices =
           await _servicesByAppId.putIfAbsent(devToolsRequest.appId, () async {

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -361,6 +361,8 @@ class DevHandler {
     extensionDebugger.devToolsRequestStream.listen((devToolsRequest) async {
       var connection = _appConnectionByAppId[devToolsRequest.appId];
       if (connection == null) {
+        // TODO(grouma) - Ideally we surface this warning to the extension so
+        // that it can be displayed to the user through an alert.
         _logWriter(Level.WARNING,
             'Not connected to an app with id: ${devToolsRequest.appId}');
         return;


### PR DESCRIPTION
We gracefully handle debug errors through `Alt + D`. We should do the same for debug requests through the extension. Otherwise, issues can kill your development server.