### PR TITLE
Filter JS scope up to and including the inclusion of the Dart SDK

### DIFF
--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -18,12 +18,9 @@ Future<List<Property>> visibleProperties(
     {List<Map<String, dynamic>> scopeList,
     Debugger debugger,
     String callFrameId}) async {
-  // We skip the global and the outer library scope and assume everything before
-  // that is a method scope.
-  var numberOfMethods = scopeList.length - 2;
-  if (numberOfMethods <= 0) return [];
-  var methodScopes = scopeList.sublist(0, numberOfMethods);
-  var propertyLists = methodScopes
+  var scopes = await _filterScopes(scopeList, debugger);
+  if (scopes.isEmpty) return [];
+  var propertyLists = scopes
       .map((scope) async =>
           await debugger.getProperties(scope['object']['objectId'] as String))
       .toList();
@@ -46,7 +43,28 @@ Future<List<Property>> visibleProperties(
   return allProperties;
 }
 
-/// Find the `this` in scope if it wasn't in the provided data from Chrome.
+/// Filters the provided scope chain into those that are pertinent for Dart
+/// debugging.
+Future<List<Map<String, dynamic>>> _filterScopes(
+    List<Map<String, dynamic>> scopeList, Debugger debugger) async {
+  var foundDartSdk = false;
+  var result = <Map<String, dynamic>>[];
+  // Iterate through the outermost scope to the inner most scope.
+  for (var scope in scopeList.reversed) {
+    var properties =
+        await debugger.getProperties(scope['object']['objectId'] as String);
+    if (!foundDartSdk) {
+      var propertyNames = properties.map((element) => element.name).toSet();
+      // TODO(sdk/issues/40774) - This appears brittle.
+      if (propertyNames.containsAll(['core', 'dart'])) foundDartSdk = true;
+    } else {
+      // Scopes after the Dart SDK is defined contain application logic.
+      result.add(scope);
+    }
+  }
+  return result;
+}
+
 ///
 /// If we were not given a `this` value in the Chrome scopes that might mean
 /// we're in a nested closure, or we might be a top-level function. Find it by evaluating

--- a/dwds/test/fixtures/debugger_data.dart
+++ b/dwds/test/fixtures/debugger_data.dart
@@ -91,6 +91,28 @@ List<Map<String, dynamic>> frames1 = [
 var variables1 = [
   WipResponse({
     'id': 1,
+    'result': {'result': []}
+  }),
+  WipResponse({
+    'id': 2,
+    'result': {'result': []}
+  }),
+  // Fake that the SDK is loaded.
+  WipResponse({
+    'id': 3,
+    'result': {
+      'result': [
+        {'name': 'dart', 'value': null},
+        {'name': 'core', 'value': null}
+      ]
+    }
+  }),
+  WipResponse({
+    'id': 4,
+    'result': {'result': []}
+  }),
+  WipResponse({
+    'id': 5,
     'result': {
       'result': [
         {
@@ -105,11 +127,7 @@ var variables1 = [
     }
   }),
   WipResponse({
-    'id': 2,
-    'result': {'result': []}
-  }),
-  WipResponse({
-    'id': 3,
+    'id': 6,
     'result': {'result': []}
   }),
 ];


### PR DESCRIPTION
The number of scopes to skip is not deterministic, so skipping the first two scopes leads to the inclusion of a number of non-useful properties in some scenarios. Instead, filter scopes until the inclusion of the Dart SDK. Nested scopes should contain application logic.

Related: https://github.com/dart-lang/sdk/issues/40774