### PR TITLE
normalize imports

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -73,6 +73,7 @@ linter:
     - prefer_is_not_empty
     - prefer_iterable_whereType
     - prefer_null_aware_operators
+    - prefer_relative_imports
     - prefer_single_quotes
     - prefer_spread_collections
     - prefer_typing_uninitialized_variables

--- a/dwds/lib/data/serializers.dart
+++ b/dwds/lib/data/serializers.dart
@@ -4,12 +4,12 @@
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
-import 'package:dwds/data/error_response.dart';
-import 'package:dwds/data/extension_request.dart';
 
 import 'build_result.dart';
 import 'connect_request.dart';
 import 'devtools_request.dart';
+import 'error_response.dart';
+import 'extension_request.dart';
 import 'isolate_events.dart';
 import 'run_request.dart';
 

--- a/dwds/lib/src/connections/debug_connection.dart
+++ b/dwds/lib/src/connections/debug_connection.dart
@@ -4,9 +4,8 @@
 
 import 'dart:async';
 
-import 'package:dwds/src/services/chrome_proxy_service.dart';
-
 import '../services/app_debug_services.dart';
+import '../services/chrome_proxy_service.dart';
 import '../utilities/wrapped_service.dart';
 
 /// A debug connection between the application in the browser and DWDS.

--- a/dwds/lib/src/debugging/execution_context.dart
+++ b/dwds/lib/src/debugging/execution_context.dart
@@ -5,7 +5,8 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
-import 'package:dwds/src/debugging/remote_debugger.dart';
+
+import 'remote_debugger.dart';
 
 abstract class ExecutionContext {
   /// Returns the context ID that contains the running Dart application.

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -5,8 +5,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:dwds/src/debugging/debugger.dart';
-import 'package:dwds/src/debugging/execution_context.dart';
 import 'package:path/path.dart' as p;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
@@ -21,7 +19,9 @@ import '../utilities/domain.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
 import 'classes.dart';
+import 'debugger.dart';
 import 'exceptions.dart';
+import 'execution_context.dart';
 import 'instance.dart';
 import 'libraries.dart';
 

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -2,12 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
-import 'package:dwds/src/debugging/inspector.dart';
-
 import '../loaders/strategy.dart';
 import '../utilities/domain.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
+import 'inspector.dart';
 import 'metadata.dart';
 
 /// Keeps track of Dart libraries available in the running application.

--- a/dwds/lib/src/debugging/webkit_debugger.dart
+++ b/dwds/lib/src/debugging/webkit_debugger.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import 'remote_debugger.dart';
 
 /// A remote debugger with a Webkit Inspection Protocol connection.
 class WebkitDebugger implements RemoteDebugger {

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -6,32 +6,32 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:async/async.dart';
-import 'package:dwds/data/build_result.dart';
-import 'package:dwds/data/error_response.dart';
-import 'package:dwds/data/run_request.dart';
-import 'package:dwds/dwds.dart';
-import 'package:dwds/src/connections/debug_connection.dart';
-import 'package:dwds/src/debugging/execution_context.dart';
-import 'package:dwds/src/debugging/remote_debugger.dart';
-import 'package:dwds/src/debugging/webkit_debugger.dart';
-import 'package:dwds/src/servers/extension_backend.dart';
-import 'package:dwds/src/services/expression_compiler.dart';
 import 'package:logging/logging.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../../data/build_result.dart';
 import '../../data/connect_request.dart';
 import '../../data/devtools_request.dart';
+import '../../data/error_response.dart';
 import '../../data/isolate_events.dart';
+import '../../data/run_request.dart';
 import '../../data/serializers.dart';
+import '../../dwds.dart';
 import '../connections/app_connection.dart';
+import '../connections/debug_connection.dart';
+import '../debugging/execution_context.dart';
+import '../debugging/remote_debugger.dart';
+import '../debugging/webkit_debugger.dart';
 import '../dwds_vm_client.dart';
 import '../readers/asset_reader.dart';
 import '../servers/devtools.dart';
+import '../servers/extension_backend.dart';
 import '../services/app_debug_services.dart';
 import '../services/debug_service.dart';
+import '../services/expression_compiler.dart';
 
 /// SSE handler to enable development features like hot reload and
 /// opening DevTools.

--- a/dwds/lib/src/handlers/injected_handler.dart
+++ b/dwds/lib/src/handlers/injected_handler.dart
@@ -7,11 +7,11 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:crypto/crypto.dart';
-import 'package:dwds/src/loaders/strategy.dart';
-import 'package:dwds/src/version.dart';
 import 'package:shelf/shelf.dart';
 
 import '../../dwds.dart';
+import '../loaders/strategy.dart';
+import '../version.dart';
 
 /// File extension that build_web_compilers will place the
 /// [entrypointExtensionMarker] in.

--- a/dwds/lib/src/loaders/frontend_server_require.dart
+++ b/dwds/lib/src/loaders/frontend_server_require.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:dwds/dwds.dart';
+import '../../dwds.dart';
 
 /// Provides a [RequireStrategy] suitable for use with Frontend Server.
 class FrontendServerRequireStrategyProvider {

--- a/dwds/lib/src/readers/proxy_server_asset_reader.dart
+++ b/dwds/lib/src/readers/proxy_server_asset_reader.dart
@@ -7,10 +7,10 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:dwds/src/utilities/shared.dart' show LogWriter;
 import 'package:shelf/shelf.dart';
 import 'package:shelf_proxy/shelf_proxy.dart';
 
+import '../utilities/shared.dart' show LogWriter;
 import 'asset_reader.dart';
 
 /// A reader for resources provided by a proxy server.

--- a/dwds/lib/src/servers/extension_backend.dart
+++ b/dwds/lib/src/servers/extension_backend.dart
@@ -6,10 +6,11 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:async/async.dart';
-import 'package:dwds/src/servers/extension_debugger.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:shelf/shelf_io.dart';
 import 'package:sse/server/sse_handler.dart';
+
+import 'extension_debugger.dart';
 
 final _sseHandler =
     SseHandler(Uri.parse('/\$debug'), keepAlive: const Duration(seconds: 30));

--- a/dwds/lib/src/servers/extension_debugger.dart
+++ b/dwds/lib/src/servers/extension_debugger.dart
@@ -6,14 +6,15 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
-import 'package:dwds/data/devtools_request.dart';
-import 'package:dwds/data/extension_request.dart';
-import 'package:dwds/data/serializers.dart';
-import 'package:dwds/src/debugging/execution_context.dart';
-import 'package:dwds/src/debugging/remote_debugger.dart';
-import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import '../../data/devtools_request.dart';
+import '../../data/extension_request.dart';
+import '../../data/serializers.dart';
+import '../debugging/execution_context.dart';
+import '../debugging/remote_debugger.dart';
+import '../services/chrome_proxy_service.dart';
 
 /// A remote debugger backed by the Dart Debug Extension
 /// with an SSE connection.

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -8,9 +8,6 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:dwds/dwds.dart';
-import 'package:dwds/src/debugging/remote_debugger.dart';
-import 'package:dwds/src/services/expression_compiler.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart' as shelf;
@@ -20,11 +17,14 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+import '../../dwds.dart';
 import '../debugging/execution_context.dart';
+import '../debugging/remote_debugger.dart';
 import '../readers/asset_reader.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
 import 'chrome_proxy_service.dart';
+import 'expression_compiler.dart';
 
 void Function(WebSocketChannel, String) _createNewConnectionHandler(
   ChromeProxyService chromeProxyService,

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -2,14 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dwds/src/debugging/debugger.dart';
-import 'package:dwds/src/debugging/location.dart';
-import 'package:dwds/src/debugging/modules.dart';
-import 'package:dwds/src/utilities/ddc_names.dart';
-import 'package:dwds/src/utilities/objects.dart' as chrome;
-import 'package:dwds/src/utilities/shared.dart' show LogWriter;
 import 'package:logging/logging.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import '../debugging/debugger.dart';
+import '../debugging/location.dart';
+import '../debugging/modules.dart';
+import '../utilities/ddc_names.dart';
+import '../utilities/objects.dart' as chrome;
+import '../utilities/shared.dart' show LogWriter;
 import 'expression_compiler.dart';
 
 class ErrorKind {

--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -10,9 +10,9 @@ import 'package:dwds/data/build_result.dart';
 import 'package:dwds/dwds.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
-import 'package:webdev/src/serve/webdev_server.dart';
 
 import '../serve/server_manager.dart';
+import '../serve/webdev_server.dart';
 import 'daemon.dart';
 import 'domain.dart';
 import 'utilites.dart';


### PR DESCRIPTION
Normalize imports:
- use relative imports with `lib/`
- add the relevant lint to the analysis_options file

I'm not sure if it's still the case (perhaps this changed with the CFE?), but historically, mixing `lib/` and package: self reference imports would create two separate libraries.
