### PR TITLE
Shutdown connection upon reuse

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 3.1.0-dev
+## 3.1.0
 
 - Support Chromium based Edge.
 
 - Depend on latest `package:sse` version `3.5.0`.
 - Bypass connection keep-alives when shutting down to avoid delaying process shutdown.
+- Fix an issue where the isolate would incorrectly be destroyed after connection reuse.
 
 ## 3.0.3
 

--- a/dwds/lib/src/connections/app_connection.dart
+++ b/dwds/lib/src/connections/app_connection.dart
@@ -21,6 +21,7 @@ class AppConnection {
   AppConnection(this.request, this._connection);
 
   bool get isInKeepAlivePeriod => _connection.isInKeepAlivePeriod;
+  void shutDown() => _connection.shutdown();
   bool get isStarted => _startedCompleter.isCompleted;
   Future<void> get onStart => _startedCompleter.future;
 

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -308,17 +308,19 @@ class DevHandler {
     var existingAppConection = _appConnectionByAppId[message.appId];
     var connection = AppConnection(message, sseConnection);
 
-    // We can take over a connection if there is no connectedInstanceId (this means
-    // the client completely disconnected), or if the existing AppConnection
-    // is in the KeepAlive state (this means it disconnected but is still waiting
-    // for a possible reconnect - this happens during a page reload).
+    // We can take over a connection if there is no connectedInstanceId (this
+    // means the client completely disconnected), or if the existing
+    // AppConnection is in the KeepAlive state (this means it disconnected but
+    // is still waiting for a possible reconnect - this happens during a page
+    // reload).
     var canReuseConnection = services != null &&
         (services.connectedInstanceId == null ||
             existingAppConection?.isInKeepAlivePeriod == true);
 
     if (canReuseConnection) {
-      // Disconnect any old connection (eg. those in the keep-alive waiting state
-      // when reloading the page).
+      // Disconnect any old connection (eg. those in the keep-alive waiting
+      // state when reloading the page).
+      existingAppConection.shutDown();
       services.chromeProxyService?.destroyIsolate();
 
       // Reconnect to existing service.

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.1.0-dev';
+const packageVersion = '3.1.0';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 3.1.0-dev
+version: 3.1.0
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM


### PR DESCRIPTION
We recently fixed an [issue](https://github.com/dart-lang/sse/pull/26) in `package:sse` that ensures the `sink.close` event fires. This highlighted an issue with our reconnection logic. We don't properly shutdown the existing connection upon reuse. Thus after the keep-alive timer completes, we would inadvertently destroy the existing isolate:
https://github.com/dart-lang/webdev/blob/e6491c5826e89d83b0fd3a6db732e920bc02e1ce/dwds/lib/src/handlers/dev_handler.dart#L250

Actively shutting down the connection resolves the issue as the corresponding keep-alive timer is killed:
https://github.com/dart-lang/sse/blob/e5cf68975e8e87171a3dc297577aa073454a91dc/lib/src/server/sse_handler.dart#L132

I wish I could provide a solid test for this but it's a race condition so can't come up with anything good :/

Closes https://github.com/dart-lang/webdev/issues/947

Will close https://github.com/flutter/flutter/issues/54290 when the latest `package:dwds` is pulled into Flutter Tools.