### PR TITLE
Inject loader bootstrap at the root

### DIFF
--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -125,9 +125,9 @@ class DevHandler {
       // before events are received.
       unawaited(Future.microtask(() => tabConnection.runtime.enable()));
       // There is no way to calculate the number of existing execution contexts
-      // so we wait for a short while to recieve a context.
+      // so we wait for a short while to receive a context.
       while (await contextQueue.hasNext
-          .timeout(const Duration(milliseconds: 50), onTimeout: () => false)) {
+          .timeout(const Duration(milliseconds: 500), onTimeout: () => false)) {
         var context = await contextQueue.next;
         var result = await tabConnection.sendCommand('Runtime.evaluate', {
           'expression': r'window["$dartAppInstanceId"];',

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -127,7 +127,7 @@ class DevHandler {
       // There is no way to calculate the number of existing execution contexts
       // so we wait for a short while to receive a context.
       while (await contextQueue.hasNext
-          .timeout(const Duration(milliseconds: 500), onTimeout: () => false)) {
+          .timeout(const Duration(milliseconds: 50), onTimeout: () => false)) {
         var context = await contextQueue.next;
         var result = await tabConnection.sendCommand('Runtime.evaluate', {
           'expression': r'window["$dartAppInstanceId"];',

--- a/dwds/lib/src/handlers/injected_handler.dart
+++ b/dwds/lib/src/handlers/injected_handler.dart
@@ -60,7 +60,11 @@ Handler Function(Handler) createInjectedHandler(LoadStrategy loadStrategy,
             var bodyLines = body.split('\n');
             var extensionIndex = bodyLines
                 .indexWhere((line) => line.contains(mainExtensionMarker));
-            body = bodyLines.sublist(0, extensionIndex).join('\n');
+            // We inject the bootstrap directly after the entrypoint marker.
+            body = '${bodyLines[0]}\n';
+            body += await loadStrategy.bootstrapFor(request.url.path);
+            // Include up until the main extension marker.
+            body += bodyLines.sublist(1, extensionIndex).join('\n');
             // The line after the marker calls `main`. We prevent `main` from
             // being called and make it runnable through a global variable.
             var mainFunction = bodyLines[extensionIndex + 1]
@@ -71,7 +75,6 @@ Handler Function(Handler) createInjectedHandler(LoadStrategy loadStrategy,
             if (urlEncoder != null) {
               requestedUriBase = await urlEncoder(requestedUriBase);
             }
-            body += await loadStrategy.bootstrapFor(request.url.path);
             body += _injectedClientJs(
               appId,
               mainFunction,

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -52,6 +52,8 @@ abstract class LoadStrategy {
   ''';
 
   /// Returns the bootstrap required for this [LoadStrategy].
+  ///
+  /// The bootstrap is appended to the end of the entry point module.
   Future<String> bootstrapFor(String entrypoint);
 
   /// A handler for strategy specific requests.

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -121,9 +121,6 @@ class FakeSseConnection implements SseConnection {
   StreamChannel<String> transformStream(
           StreamTransformer<String, String> transformer) =>
       null;
-
-  @override
-  bool get isInKeepAlivePeriod => false;
 }
 
 class FakeWebkitDebugger implements WebkitDebugger {

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -118,6 +118,9 @@ class FakeSseConnection implements SseConnection {
   StreamChannel<String> transformStream(
           StreamTransformer<String, String> transformer) =>
       null;
+
+  @override
+  bool get isInKeepAlivePeriod => false;
 }
 
 class FakeWebkitDebugger implements WebkitDebugger {


### PR DESCRIPTION
Elements of the Require Loader bootstrap are expected to be globally available, e.g. the [customModulePaths](https://github.com/dart-lang/webdev/blob/master/dwds/lib/src/loaders/require.dart#L225). Previously we were injecting the bootstrap within the main module.

This change cleans up the injection logic so that the bootstrap is injected globally at the end. The injected client must occur inside the root module so I've added documentation to make that clear. I've also removed the logic which changes the hot restart handler as that is no longer used.