### PR TITLE
Remove keep-alive

### DIFF
--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -37,8 +37,7 @@ import '../services/debug_service.dart';
 /// opening DevTools.
 class DevHandler {
   StreamSubscription _sub;
-  final SseHandler _sseHandler = SseHandler(Uri.parse(r'/$sseHandler'),
-      keepAlive: const Duration(seconds: 30));
+  final SseHandler _sseHandler = SseHandler(Uri.parse(r'/$sseHandler'));
   final _injectedConnections = <SseConnection>{};
   final DevTools _devTools;
   final AssetReader _assetReader;

--- a/dwds/lib/src/servers/extension_backend.dart
+++ b/dwds/lib/src/servers/extension_backend.dart
@@ -11,8 +11,7 @@ import 'package:http_multi_server/http_multi_server.dart';
 import 'package:shelf/shelf_io.dart';
 import 'package:sse/server/sse_handler.dart';
 
-final _sseHandler =
-    SseHandler(Uri.parse('/\$debug'), keepAlive: const Duration(seconds: 30));
+final _sseHandler = SseHandler(Uri.parse('/\$debug'));
 
 /// A backend for the Dart Debug Extension.
 ///


### PR DESCRIPTION
Looks like https://github.com/dart-lang/webdev/pull/876 caused some issues.

When you refresh the page we don't get an isolate destroy event (or there may be a race condition) so resetting breakpoints and other debug functionality is impacted.

Before adding back the keep-alive functionality we should test the refresh functionality and ensure we get proper destroy events.

cc @danytup