### PR TITLE
Support Edge

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 3.0.4-dev
+## 3.1.0-dev
+
+- Support Chromium based Edge.
 
 ## 3.0.3
 

--- a/dwds/lib/src/injected/client.js
+++ b/dwds/lib/src/injected/client.js
@@ -8343,9 +8343,6 @@
       t1.body.appendChild(scriptElement);
       P.Future_Future$microtask(C.ScriptElement_methods.get$remove(scriptElement), type$.void);
     },
-    _isChrome: function() {
-      return J.contains$1$asx(window.navigator.userAgent, "Chrome") && !J.contains$1$asx(window.navigator.userAgent, "Edg");
-    },
     main_closure: function main_closure() {
     },
     main__closure: function main__closure(t0) {
@@ -22224,7 +22221,7 @@
               t3 = type$.void_Function_KeyboardEvent._as(new D.main__closure3());
               t1._as(null);
               W._EventStreamSubscription$(t2, "keydown", t3, false, type$.KeyboardEvent);
-              if (D._isChrome()) {
+              if (J.contains$1$asx(window.navigator.userAgent, "Chrome")) {
                 t1 = client._outgoingController;
                 t2 = $.$get$serializers();
                 t3 = new E.ConnectRequestBuilder();
@@ -22253,8 +22250,8 @@
   D.main__closure0.prototype = {
     call$0: function() {
       var t1, t2, t3;
-      if (!D._isChrome()) {
-        window.alert("Dart DevTools is only supported on Chrome");
+      if (!J.contains$1$asx(window.navigator.userAgent, "Chrome")) {
+        window.alert("Dart DevTools is only supported on Chromium based browsers.");
         return;
       }
       t1 = this.client._outgoingController;

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.0.4-dev';
+const packageVersion = '3.1.0-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 3.0.4-dev
+version: 3.1.0-dev
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -122,6 +122,9 @@ class FakeSseConnection implements SseConnection {
   StreamChannel<String> transformStream(
           StreamTransformer<String, String> transformer) =>
       null;
+
+  @override
+  void shutdown() {}
 }
 
 class FakeWebkitDebugger implements WebkitDebugger {

--- a/dwds/web/client.dart
+++ b/dwds/web/client.dart
@@ -57,8 +57,9 @@ Future<void> main() {
     });
 
     launchDevToolsJs = allowInterop(() {
-      if (!_isChrome) {
-        window.alert('Dart DevTools is only supported on Chrome');
+      if (!_isChromium) {
+        window.alert(
+            'Dart DevTools is only supported on Chromium based browsers.');
         return;
       }
       client.sink.add(jsonEncode(serializers.serialize(DevToolsRequest((b) => b
@@ -109,12 +110,12 @@ Future<void> main() {
       }
     });
 
-    if (_isChrome) {
+    if (_isChromium) {
       client.sink.add(jsonEncode(serializers.serialize(ConnectRequest((b) => b
         ..appId = dartAppId
         ..instanceId = dartAppInstanceId))));
     } else {
-      // If not chrome we just invoke main, devtools aren't supported.
+      // If not Chromium we just invoke main, devtools aren't supported.
       runMain();
     }
   }, onError: (error, stackTrace) {
@@ -187,8 +188,4 @@ void runMain() {
   Future.microtask(scriptElement.remove);
 }
 
-bool get _isChrome =>
-    window.navigator.userAgent.contains('Chrome') &&
-    // Edge has `Chrome` in its user agent string, but it also has `Edg` which
-    // chrome doesn't.
-    !window.navigator.userAgent.contains('Edg');
+bool get _isChromium => window.navigator.userAgent.contains('Chrome');


### PR DESCRIPTION
Closes https://github.com/dart-lang/webdev/issues/962 and sneak in a forward fix to the latest `package:sse` change.

**To make our intentions explicit:**
We'll continue to support Edge as long as it continues to be minimal effort and the browser does not diverge significantly from Chrome.

