### PR TITLE
add a stub implementation for getClassList()

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -389,6 +389,12 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   }
 
   @override
+  Future<ClassList> getClassList(String isolateId) {
+    // See dart-lang/webdev/issues/971.
+    throw UnimplementedError();
+  }
+
+  @override
   Future<FlagList> getFlagList() async {
     // VM flags do not apply to web apps.
     return FlagList(flags: []);

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   shelf_web_socket: ^0.2.0
   source_maps: ^0.10.0
   sse: ^3.5.0
-  vm_service: 4.0.0
+  vm_service: ^4.0.2
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: '>=0.5.0+1 <0.6.0'
 

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -21,8 +21,10 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 import 'fixtures/context.dart';
 
 final context = TestContext();
+
 ChromeProxyService get service =>
     fetchChromeProxyService(context.debugConnection);
+
 WipConnection get tabConnection => context.tabConnection;
 
 void main() {
@@ -303,6 +305,10 @@ void main() {
     test('getAllocationProfile', () {
       expect(
           () => service.getAllocationProfile(null), throwsUnimplementedError);
+    });
+
+    test('getClassList', () {
+      expect(() => service.getClassList(null), throwsUnimplementedError);
     });
 
     test('getFlagList', () async {


### PR DESCRIPTION
- add a stub implementation for `getClassList()` (introduced in package:vm_serverice 4.0.2)
- related to https://github.com/dart-lang/webdev/issues/971

cc @grouma 
