### PR TITLE
Destroy isolate during connect request even when there's a connected client

### DIFF
--- a/dwds/debug_extension/pubspec.yaml
+++ b/dwds/debug_extension/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   js: ^0.6.1+1
   pedantic: ^1.5.0
   pub_semver: ^1.3.2
-  sse: ^3.1.1
+  sse: ^3.2.0
 
 dev_dependencies:
   webdev: ^2.0.0

--- a/dwds/lib/src/connections/app_connection.dart
+++ b/dwds/lib/src/connections/app_connection.dart
@@ -20,6 +20,7 @@ class AppConnection {
 
   AppConnection(this.request, this._connection);
 
+  bool get isInKeepAlivePeriod => _connection.isInKeepAlivePeriod;
   bool get isStarted => _startedCompleter.isCompleted;
   Future<void> get onStart => _startedCompleter.future;
 

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -37,7 +37,8 @@ import '../services/debug_service.dart';
 /// opening DevTools.
 class DevHandler {
   StreamSubscription _sub;
-  final SseHandler _sseHandler = SseHandler(Uri.parse(r'/$sseHandler'));
+  final SseHandler _sseHandler = SseHandler(Uri.parse(r'/$sseHandler'),
+      keepAlive: const Duration(seconds: 30));
   final _injectedConnections = <SseConnection>{};
   final DevTools _devTools;
   final AssetReader _assetReader;
@@ -309,7 +310,8 @@ class DevHandler {
     // were previously launched and create the new isolate.
     var services = _servicesByAppId[message.appId];
     var connection = AppConnection(message, sseConnection);
-    if (services != null && services.connectedInstanceId == null) {
+    if (services != null &&
+        services.connectedInstanceId != message.instanceId) {
       // Disconnect any old connection (eg. those in the keep-alive waiting state
       // when reloading the page).
       services.chromeProxyService?.destroyIsolate();

--- a/dwds/lib/src/servers/extension_backend.dart
+++ b/dwds/lib/src/servers/extension_backend.dart
@@ -11,7 +11,8 @@ import 'package:http_multi_server/http_multi_server.dart';
 import 'package:shelf/shelf_io.dart';
 import 'package:sse/server/sse_handler.dart';
 
-final _sseHandler = SseHandler(Uri.parse('/\$debug'));
+final _sseHandler =
+    SseHandler(Uri.parse('/\$debug'), keepAlive: const Duration(seconds: 30));
 
 /// A backend for the Dart Debug Extension.
 ///

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   shelf_static: ^0.2.8
   shelf_web_socket: ^0.2.0
   source_maps: ^0.10.0
-  sse: ^3.1.1
+  sse: ^3.2.0
   vm_service: 2.3.1
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: '>=0.4.0 <0.6.0'

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -96,6 +96,9 @@ class FakeSseConnection implements SseConnection {
       null;
 
   @override
+  bool get isInKeepAlivePeriod => false;
+
+  @override
   void pipe(StreamChannel<String> other) {}
 
   @override

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   shelf: ^0.7.4
   shelf_proxy: ^0.1.0+5
   shelf_static: ^0.2.8
-  sse: ^3.1.1
+  sse: ^3.2.0
   vm_service: ^2.0.0
   webkit_inspection_protocol: '>=0.4.0 <0.6.0'
   yaml: ^2.1.13


### PR DESCRIPTION
@grouma This seems to solve the issue described in #901 (https://github.com/dart-lang/webdev/pull/901#issuecomment-586438132). The issue was that when DevTools is connected, `connectedInstanceId` is not-null so it wasn't destroying/re-creating the isolate (but it did when it was `null`). I was able to repro this in a test by copying the `destroys and recreates the isolate during a page refresh` test into `devtools_test` (or at least, I believe I have - it doesn't seem to complete without the fix, and passes after the fix - I'm not sure why it's not timing out though).

Does this seem like a reasonable fix (and also copying the test)?

(I don't know if all tests pass yet, I'm having some issues with a few locally - but they seem to fail before the change, so I'll see what happens o Travis).
