### PR TITLE
use a more terse name for isolates

### DIFF
--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -107,7 +107,7 @@ class AppInspector extends Domain {
   ) async {
     var id = createId();
     var time = DateTime.now().millisecondsSinceEpoch;
-    var name = '$root:main()';
+    var name = 'main()';
     var isolate = Isolate(
         id: id,
         number: id,

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -326,7 +326,7 @@ void main() {
         var result = await service.getIsolate(vm.isolates.first.id);
         expect(result, const TypeMatcher<Isolate>());
         var isolate = result;
-        expect(isolate.name, contains(context.appUrl));
+        expect(isolate.name, contains('main'));
         // TODO: library names change with kernel dart-lang/sdk#36736
         expect(isolate.rootLib.uri, endsWith('main.dart'));
 


### PR DESCRIPTION
- use a more terse name for isolates

This is a ~better match for how the VM assigns isolate names, and helps us with the isolate selectors display in DevTools.