### PR TITLE
initial setup for the new frontend server client package + sdk versioning policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ services:
 jobs:
   include:
     - stage: analyzer_and_format
-      name: "SDK: 2.7.0; PKGS: dwds, example, frontend_server_client, frontend_server_common, webdev; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.7.0; PKGS: dwds, example, frontend_server_common, webdev; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.7.0"
       os: linux
-      env: PKGS="dwds example frontend_server_client frontend_server_common webdev"
+      env: PKGS="dwds example frontend_server_common webdev"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyzer_and_format
       name: "SDK: dev; PKG: dwds; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`, `pub run test test/build/ensure_version_test.dart`]"
@@ -28,10 +28,16 @@ jobs:
       env: PKGS="dwds"
       script: ./tool/travis.sh dartfmt dartanalyzer_0 test_0
     - stage: analyzer_and_format
-      name: "SDK: dev; PKGS: example, frontend_server_client, frontend_server_common; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      name: "SDK: dev; PKGS: example, frontend_server_common; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: dev
       os: linux
-      env: PKGS="example frontend_server_client frontend_server_common"
+      env: PKGS="example frontend_server_common"
+      script: ./tool/travis.sh dartfmt dartanalyzer_0
+    - stage: analyzer_and_format
+      name: "SDK: 2.7.0; PKG: frontend_server_client; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      dart: "2.7.0"
+      os: linux
+      env: PKGS="frontend_server_client"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyzer_and_format
       name: "SDK: dev; PKG: webdev; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`, `pub run test test/build/ensure_build_test.dart`]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,17 @@ jobs:
       env: PKGS="dwds"
       script: ./tool/travis.sh dartfmt dartanalyzer_0 test_0
     - stage: analyzer_and_format
-      name: "SDK: dev; PKGS: example, frontend_server_common; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      name: "SDK: dev; PKGS: example, frontend_server_client, frontend_server_common; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: dev
       os: linux
-      env: PKGS="example frontend_server_common"
+      env: PKGS="example frontend_server_client frontend_server_common"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
+    - stage: analyzer_and_format
+      name: "SDK: 2.8.0; PKG: frontend_server_client; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.8.0"
+      os: linux
+      env: PKGS="frontend_server_client"
+      script: ./tool/travis.sh dartanalyzer_1
     - stage: analyzer_and_format
       name: "SDK: dev; PKG: webdev; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`, `pub run test test/build/ensure_build_test.dart`]"
       dart: dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ services:
 jobs:
   include:
     - stage: analyzer_and_format
-      name: "SDK: 2.7.0; PKGS: dwds, example, frontend_server_common, webdev; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.7.0; PKGS: dwds, example, frontend_server_client, frontend_server_common, webdev; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.7.0"
       os: linux
-      env: PKGS="dwds example frontend_server_common webdev"
+      env: PKGS="dwds example frontend_server_client frontend_server_common webdev"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyzer_and_format
       name: "SDK: dev; PKG: dwds; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`, `pub run test test/build/ensure_version_test.dart`]"
@@ -33,12 +33,6 @@ jobs:
       os: linux
       env: PKGS="example frontend_server_client frontend_server_common"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
-    - stage: analyzer_and_format
-      name: "SDK: 2.8.0; PKG: frontend_server_client; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.8.0"
-      os: linux
-      env: PKGS="frontend_server_client"
-      script: ./tool/travis.sh dartanalyzer_1
     - stage: analyzer_and_format
       name: "SDK: dev; PKG: webdev; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`, `pub run test test/build/ensure_build_test.dart`]"
       dart: dev

--- a/frontend_server_client/CHANGELOG.md
+++ b/frontend_server_client/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0-dev
+
+- Initial version

--- a/frontend_server_client/LICENSE
+++ b/frontend_server_client/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2020, the Dart project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/frontend_server_client/README.md
+++ b/frontend_server_client/README.md
@@ -1,0 +1,23 @@
+This package provides a client interface around the frontend_server compiler
+which ships with the Dart SDK.
+
+## Usage
+
+TODO
+
+## SDK Versioning Policy
+
+This package keeps a relatively tight version constraint on the SDK to allow
+for breaking changes in the frontend_server binary itself.
+
+Specifically, releases of this package will have an upper bound of less than
+the next _minor_ (middle) version number of the latest stable SDK. There are no
+requirements for the lower bound (other than the package must pass tests on
+that SDK).
+
+The effect of this policy is that breaking changes will be allowed to the
+frontend_server binary, but only in _minor_ SDK version releases.
+
+**Note**: This also means that when a new stable SDK is released, this package
+will also need a new version published on pub before users can get a valid
+version solve.

--- a/frontend_server_client/README.md
+++ b/frontend_server_client/README.md
@@ -21,3 +21,18 @@ frontend_server binary, but only in _minor_ SDK version releases.
 **Note**: This also means that when a new stable SDK is released, this package
 will also need a new version published on pub before users can get a valid
 version solve.
+
+### Working with dev SDK releases
+
+By default when you do a pub get/upgrade, a constraint like `<2.9.0` will
+actually allow dev releases of `2.9.0` if the current SDK is a dev release. It
+emits a warning when it does this, but will happily alow it.
+
+* This means that we don't have to publish versions that explicitly allow dev
+  releases. We will be notified of breakages by our bots if a dev release does
+  break us, and can release a patch.
+
+If we need to depend on some new feature from a dev release, the min sdk
+constraint should be bumped to that version but the max sdk constraint should
+_not_ be changed. So for example we will have constraints like
+`>=2.9.0-dev.1 <2.9.0`.

--- a/frontend_server_client/lib/frontend_server_client.dart
+++ b/frontend_server_client/lib/frontend_server_client.dart
@@ -1,0 +1,5 @@
+// Copyright 2020 The Dart Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+export 'src/frontend_server_client.dart';

--- a/frontend_server_client/lib/frontend_server_client.dart
+++ b/frontend_server_client/lib/frontend_server_client.dart
@@ -2,4 +2,4 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'src/frontend_server_client.dart';
+export 'src/frontend_server_client.dart' show FrontendServerClient;

--- a/frontend_server_client/lib/src/frontend_server_client.dart
+++ b/frontend_server_client/lib/src/frontend_server_client.dart
@@ -1,0 +1,6 @@
+// Copyright 2020 The Dart Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO: Actually implement
+abstract class FrontendServerClient {}

--- a/frontend_server_client/mono_pkg.yaml
+++ b/frontend_server_client/mono_pkg.yaml
@@ -7,4 +7,4 @@ stages:
       dart: dev
     - group:
       - dartanalyzer: --fatal-warnings .
-      dart: [2.7.0]
+      dart: [2.8.0]

--- a/frontend_server_client/mono_pkg.yaml
+++ b/frontend_server_client/mono_pkg.yaml
@@ -1,0 +1,10 @@
+# See https://github.com/dart-lang/mono_repo for details
+stages:
+  - analyzer_and_format:
+    - group:
+      - dartfmt
+      - dartanalyzer: --fatal-infos --fatal-warnings .
+      dart: dev
+    - group:
+      - dartanalyzer: --fatal-warnings .
+      dart: [2.7.0]

--- a/frontend_server_client/mono_pkg.yaml
+++ b/frontend_server_client/mono_pkg.yaml
@@ -7,4 +7,4 @@ stages:
       dart: dev
     - group:
       - dartanalyzer: --fatal-warnings .
-      dart: [2.8.0]
+      dart: [2.7.0]

--- a/frontend_server_client/mono_pkg.yaml
+++ b/frontend_server_client/mono_pkg.yaml
@@ -4,7 +4,4 @@ stages:
     - group:
       - dartfmt
       - dartanalyzer: --fatal-infos --fatal-warnings .
-      dart: dev
-    - group:
-      - dartanalyzer: --fatal-warnings .
-      dart: [2.7.0]
+      dart: 2.7.0

--- a/frontend_server_client/pubspec.yaml
+++ b/frontend_server_client/pubspec.yaml
@@ -4,4 +4,4 @@ description: >-
   Client code to start and interact with the frontend_server compiler from the
   Dart SDK.
 environment:
-  sdk: ">=2.8.0 <2.9.0"
+  sdk: ">=2.7.0 <2.8.0"

--- a/frontend_server_client/pubspec.yaml
+++ b/frontend_server_client/pubspec.yaml
@@ -1,0 +1,7 @@
+name: frontend_server_client
+version: 1.0.0-dev
+description: >-
+  Client code to start and interact with the frontend_server compiler from the
+  Dart SDK.
+environment:
+  sdk: ">=2.8.0 <2.9.0"


### PR DESCRIPTION
This is just a skeleton, please specifically review the planned [SDK versioning policy](https://github.com/dart-lang/webdev/pull/972/files#diff-09108d6152121a2f9e03b46469bc0ff5R8) in the README.md file, which is how I propose we deal  with breaking changes in the frontend_server itself, now that we will have a _package_ which depends on its api.

@aam @alexmarkov  please add anybody else who cares about frontend_server in the sdk and the ability to do breaking changes in it.

cc @jonahwilliams