### PR TITLE
use package:webkit_inspector_protocol in more places

### DIFF
--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -89,7 +89,7 @@ class Debugger extends Domain {
 
   Future<Success> pause() async {
     _isStepping = false;
-    var result = await _remoteDebugger.sendCommand('Debugger.pause');
+    var result = await _remoteDebugger.pause();
     handleErrorIfPresent(result);
     return Success();
   }
@@ -126,20 +126,20 @@ class Debugger extends Domain {
       _isStepping = true;
       switch (step) {
         case 'Over':
-          result = await _remoteDebugger.sendCommand('Debugger.stepOver');
+          result = await _remoteDebugger.stepOver();
           break;
         case 'Out':
-          result = await _remoteDebugger.sendCommand('Debugger.stepOut');
+          result = await _remoteDebugger.stepOut();
           break;
         case 'Into':
-          result = await _remoteDebugger.sendCommand('Debugger.stepInto');
+          result = await _remoteDebugger.stepInto();
           break;
         default:
           throw ArgumentError('Unexpected value for step: $step');
       }
     } else {
       _isStepping = false;
-      result = await _remoteDebugger.sendCommand('Debugger.resume');
+      result = await _remoteDebugger.resume();
     }
     handleErrorIfPresent(result);
     return Success();
@@ -190,7 +190,7 @@ class Debugger extends Domain {
       logger.warning('Error handling Chrome event', e, s);
     });
 
-    handleErrorIfPresent(await _remoteDebugger?.sendCommand('Page.enable'));
+    handleErrorIfPresent(await _remoteDebugger?.enablePage());
     handleErrorIfPresent(await _remoteDebugger?.enable() as WipResponse);
   }
 
@@ -495,7 +495,7 @@ class Debugger extends Domain {
     } else {
       // If we don't have source location continue stepping.
       if (_isStepping && (await _sourceLocation(e)) == null) {
-        await _remoteDebugger.sendCommand('Debugger.stepInto');
+        await _remoteDebugger.stepInto();
         return;
       }
       event = Event(

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -294,9 +294,7 @@ class Debugger extends Domain {
 
   /// Call the Chrome protocol removeBreakpoint.
   Future<void> _removeBreakpoint(String breakpointId) async {
-    var response = await _remoteDebugger.sendCommand(
-        'Debugger.removeBreakpoint',
-        params: {'breakpointId': breakpointId});
+    var response = await _remoteDebugger.removeBreakpoint(breakpointId);
     handleErrorIfPresent(response);
   }
 
@@ -560,13 +558,17 @@ class Debugger extends Domain {
   Future<RemoteObject> evaluateJsOnCallFrame(
       String callFrameId, String expression) async {
     // TODO(alanknight): Support a version with arguments if needed.
-    WipResponse result;
-    result = await _remoteDebugger.sendCommand('Debugger.evaluateOnCallFrame',
-        params: {'callFrameId': callFrameId, 'expression': expression});
-    handleErrorIfPresent(result, evalContents: expression, additionalDetails: {
-      'Dart expression': expression,
-    });
-    return RemoteObject(result.result['result'] as Map<String, dynamic>);
+    try {
+      return await _remoteDebugger.evaluateOnCallFrame(callFrameId, expression);
+    } on ExceptionDetails catch (e) {
+      throw ChromeDebugException(
+        e.json,
+        evalContents: expression,
+        additionalDetails: {
+          'Dart expression': expression,
+        },
+      );
+    }
   }
 }
 

--- a/dwds/lib/src/debugging/remote_debugger.dart
+++ b/dwds/lib/src/debugging/remote_debugger.dart
@@ -37,6 +37,8 @@ abstract class RemoteDebugger {
 
   Future<WipResponse> setPauseOnExceptions(PauseState state);
 
+  Future<WipResponse> removeBreakpoint(String breakpointId);
+
   Future<WipResponse> stepInto();
 
   Future<WipResponse> stepOut();
@@ -47,7 +49,11 @@ abstract class RemoteDebugger {
 
   Future<WipResponse> pageReload();
 
-  Future<RemoteObject> evaluate(String expression);
+  Future<RemoteObject> evaluate(String expression,
+      {bool returnByValue, int contextId});
+
+  Future<RemoteObject> evaluateOnCallFrame(
+      String callFrameId, String expression);
 
   Stream<T> eventStream<T>(String method, WipEventTransformer<T> transformer);
 

--- a/dwds/lib/src/debugging/remote_debugger.dart
+++ b/dwds/lib/src/debugging/remote_debugger.dart
@@ -7,27 +7,49 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 /// A generic debugger used in remote debugging.
 abstract class RemoteDebugger {
   Stream<ConsoleAPIEvent> get onConsoleAPICalled;
+
   Stream<ExceptionThrownEvent> get onExceptionThrown;
+
+  Stream<GlobalObjectClearedEvent> get onGlobalObjectCleared;
+
+  Stream<DebuggerPausedEvent> get onPaused;
+
+  Stream<DebuggerResumedEvent> get onResumed;
+
+  Stream<ScriptParsedEvent> get onScriptParsed;
+
+  Map<String, WipScript> get scripts;
+
+  Stream<void> get onClose;
+
   Future<WipResponse> sendCommand(String command,
       {Map<String, dynamic> params});
-  void close();
+
   Future<void> disable();
+
   Future<void> enable();
+
   Future<String> getScriptSource(String scriptId);
-  Future<void> pause();
-  Future<void> resume();
-  Future<void> setPauseOnExceptions(PauseState state);
-  Future<void> stepInto();
-  Future<void> stepOut();
-  Future<void> stepOver();
-  Future<void> enablePage();
-  Future<void> pageReload();
+
+  Future<WipResponse> pause();
+
+  Future<WipResponse> resume();
+
+  Future<WipResponse> setPauseOnExceptions(PauseState state);
+
+  Future<WipResponse> stepInto();
+
+  Future<WipResponse> stepOut();
+
+  Future<WipResponse> stepOver();
+
+  Future<WipResponse> enablePage();
+
+  Future<WipResponse> pageReload();
+
   Future<RemoteObject> evaluate(String expression);
+
   Stream<T> eventStream<T>(String method, WipEventTransformer<T> transformer);
-  Stream<GlobalObjectClearedEvent> get onGlobalObjectCleared;
-  Stream<DebuggerPausedEvent> get onPaused;
-  Stream<DebuggerResumedEvent> get onResumed;
-  Stream<ScriptParsedEvent> get onScriptParsed;
-  Map<String, WipScript> get scripts;
-  Stream<void> get onClose;
+
+  void close();
 }

--- a/dwds/lib/src/debugging/webkit_debugger.dart
+++ b/dwds/lib/src/debugging/webkit_debugger.dart
@@ -53,6 +53,10 @@ class WebkitDebugger implements RemoteDebugger {
       _wipDebugger.setPauseOnExceptions(state);
 
   @override
+  Future<WipResponse> removeBreakpoint(String breakpointId) =>
+      _wipDebugger.removeBreakpoint(breakpointId);
+
+  @override
   Future<WipResponse> stepInto() => _wipDebugger.stepInto();
 
   @override
@@ -68,8 +72,18 @@ class WebkitDebugger implements RemoteDebugger {
   Future<WipResponse> pageReload() => _wipDebugger.connection.page.reload();
 
   @override
-  Future<RemoteObject> evaluate(String expression) =>
-      _wipDebugger.connection.runtime.evaluate(expression);
+  Future<RemoteObject> evaluate(String expression,
+      {bool returnByValue, int contextId}) {
+    return _wipDebugger.connection.runtime
+        .evaluate(expression, returnByValue: returnByValue);
+  }
+
+  @override
+  Future<RemoteObject> evaluateOnCallFrame(
+      String callFrameId, String expression) {
+    return _wipDebugger.connection.debugger
+        .evaluateOnCallFrame(callFrameId, expression);
+  }
 
   @override
   Stream<T> eventStream<T>(String method, WipEventTransformer<T> transformer) =>

--- a/dwds/lib/src/debugging/webkit_debugger.dart
+++ b/dwds/lib/src/debugging/webkit_debugger.dart
@@ -43,29 +43,29 @@ class WebkitDebugger implements RemoteDebugger {
       _wipDebugger.getScriptSource(scriptId);
 
   @override
-  Future<void> pause() => _wipDebugger.pause();
+  Future<WipResponse> pause() => _wipDebugger.pause();
 
   @override
-  Future<void> resume() => _wipDebugger.resume();
+  Future<WipResponse> resume() => _wipDebugger.resume();
 
   @override
-  Future<void> setPauseOnExceptions(PauseState state) =>
+  Future<WipResponse> setPauseOnExceptions(PauseState state) =>
       _wipDebugger.setPauseOnExceptions(state);
 
   @override
-  Future<void> stepInto() => _wipDebugger.stepInto();
+  Future<WipResponse> stepInto() => _wipDebugger.stepInto();
 
   @override
-  Future<void> stepOut() => _wipDebugger.stepOut();
+  Future<WipResponse> stepOut() => _wipDebugger.stepOut();
 
   @override
-  Future<void> stepOver() => _wipDebugger.stepOver();
+  Future<WipResponse> stepOver() => _wipDebugger.stepOver();
 
   @override
-  Future<void> enablePage() => _wipDebugger.connection.page.enable();
+  Future<WipResponse> enablePage() => _wipDebugger.connection.page.enable();
 
   @override
-  Future<void> pageReload() => _wipDebugger.connection.page.reload();
+  Future<WipResponse> pageReload() => _wipDebugger.connection.page.reload();
 
   @override
   Future<RemoteObject> evaluate(String expression) =>

--- a/dwds/lib/src/servers/extension_debugger.dart
+++ b/dwds/lib/src/servers/extension_debugger.dart
@@ -168,10 +168,10 @@ class ExtensionDebugger implements RemoteDebugger {
   Future<WipResponse> stepOver() => sendCommand('Debugger.stepOver');
 
   @override
-  Future<void> enablePage() => sendCommand('Page.enable');
+  Future<WipResponse> enablePage() => sendCommand('Page.enable');
 
   @override
-  Future<void> pageReload() => sendCommand('Page.reload');
+  Future<WipResponse> pageReload() => sendCommand('Page.reload');
 
   @override
   Future<RemoteObject> evaluate(String expression) async {

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   sse: ^3.5.0
   vm_service: ^4.0.2
   web_socket_channel: ^1.0.0
-  webkit_inspection_protocol: '>=0.5.0+1 <0.6.0'
+  webkit_inspection_protocol: '>=0.5.1 <0.6.0'
 
 dev_dependencies:
   args: ^1.0.0
@@ -54,7 +54,3 @@ dev_dependencies:
   test: ^1.6.0
   uuid: ^2.0.0
   webdriver: ^2.0.0
-
-dependency_overrides:
-  webkit_inspection_protocol:
-    path: ../../../google/webkit_inspection_protocol.dart/

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -54,3 +54,7 @@ dev_dependencies:
   test: ^1.6.0
   uuid: ^2.0.0
   webdriver: ^2.0.0
+
+dependency_overrides:
+  webkit_inspection_protocol:
+    path: ../../../google/webkit_inspection_protocol.dart/

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -196,12 +196,7 @@ class FakeWebkitDebugger implements WebkitDebugger {
     if (method == 'Runtime.getProperties') {
       return results[resultsReturned++];
     }
-    if (method == 'Debugger.evaluateOnCallFrame') {
-      return WipResponse({
-        'id': 42,
-        'result': {'result': <String, dynamic>{}}
-      });
-    }
+
     if (method == 'Runtime.evaluate') {
       // Fake response adapted from modules query at google3
       return WipResponse({
@@ -226,6 +221,7 @@ class FakeWebkitDebugger implements WebkitDebugger {
         }
       });
     }
+
     return null;
   }
 
@@ -263,8 +259,9 @@ class FakeWebkitDebugger implements WebkitDebugger {
 
   @override
   Future<RemoteObject> evaluateOnCallFrame(
-          String callFrameId, String expression) =>
-      null;
+      String callFrameId, String expression) async {
+    return RemoteObject(<String, dynamic>{});
+  }
 
   @override
   Future<WipResponse> enablePage() => null;

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -233,6 +233,9 @@ class FakeWebkitDebugger implements WebkitDebugger {
   Future<WipResponse> setPauseOnExceptions(PauseState state) => null;
 
   @override
+  Future<WipResponse> removeBreakpoint(String breakpointId) => null;
+
+  @override
   Future<WipResponse> stepInto() => null;
 
   @override
@@ -254,7 +257,14 @@ class FakeWebkitDebugger implements WebkitDebugger {
   Stream<WipConnection> get onClose => null;
 
   @override
-  Future<RemoteObject> evaluate(String expression) => null;
+  Future<RemoteObject> evaluate(String expression,
+          {bool returnByValue, int contextId}) =>
+      null;
+
+  @override
+  Future<RemoteObject> evaluateOnCallFrame(
+          String callFrameId, String expression) =>
+      null;
 
   @override
   Future<WipResponse> enablePage() => null;

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -176,10 +176,10 @@ class FakeWebkitDebugger implements WebkitDebugger {
   Stream<ScriptParsedEvent> get onScriptParsed => null;
 
   @override
-  Future pause() => null;
+  Future<WipResponse> pause() => null;
 
   @override
-  Future resume() => null;
+  Future<WipResponse> resume() => null;
 
   @override
   Map<String, WipScript> get scripts => null;
@@ -230,16 +230,16 @@ class FakeWebkitDebugger implements WebkitDebugger {
   }
 
   @override
-  Future setPauseOnExceptions(PauseState state) => null;
+  Future<WipResponse> setPauseOnExceptions(PauseState state) => null;
 
   @override
-  Future stepInto() => null;
+  Future<WipResponse> stepInto() => null;
 
   @override
-  Future stepOut() => null;
+  Future<WipResponse> stepOut() => null;
 
   @override
-  Future stepOver() => null;
+  Future<WipResponse> stepOver() => null;
 
   @override
   Stream<ConsoleAPIEvent> get onConsoleAPICalled => null;
@@ -257,10 +257,10 @@ class FakeWebkitDebugger implements WebkitDebugger {
   Future<RemoteObject> evaluate(String expression) => null;
 
   @override
-  Future<void> enablePage() => null;
+  Future<WipResponse> enablePage() => null;
 
   @override
-  Future<void> pageReload() => null;
+  Future<WipResponse> pageReload() => null;
 }
 
 /// Fake execution context that is needed for id only


### PR DESCRIPTION
- replace several uses of `sendCommand ()` with the typed equivalent calls in `package:webkit_inspector_protocol`

No issues were found, but this generally reduces the chance of typos.