### PR TITLE
LoadStrategy

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0-dev
+
+**Breaking Changes:**
+- Now require a `LoadStrategy` to `Dwds.start`. This package defines two
+  compatible load strategies, `RequireStrategy` and `LegacyStrategy.
+
 ## 1.0.1
 
 - Make the `root` optional for the `ProxyServerAssetReader`.

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -3,6 +3,9 @@
 **Breaking Changes:**
 - Now require a `LoadStrategy` to `Dwds.start`. This package defines two
   compatible load strategies, `RequireStrategy` and `LegacyStrategy.
+- `Dwds.start` function signature has been changed to accept one more parameter
+  of new interface type `ExpressionCompiler` to support expression
+  evaluation
 
 ## 1.0.1
 
@@ -27,9 +30,6 @@
   clearly defined. The new abstraction is now consumed through `dwds.dart`.
 - `BuildRunnerAssetHandler` has been renamed to `ProxyServerAssetReader` and is
   now consumed through `dwds.dart`.
-- `Dwds.start` function signature has been changed to accept one more parameter
-  of new interface type `ExpressionCompiler` to support expression
-  evaluation
 
 ## 0.9.0
 

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -4,17 +4,17 @@
 
 import 'dart:async';
 
-import 'package:dwds/data/build_result.dart';
-import 'package:dwds/src/utilities/shared.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import 'data/build_result.dart';
 import 'src/connections/app_connection.dart';
 import 'src/connections/debug_connection.dart';
 import 'src/handlers/dev_handler.dart';
 import 'src/handlers/injected_handler.dart';
+import 'src/loaders/strategy.dart';
 import 'src/readers/asset_reader.dart';
 import 'src/servers/devtools.dart';
 import 'src/servers/extension_backend.dart';
@@ -22,6 +22,9 @@ import 'src/servers/extension_backend.dart';
 export 'src/connections/app_connection.dart' show AppConnection;
 export 'src/connections/debug_connection.dart' show DebugConnection;
 export 'src/handlers/dev_handler.dart' show AppConnectionException;
+export 'src/loaders/legacy.dart' show LegacyStrategy;
+export 'src/loaders/require.dart' show RequireStrategy;
+export 'src/loaders/strategy.dart' show LoadStrategy, ReloadConfiguration;
 export 'src/readers/asset_reader.dart' show AssetReader;
 export 'src/readers/frontend_server_asset_reader.dart'
     show FrontendServerAssetReader;
@@ -31,8 +34,6 @@ export 'src/services/chrome_proxy_service.dart' show ChromeDebugException;
 typedef LogWriter = void Function(Level, String);
 typedef ConnectionProvider = Future<ChromeConnection> Function();
 typedef UrlEncoder = Future<String> Function(String url);
-enum ReloadConfiguration { none, hotReload, hotRestart, liveReload }
-enum ModuleStrategy { requireJS, legacy }
 
 /// The Dart Web Debug Service.
 class Dwds {
@@ -70,27 +71,25 @@ class Dwds {
     @required AssetReader assetReader,
     @required Stream<BuildResult> buildResults,
     @required ConnectionProvider chromeConnection,
+    @required LoadStrategy loadStrategy,
     @required bool enableDebugging,
+    bool enableDebugExtension,
     String hostname,
-    ReloadConfiguration reloadConfiguration,
     bool useSseForDebugProxy,
     bool serveDevTools,
     LogWriter logWriter,
     bool verbose,
-    bool enableDebugExtension,
-    ModuleStrategy moduleStrategy,
     UrlEncoder urlEncoder,
     @deprecated bool restoreBreakpoints,
   }) async {
     hostname ??= 'localhost';
-    reloadConfiguration ??= ReloadConfiguration.none;
     enableDebugging ??= true;
     enableDebugExtension ??= false;
     useSseForDebugProxy ??= true;
     serveDevTools ??= true;
     logWriter ??= (level, message) => print(message);
     verbose ??= false;
-    globalModuleStrategy = moduleStrategy ?? ModuleStrategy.requireJS;
+    globalLoadStrategy = loadStrategy;
     restoreBreakpoints ??= false;
 
     DevTools devTools;
@@ -130,7 +129,6 @@ class Dwds {
 
     return Dwds._(
       createInjectedHandler(
-        reloadConfiguration,
         extensionUri: extensionUri,
         urlEncoder: urlEncoder,
       ),

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
+import '../loaders/strategy.dart';
 import '../utilities/domain.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
@@ -68,7 +69,7 @@ class ClassHelper extends Domain {
     var rawName = classRef.name.split('<').first;
     var expression = '''
     (function() {
-      ${getLibrarySnippet(libraryRef.uri)}
+      ${globalLoadStrategy.loadLibrarySnippet(libraryRef.uri)}
       var result = {};
       var clazz = library["$rawName"];
       var descriptor = {

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dwds/src/utilities/shared.dart';
-
+import '../loaders/strategy.dart';
 import '../utilities/objects.dart';
 import 'debugger.dart';
 
@@ -59,7 +58,7 @@ Future<Property> _findMissingThis(String callFrameId, Debugger debugger) async {
   final findCurrent = '''
         (function (THIS) {
            if (THIS === window) { return null; }
-           $getLibraries
+           ${globalLoadStrategy.loadLibrariesSnippet}
            for (let lib of libs) {
              if (lib === THIS) {
                 return null;

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -10,6 +10,7 @@ import 'package:meta/meta.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     hide StackTrace;
 
+import '../loaders/strategy.dart';
 import '../readers/asset_reader.dart';
 import '../services/chrome_proxy_service.dart';
 import '../utilities/conversions.dart';
@@ -386,7 +387,7 @@ class Debugger extends Domain {
     // want. To make those alternatives easier in JS, pass both count and end.
     var expression = '''
         function (offset, count, end) {
-          const sdk = $loadModule("dart_sdk");
+          const sdk = ${globalLoadStrategy.loadModuleSnippet}("dart_sdk");
           if (sdk.core.Map.is(this)) {
             const entries = sdk.dart.dload(this, "entries");
             const skipped = sdk.dart.dsend(entries, "skip", [offset])

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../loaders/strategy.dart';
 import '../utilities/conversions.dart';
 import '../utilities/domain.dart';
 import '../utilities/objects.dart';
@@ -172,7 +173,7 @@ class InstanceHelper extends Domain {
     // values that we need to be RemoteObject, e.g. a List of int.
     var expression = '''
       function() {
-        var sdkUtils = $loadModule('dart_sdk').dart;
+        var sdkUtils = ${globalLoadStrategy.loadModuleSnippet}('dart_sdk').dart;
         var entries = sdkUtils.dloadRepl(this, "entries");
         entries = sdkUtils.dsendRepl(entries, "toList", []);
         function asKey(entry) {
@@ -268,7 +269,7 @@ class InstanceHelper extends Domain {
     // of these as special.
     // TODO(alanknight): Handle superclass fields.
     final fieldNameExpression = '''function() {
-      const sdk = $loadModule("dart_sdk");
+      const sdk = ${globalLoadStrategy.loadModuleSnippet}("dart_sdk");
       const sdk_utils = sdk.dart;
       const fields = sdk_utils.getFields(sdk_utils.getType(this)) || [];
       if (!fields && (dart_sdk._interceptors.JSArray.is(this) ||

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -4,6 +4,7 @@
 
 import 'package:dwds/src/debugging/inspector.dart';
 
+import '../loaders/strategy.dart';
 import '../utilities/domain.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
@@ -26,7 +27,7 @@ class LibraryHelper extends Domain {
     if (_libraryRefsById.isNotEmpty) return _libraryRefsById.values.toList();
     var expression = '''
       (function() {
-        $getLibraries
+        ${globalLoadStrategy.loadLibrariesSnippet}
         return libs;
       })()
      ''';
@@ -64,7 +65,7 @@ class LibraryHelper extends Domain {
     // Fetch information about all the classes in this library.
     var expression = '''
     (function() {
-      ${getLibrarySnippet(libraryRef.uri)}
+      ${globalLoadStrategy.loadLibrarySnippet(libraryRef.uri)}
       var result = {};
       var classes = Object.values(Object.getOwnPropertyDescriptors(library))
         .filter((p) => 'value' in p)

--- a/dwds/lib/src/debugging/metadata.dart
+++ b/dwds/lib/src/debugging/metadata.dart
@@ -6,6 +6,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../debugging/classes.dart';
 import '../debugging/inspector.dart';
+import '../loaders/strategy.dart';
 import '../services/chrome_proxy_service.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
@@ -51,7 +52,7 @@ class ClassMetaData {
     try {
       var evalExpression = '''
       function(arg) {
-        const sdkUtils = $loadModule('dart_sdk').dart;
+        const sdkUtils = ${globalLoadStrategy.loadModuleSnippet}('dart_sdk').dart;
         const classObject = sdkUtils.getReifiedType(arg);
         const isFunction = sdkUtils.AbstractFunctionType.is(classObject);
         const result = {};
@@ -101,7 +102,7 @@ class FunctionMetaData {
       RemoteDebugger remoteDebugger, RemoteObject remoteObject) async {
     var evalExpression = '''
       function(remoteObject) {
-        var sdkUtils = $loadModule('dart_sdk').dart;
+        var sdkUtils = ${globalLoadStrategy.loadModuleSnippet}('dart_sdk').dart;
         var name = remoteObject.name;
         if(remoteObject._boundObject) {
          name = sdkUtils.getType(remoteObject._boundObject).name +

--- a/dwds/lib/src/debugging/modules.dart
+++ b/dwds/lib/src/debugging/modules.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:dwds/src/debugging/execution_context.dart';
 import 'package:path/path.dart' as p;
 
+import '../loaders/strategy.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/shared.dart';
 import 'remote_debugger.dart';
@@ -90,7 +91,7 @@ class Modules {
   Future<void> _initializeMapping() async {
     var expression = '''
     (function() {
-          var dart = $loadModule('dart_sdk').dart;
+          var dart = ${globalLoadStrategy.loadModuleSnippet}('dart_sdk').dart;
           var result = {};
           dart.getModuleNames().forEach(function(module){
             Object.keys(dart.getModuleLibraries(module)).forEach(

--- a/dwds/lib/src/handlers/injected_handler.dart
+++ b/dwds/lib/src/handlers/injected_handler.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:crypto/crypto.dart';
-import 'package:dwds/src/utilities/shared.dart';
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/version.dart';
 import 'package:shelf/shelf.dart';
 
@@ -26,9 +26,7 @@ const mainExtensionMarker = '/* MAIN_EXTENSION_MARKER */';
 const _clientScript = 'dwds/src/injected/client';
 
 Handler Function(Handler) createInjectedHandler(
-        ReloadConfiguration configuration,
-        {String extensionUri,
-        UrlEncoder urlEncoder}) =>
+        {String extensionUri, UrlEncoder urlEncoder}) =>
     (innerHandler) {
       return (Request request) async {
         if (request.url.path.endsWith('$_clientScript.js')) {
@@ -74,7 +72,6 @@ Handler Function(Handler) createInjectedHandler(
               requestedUriBase = await urlEncoder(requestedUriBase);
             }
             body += _injectedClientJs(
-              configuration,
               appId,
               mainFunction,
               requestedUriBase,
@@ -99,7 +96,6 @@ Handler Function(Handler) createInjectedHandler(
     };
 
 String _injectedClientJs(
-  ReloadConfiguration configuration,
   String appId,
   String mainFunction,
   String requestedUriBase, {
@@ -108,11 +104,11 @@ String _injectedClientJs(
   var injectedBody = '// Injected by webdev for build results support.\n'
       'window.\$dartAppId = "$appId";\n'
       'window.\$dartRunMain = $mainFunction;\n'
-      'window.\$dartReloadConfiguration = "$configuration";\n'
+      'window.\$dartReloadConfiguration = "${globalLoadStrategy.reloadConfiguration}";\n'
       'window.\$dartLoader.forceLoadModule("$_clientScript");\n'
-      'window.\$dartModuleStrategy = "$loadModule";\n'
+      'window.\$dartModuleStrategy = "${globalLoadStrategy.id}";\n'
       'window.\$dartUriBase = "$requestedUriBase";\n'
-      'window.\$loadModuleConfig = $loadModule;\n'
+      'window.\$loadModuleConfig = ${globalLoadStrategy.loadModuleSnippet};\n'
       'window.\$dwdsVersion = "$packageVersion";\n';
   if (extensionUri != null) {
     injectedBody += 'window.\$dartExtensionUri = "$extensionUri";\n';

--- a/dwds/lib/src/injected/client.js
+++ b/dwds/lib/src/injected/client.js
@@ -23275,7 +23275,7 @@
               return P._asyncAwait(t1.get$first(t1), $async$call$0);
             case 2:
               // returning from await.
-              $async$goto = J.$eq$(self.$dartModuleStrategy, "require") ? 3 : 5;
+              $async$goto = J.$eq$(self.$dartModuleStrategy, "require-js") ? 3 : 5;
               break;
             case 3:
               // then
@@ -23289,7 +23289,7 @@
               break;
             case 5:
               // else
-              if (J.$eq$(self.$dartModuleStrategy, "dart_library.import"))
+              if (J.$eq$(self.$dartModuleStrategy, "legacy"))
                 restarter = new Z.LegacyRestarter();
               else
                 throw H.wrapException(P.StateError$("Unknown module strategy: " + H.S(self.$dartModuleStrategy)));

--- a/dwds/lib/src/loaders/legacy.dart
+++ b/dwds/lib/src/loaders/legacy.dart
@@ -15,10 +15,11 @@ class LegacyStrategy extends LoadStrategy {
   String get id => 'legacy';
 
   @override
-  String get importLibrariesSnippet =>
+  String get loadLibrariesSnippet =>
       'for(let module of dart_library.libraries()) {\n'
       'dart_library.import(module)[module];\n'
-      '}';
+      '}\n'
+      'let libs = $loadModuleSnippet("dart_sdk").dart.getLibraries();\n';
 
   @override
   String get loadModuleSnippet => 'dart_library.import';

--- a/dwds/lib/src/loaders/legacy.dart
+++ b/dwds/lib/src/loaders/legacy.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'strategy.dart';
+
+/// A load strategy for the legacy module system.
+class LegacyStrategy extends LoadStrategy {
+  @override
+  final ReloadConfiguration reloadConfiguration;
+
+  LegacyStrategy(this.reloadConfiguration);
+
+  @override
+  String get id => 'legacy';
+
+  @override
+  String get importLibrariesSnippet =>
+      'for(let module of dart_library.libraries()) {\n'
+      'dart_library.import(module)[module];\n'
+      '}';
+
+  @override
+  String get loadModuleSnippet => 'dart_library.import';
+}

--- a/dwds/lib/src/loaders/require.dart
+++ b/dwds/lib/src/loaders/require.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'strategy.dart';
+
+/// A load strategy for the require-js module system.
+class RequireStrategy extends LoadStrategy {
+  @override
+  final ReloadConfiguration reloadConfiguration;
+
+  RequireStrategy(this.reloadConfiguration);
+
+  @override
+  String get id => 'require-js';
+
+  @override
+  // Libraries do not need to be imported with this strategy.
+  String get importLibrariesSnippet => '';
+
+  @override
+  String get loadModuleSnippet => 'require';
+}

--- a/dwds/lib/src/loaders/require.dart
+++ b/dwds/lib/src/loaders/require.dart
@@ -15,8 +15,8 @@ class RequireStrategy extends LoadStrategy {
   String get id => 'require-js';
 
   @override
-  // Libraries do not need to be imported with this strategy.
-  String get importLibrariesSnippet => '';
+  String get loadLibrariesSnippet =>
+      'let libs = $loadModuleSnippet("dart_sdk").dart.getLibraries();\n';
 
   @override
   String get loadModuleSnippet => 'require';

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -15,9 +15,12 @@ LoadStrategy get globalLoadStrategy {
 
 abstract class LoadStrategy {
   /// The ID for this strategy.
+  ///
+  /// This ID is passed to the injected client so that it can react accordingly.
   String get id;
 
-  /// Returns a snippet of JS code that imports all Dart libraries.
+  /// Returns a snippet of JS code that synchronously imports all Dart
+  /// libraries using the DDC import functionality.
   String get importLibrariesSnippet;
 
   /// Returns a snippet of JS code that loads all Dart libraries into a `libs`
@@ -26,6 +29,9 @@ abstract class LoadStrategy {
       'let libs = $loadModuleSnippet("dart_sdk").dart.getLibraries();\n';
 
   /// Returns a snippet of JS code that can be used to load a JS module.
+  ///
+  /// The snippet should be a reference to a function that takes a single
+  /// argument which is the module name to load.
   String get loadModuleSnippet;
 
   /// The reload configuration for this strategy, e.g. liveReload.

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -2,7 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-LoadStrategy globalLoadStrategy;
+LoadStrategy _globalLoadStrategy;
+
+set globalLoadStrategy(LoadStrategy strategy) => _globalLoadStrategy = strategy;
+
+LoadStrategy get globalLoadStrategy {
+  if (_globalLoadStrategy == null) {
+    throw StateError('Global load strategy not set');
+  }
+  return _globalLoadStrategy;
+}
 
 abstract class LoadStrategy {
   /// The ID for this strategy.

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+LoadStrategy globalLoadStrategy;
+
+abstract class LoadStrategy {
+  /// The ID for this strategy.
+  String get id;
+
+  /// Returns a snippet of JS code that imports all Dart libraries.
+  String get importLibrariesSnippet;
+
+  /// Returns a snippet of JS code that loads all Dart libraries into a `libs`
+  /// variable.
+  String get loadLibrariesSnippet => '$importLibrariesSnippet\n'
+      'let libs = $loadModuleSnippet("dart_sdk").dart.getLibraries();\n';
+
+  /// Returns a snippet of JS code that can be used to load a JS module.
+  String get loadModuleSnippet;
+
+  /// The reload configuration for this strategy, e.g. liveReload.
+  ReloadConfiguration get reloadConfiguration;
+
+  /// Returns a snippet of JS code that initializes a `library` variable that
+  /// has the actual library object in DDC for [libraryUri].
+  ///
+  /// In DDC we have module libraries indexed by names of the form
+  /// 'packages/package/mainFile' with no .dart suffix on the file, or
+  /// 'directory/packageName/mainFile', also with no .dart suffix, and relative
+  /// to the serving root, normally /web within the package. These modules have
+  /// a map from the URI with a Dart-specific scheme
+  /// (package: or org-dartlang-app:) to the library objects. The [libraryUri]
+  /// parameter should be one of these Dart-specific scheme URIs, and we set
+  /// `library` the corresponding library.
+  String loadLibrarySnippet(String libraryUri) => '''
+   var sdkUtils = $loadModuleSnippet('dart_sdk').dart;
+   var library = sdkUtils.getLibrary('$libraryUri');
+   if (!library) throw 'cannot find library for $libraryUri';
+  ''';
+}
+
+enum ReloadConfiguration { none, hotReload, hotRestart, liveReload }

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -19,14 +19,9 @@ abstract class LoadStrategy {
   /// This ID is passed to the injected client so that it can react accordingly.
   String get id;
 
-  /// Returns a snippet of JS code that synchronously imports all Dart
-  /// libraries using the DDC import functionality.
-  String get importLibrariesSnippet;
-
   /// Returns a snippet of JS code that loads all Dart libraries into a `libs`
   /// variable.
-  String get loadLibrariesSnippet => '$importLibrariesSnippet\n'
-      'let libs = $loadModuleSnippet("dart_sdk").dart.getLibraries();\n';
+  String get loadLibrariesSnippet;
 
   /// Returns a snippet of JS code that can be used to load a JS module.
   ///

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -18,6 +18,7 @@ import '../debugging/inspector.dart';
 import '../debugging/location.dart';
 import '../debugging/modules.dart';
 import '../debugging/remote_debugger.dart';
+import '../loaders/strategy.dart';
 import '../readers/asset_reader.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/shared.dart';
@@ -262,7 +263,7 @@ class ChromeProxyService implements VmServiceInterface {
     var stringArgs = args.map((k, v) => MapEntry(
         k is String ? k : jsonEncode(k), v is String ? v : jsonEncode(v)));
     var expression = '''
-$loadModule("dart_sdk").developer.invokeExtension(
+${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
     "$method", JSON.stringify(${jsonEncode(stringArgs)}));
 ''';
     var response =

--- a/dwds/lib/src/utilities/shared.dart
+++ b/dwds/lib/src/utilities/shared.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-import '../../dwds.dart' show ChromeDebugException, ModuleStrategy;
+import '../../dwds.dart' show ChromeDebugException;
 import '../utilities/wrapped_service.dart';
 
 VMRef toVMRef(VM vm) => VMRef()..name = vm.name;
@@ -34,46 +34,6 @@ Future<int> findUnusedPort() async {
   await socket.close();
   return port;
 }
-
-String _fetchModuleStrategy(ModuleStrategy config) {
-  switch (config) {
-    case ModuleStrategy.legacy:
-      return 'dart_library.import';
-    case ModuleStrategy.requireJS:
-      return 'require';
-  }
-  throw StateError('Unreachable code');
-}
-
-ModuleStrategy globalModuleStrategy;
-String get loadModule => _fetchModuleStrategy(globalModuleStrategy);
-
-String get getLibraries {
-  var expression = '';
-  if (globalModuleStrategy == ModuleStrategy.legacy) {
-    expression += 'for(let module of dart_library.libraries()) {\n'
-        'dart_library.import(module)[module];\n'
-        '}\n';
-  }
-  return expression +=
-      "let libs = $loadModule('dart_sdk').dart.getLibraries();\n";
-}
-
-/// Creates a snippet of JS code that initializes a `library` variable that has
-/// the actual library object in DDC for [libraryUri].
-///
-/// In DDC we have module libraries indexed by names of the form
-/// 'packages/package/mainFile' with no .dart suffix on the file, or
-/// 'directory/packageName/mainFile', also with no .dart suffix, and relative to
-/// the serving root, normally /web within the package. These modules have a map
-/// from the URI with a Dart-specific scheme (package: or org-dartlang-app:) to
-/// the library objects. The [libraryUri] parameter should be one of these
-/// Dart-specific scheme URIs, and we set `library` the corresponding library.
-String getLibrarySnippet(String libraryUri) => '''
-   var sdkUtils = $loadModule('dart_sdk').dart;
-   var library = sdkUtils.getLibrary('$libraryUri');
-   if (!library) throw 'cannot find library for $libraryUri';
-  ''';
 
 /// Throws an [ExceptionDetails] object if `exceptionDetails` is present on the
 /// result.

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.0.1';
+const packageVersion = '2.0.0-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 1.0.1
+version: 2.0.0-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -8,10 +8,9 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dwds/src/connections/debug_connection.dart';
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
-import 'package:dwds/src/utilities/shared.dart';
-
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 import 'package:pedantic/pedantic.dart';
@@ -438,7 +437,7 @@ void main() {
       Future<RemoteObject> createList() {
         var expr = '''
           (function () {
-            const sdk = $loadModule("dart_sdk");
+            const sdk = ${globalLoadStrategy.loadModuleSnippet}("dart_sdk");
             const list = sdk.dart.dsend(sdk.core.List,"filled", [1001, 5]);
             list[4] = 100;
             return list;
@@ -450,10 +449,10 @@ void main() {
       Future<RemoteObject> createMap() {
         var expr = '''
           (function () {
-            const sdk = $loadModule("dart_sdk");
+            const sdk = ${globalLoadStrategy.loadModuleSnippet}("dart_sdk");
             const iterable = sdk.dart.dsend(sdk.core.Iterable, "generate", [1001]);
             const list1 = sdk.dart.dsend(iterable, "toList", []);
-            const reversed = sdk.dart.dload(list1, "reversed"); 
+            const reversed = sdk.dart.dload(list1, "reversed");
             const list2 = sdk.dart.dsend(reversed, "toList", []);
             const map = sdk.dart.dsend(list2, "asMap", []);
             const linkedMap = sdk.dart.dsend(sdk.collection.LinkedHashMap, "from", [map]);

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -5,13 +5,11 @@
 @TestOn('vm')
 import 'dart:async';
 
-import 'package:dwds/dwds.dart' show ModuleStrategy;
 import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/debugging/location.dart';
 import 'package:dwds/src/debugging/modules.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
-import 'package:dwds/src/utilities/shared.dart';
 import 'package:source_maps/parser.dart';
 import 'package:test/test.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
@@ -30,7 +28,6 @@ Locations locations;
 
 void main() async {
   setUpAll(() async {
-    globalModuleStrategy = ModuleStrategy.requireJS;
     webkitDebugger = FakeWebkitDebugger();
     pausedController = StreamController<DebuggerPausedEvent>();
     webkitDebugger.onPaused = pausedController.stream;

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -5,9 +5,11 @@
 import 'dart:async';
 
 import 'package:async/src/stream_sink_transformer.dart';
+import 'package:dwds/dwds.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/debugging/instance.dart';
 import 'package:dwds/src/debugging/webkit_debugger.dart';
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/utilities/domain.dart';
 import 'package:dwds/src/utilities/wrapped_service.dart';
 import 'package:sse/server/sse_handler.dart';
@@ -123,6 +125,10 @@ class FakeWebkitDebugger implements WebkitDebugger {
 
   @override
   Future enable() => null;
+
+  FakeWebkitDebugger() {
+    globalLoadStrategy = RequireStrategy(ReloadConfiguration.none);
+  }
 
   @override
   Stream<T> eventStream<T>(String method, WipEventTransformer<T> transformer) =>

--- a/dwds/test/fixtures/server.dart
+++ b/dwds/test/fixtures/server.dart
@@ -85,7 +85,7 @@ class TestServer {
       buildResults: filteredBuildResults,
       chromeConnection: chromeConnection,
       logWriter: logWriter,
-      reloadConfiguration: reloadConfiguration,
+      loadStrategy: RequireStrategy(reloadConfiguration),
       serveDevTools: serveDevTools,
       enableDebugExtension: enableDebugExtension,
       enableDebugging: enableDebugging,

--- a/dwds/test/handlers/injected_handler_test.dart
+++ b/dwds/test/handlers/injected_handler_test.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 
 import 'package:dwds/dwds.dart';
 import 'package:dwds/src/handlers/injected_handler.dart';
-import 'package:dwds/src/utilities/shared.dart';
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/version.dart';
 import 'package:http/http.dart' as http;
 import 'package:shelf/shelf.dart';
@@ -21,10 +21,9 @@ void main() {
 
   group('InjectedHandlerWithoutExtension', () {
     setUp(() async {
-      globalModuleStrategy = ModuleStrategy.requireJS;
-      var pipeline = const Pipeline().addMiddleware(createInjectedHandler(
-          ReloadConfiguration.liveReload,
-          urlEncoder: (url) async => encodedUrl));
+      globalLoadStrategy = RequireStrategy(ReloadConfiguration.none);
+      var pipeline = const Pipeline().addMiddleware(
+          createInjectedHandler(urlEncoder: (url) async => encodedUrl));
       server = await shelf_io.serve(pipeline.addHandler((request) {
         if (request.url.path.endsWith(bootstrapJsExtension)) {
           return Response.ok(
@@ -128,10 +127,10 @@ void main() {
 
   group('InjectedHandlerWithExtension', () {
     setUp(() async {
+      globalLoadStrategy = RequireStrategy(ReloadConfiguration.none);
       var extensionUri = 'http://localhost:4000';
-      var pipeline = const Pipeline().addMiddleware(createInjectedHandler(
-          ReloadConfiguration.liveReload,
-          extensionUri: extensionUri));
+      var pipeline = const Pipeline()
+          .addMiddleware(createInjectedHandler(extensionUri: extensionUri));
       server = await shelf_io.serve(pipeline.addHandler((request) {
         return Response.ok(
             '$entrypointExtensionMarker\n'

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -6,8 +6,8 @@
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/inspector.dart';
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/utilities/conversions.dart';
-import 'package:dwds/src/utilities/shared.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
@@ -38,7 +38,7 @@ void main() {
 
   /// A convenient way to get a library variable without boilerplate.
   String libraryVariableExpression(String variable) =>
-      '$loadModule("dart_sdk").dart.getModuleLibraries("web/scopes_main")["$url"]["$variable"];';
+      '${globalLoadStrategy.loadModuleSnippet}("dart_sdk").dart.getModuleLibraries("web/scopes_main")["$url"]["$variable"];';
 
   Future<RemoteObject> libraryPublicFinal() =>
       inspector.jsEvaluate(libraryVariableExpression('libraryPublicFinal'));

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -6,7 +6,7 @@ import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/debugging/instance.dart';
-import 'package:dwds/src/utilities/shared.dart';
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
@@ -38,7 +38,7 @@ void main() {
   final url = 'org-dartlang-app:///web/scopes_main.dart';
 
   String libraryVariableExpression(String variable) =>
-      '$loadModule("dart_sdk").dart.getModuleLibraries("web/scopes_main")'
+      '${globalLoadStrategy.loadModuleSnippet}("dart_sdk").dart.getModuleLibraries("web/scopes_main")'
       '["$url"]["$variable"];';
 
   /// A reference to the the variable `libraryPublicFinal`, an instance of

--- a/dwds/web/client.dart
+++ b/dwds/web/client.dart
@@ -42,9 +42,9 @@ Future<void> main() {
     await client.onOpen.first;
 
     Restarter restarter;
-    if (dartModuleStrategy == 'require') {
+    if (dartModuleStrategy == 'require-js') {
       restarter = await RequireRestarter.create();
-    } else if (dartModuleStrategy == 'dart_library.import') {
+    } else if (dartModuleStrategy == 'legacy') {
       restarter = LegacyRestarter();
     } else {
       throw StateError('Unknown module strategy: $dartModuleStrategy');

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -108,7 +108,7 @@ class WebDevServer {
         chromeConnection: () async =>
             (await Chrome.connectedInstance).chromeConnection,
         logWriter: logWriter,
-        reloadConfiguration: options.configuration.reload,
+        loadStrategy: RequireStrategy(options.configuration.reload),
         serveDevTools:
             options.configuration.debug || options.configuration.debugExtension,
         verbose: options.configuration.verbose,


### PR DESCRIPTION
Towards https://github.com/dart-lang/webdev/issues/893

Collect module strategy and related loading logic into new `LoadStrategy` abstraction. This will allow us to  make an explicit contract for the `RequireStrategy`.