### PR TITLE
change the failure results for getClassList and reloadSources

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,7 +1,12 @@
+## 3.1.1-dev
+
+- Change the reported names for isolates to be more terse.
+- Change the returned errors for the unimplemented `getClassList` and `reloadSources`
+  methods to -32601 ('method does not exist / is not available').
+
 ## 3.1.0
 
 - Support Chromium based Edge.
-
 - Depend on latest `package:sse` version `3.5.0`.
 - Bypass connection keep-alives when shutting down to avoid delaying process shutdown.
 - Fix an issue where the isolate would incorrectly be destroyed after connection reuse.

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -391,7 +391,11 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   @override
   Future<ClassList> getClassList(String isolateId) {
     // See dart-lang/webdev/issues/971.
-    throw UnimplementedError();
+    return Future.error(RPCError(
+      'getClassList',
+      -32601,
+      'Not supported on web devices',
+    ));
   }
 
   @override
@@ -531,8 +535,12 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
   @override
   Future<ReloadReport> reloadSources(String isolateId,
-      {bool force, bool pause, String rootLibUri, String packagesUri}) async {
-    throw UnimplementedError();
+      {bool force, bool pause, String rootLibUri, String packagesUri}) {
+    return Future.error(RPCError(
+      'reloadSources',
+      -32601,
+      'Hot reload not supported on web devices',
+    ));
   }
 
   @override

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.1.0';
+const packageVersion = '3.1.1-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 3.1.0
+version: 3.1.1-dev
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -308,7 +308,8 @@ void main() {
     });
 
     test('getClassList', () {
-      expect(() => service.getClassList(null), throwsUnimplementedError);
+      expect(() => service.getClassList(null),
+          throwsA(const TypeMatcher<RPCError>()));
     });
 
     test('getFlagList', () async {
@@ -1001,7 +1002,8 @@ void main() {
     });
 
     test('reloadSources', () {
-      expect(() => service.reloadSources(null), throwsUnimplementedError);
+      expect(() => service.reloadSources(null),
+          throwsA(const TypeMatcher<RPCError>()));
     });
 
     test('setExceptionPauseMode', () async {


### PR DESCRIPTION
- change the failure results for `getClassList` and `reloadSources `

Throwing something other than an `RPCError` from these methods is interpreted as a server crash by package:vm_service; it does get wrapped with an RPCError, but loses a bit of semantic intent (and does things like include a stack trace in the error message).

For the next version of `package:vm_service`, we'll be able to use constants for the RPCError failure codes.
