### PR TITLE
Fix test break due to an SDK update

### DIFF
--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -30,8 +30,10 @@ Future<List<Property>> visibleProperties(
   // parameters. Hide those.
   // TODO(#786) Handle these correctly rather than just suppressing them.
   allProperties.removeWhere((each) =>
-      each.value.type == 'function' &&
-      each.value.description.startsWith('class '));
+      (each.value.type == 'function' &&
+          each.value.description.startsWith('class ')) ||
+      (each.value.type == 'object' &&
+          each.value.description == 'dart.LegacyType.new'));
   var existingThis =
       allProperties.firstWhere((x) => x.name == 'this', orElse: () => null);
   if (existingThis == null) {


### PR DESCRIPTION
Recent SDK update brought changes in descriptions and types
of properties that were chosen not to be shown to the users,
and broke heuristics for calculation those fields.
Update those heuristics.

fixes build break:
https://travis-ci.org/github/dart-lang/webdev/builds/677981606