### PR TITLE
remove unnecessary error messages in expression evaluation

### DIFF
--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -43,9 +43,6 @@ class ExpressionEvaluator {
   }
 
   RemoteObject _createError(ErrorKind severity, String message) {
-    if (severity == ErrorKind.internal) {
-      _logWriter(Level.WARNING, '$severity: $message');
-    }
     return RemoteObject(
         <String, String>{'type': '$severity', 'value': message});
   }
@@ -154,8 +151,6 @@ class ExpressionEvaluator {
     var isError = compilationResult.isError;
     var jsExpression = compilationResult.result;
 
-    _printTrace('Expression evaluator: js: $jsExpression, isError: $isError');
-
     if (isError) {
       // Frontend currently gives a text message including library name
       // and function name on compilation error. Strip this information
@@ -173,8 +168,8 @@ class ExpressionEvaluator {
         error = error.substring(0, error.lastIndexOf(']'));
       }
 
-      if (error.contains('InternalError:')) {
-        error = error.replaceAll('CompilationError: InternalError: ', '');
+      if (error.contains('InternalError: ')) {
+        error = error.replaceAll('InternalError: ', '');
         return _createError(ErrorKind.internal, error);
       }
 

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -71,8 +71,7 @@ void main() {
       var frame = stack.frames.first;
       var variableNames = frame.vars.map((variable) => variable.name).toList()
         ..sort();
-      expect(variableNames, [
-        'T',
+      expect(variableNames, containsAll([
         'aClass',
         'another',
         'intLocalInMain',
@@ -81,7 +80,7 @@ void main() {
         'nestedFunction',
         'parameter',
         'testClass'
-      ]);
+      ]));
     });
 
     test('variables in closure nested in method', () async {

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -72,6 +72,7 @@ void main() {
       var variableNames = frame.vars.map((variable) => variable.name).toList()
         ..sort();
       expect(variableNames, [
+        'T',
         'aClass',
         'another',
         'intLocalInMain',

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -71,16 +71,18 @@ void main() {
       var frame = stack.frames.first;
       var variableNames = frame.vars.map((variable) => variable.name).toList()
         ..sort();
-      expect(variableNames, containsAll([
-        'aClass',
-        'another',
-        'intLocalInMain',
-        'local',
-        'localThatsNull',
-        'nestedFunction',
-        'parameter',
-        'testClass'
-      ]));
+      expect(
+          variableNames,
+          containsAll([
+            'aClass',
+            'another',
+            'intLocalInMain',
+            'local',
+            'localThatsNull',
+            'nestedFunction',
+            'parameter',
+            'testClass'
+          ]));
     });
 
     test('variables in closure nested in method', () async {


### PR DESCRIPTION
A few redundant messages are showing in the error log, and a repeated "InternalError: InternalError: ..." message is shown on internal error coming from the frontend server. Remove them.