### PR TITLE
Fix error in js-to-dart location lookup for eval

### DIFF
--- a/dwds/lib/src/debugging/location.dart
+++ b/dwds/lib/src/debugging/location.dart
@@ -66,7 +66,7 @@ class DartLocation {
   );
 
   @override
-  String toString() => 'DartLoc: ${uri.serverPath}, $line, $column';
+  String toString() => '[${uri.serverPath}:$line:$column]';
 
   static DartLocation fromZeroBased(DartUri uri, int line, int column) =>
       DartLocation._(uri, line + 1, column + 1);
@@ -93,7 +93,7 @@ class JsLocation {
   );
 
   @override
-  String toString() => 'JSLoc: $scriptId, $line, $column';
+  String toString() => '[$scriptId:$line:$column]';
 
   static JsLocation fromZeroBased(String scriptId, int line, int column) =>
       JsLocation._(scriptId, line + 1, column + 1);

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -63,7 +63,9 @@ class ExpressionEvaluator {
     var jsFrame = WipCallFrame(jsStack[frameIndex]);
 
     var functionName = jsFrame.functionName;
-    var jsLocation = jsFrame.location;
+    var jsLocation = JsLocation.fromZeroBased(jsFrame.location.scriptId,
+        jsFrame.location.lineNumber, jsFrame.location.columnNumber);
+
     _printTrace('Expression evaluator: JS location: '
         '$functionName, $jsLocation');
 
@@ -77,16 +79,15 @@ class ExpressionEvaluator {
     // so this will result in expressions not evaluated in some
     // cases. Invent location matching strategy for those cases.
     // [issue 890](https://github.com/dart-lang/webdev/issues/890)
-    var locationMap = await _locations.locationForJs(
-        jsLocation.scriptId, jsLocation.lineNumber);
+    var locationMap =
+        await _locations.locationForJs(jsLocation.scriptId, jsLocation.line);
 
     if (locationMap == null) {
       return _createError(
           'Internal Error',
-          'Cannot find Dart location for JS location '
-              '{script: $jsLocation.scriptId, '
+          'Cannot find Dart location for JS location: '
               'function: $functionName, '
-              'location: $jsLocation})');
+              'location: $jsLocation');
     }
 
     var dartLocation = locationMap.dartLocation;


### PR DESCRIPTION
- fixed off-by-one error in translation of js location to dart locations
- fixed a typo in printing verbose messages
- made location printing concise and recognizable

Fixes #938