### PR TITLE
Lazily get modules

### DIFF
--- a/dwds/lib/src/debugging/modules.dart
+++ b/dwds/lib/src/debugging/modules.dart
@@ -43,7 +43,6 @@ class Modules {
     _sourceToModule.clear();
     _sourceToLibrary.clear();
     _moduleCompleter = Completer<bool>();
-    _initializeMapping();
   }
 
   /// Returns the module for the Chrome script ID.
@@ -56,19 +55,19 @@ class Modules {
 
   /// Returns the containing module for the provided Dart server path.
   Future<String> moduleForSource(String serverPath) async {
-    await _moduleCompleter.future;
+    await _initializeMapping();
     return _sourceToModule[serverPath];
   }
 
   /// Returns the containing library importUri for the provided Dart server path.
   Future<Uri> libraryForSource(String serverPath) async {
-    await _moduleCompleter.future;
+    await _initializeMapping();
     return _sourceToLibrary[serverPath];
   }
 
   // Returns mapping from server paths to library paths
   Future<Map<String, String>> modules() async {
-    await _moduleCompleter.future;
+    await _initializeMapping();
     return _sourceToModule;
   }
 


### PR DESCRIPTION
The recent change in module logic introduced a race condition in which we prematurely execute the evaluation to get the source to module mapping. This issue doesn't show up in our E2E tests because the applications are too small. All of the sources are already loaded by the time we execute the evaluation. Long term this won't be an issue as we'll forgo the evaluation and speak directly to the compiler to get the required metadata.