### PR TITLE
add bootstrapping for amd to frontend_server_client

### DIFF
--- a/frontend_server_client/example/app/index.html
+++ b/frontend_server_client/example/app/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="main.dart.js" type="application/javascript"></script>
+    </head>
+</html>

--- a/frontend_server_client/example/web_client.dart
+++ b/frontend_server_client/example/web_client.dart
@@ -2,10 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:async/async.dart';
 import 'package:frontend_server_client/frontend_server_client.dart';
 import 'package:path/path.dart' as p;
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_packages_handler/shelf_packages_handler.dart';
+import 'package:shelf_static/shelf_static.dart';
 
 void main(List<String> args) async {
   watch.start();
@@ -16,21 +22,62 @@ void main(List<String> args) async {
   var client = await DartDevcFrontendServerClient.start(
       'org-dartlang-root:///$app', outputDill,
       fileSystemRoots: [p.current], fileSystemScheme: 'org-dartlang-root');
+
   _print('compiling $app');
   await client.compile([]);
   client.accept();
   _print('done compiling $app');
 
-  _print('editing $app');
+  _print('starting shelf server');
+  var cascade = Cascade()
+      .add(_clientHandler(client))
+      .add(createStaticHandler(p.current))
+      .add(createFileHandler(
+          p.join(sdkDir, 'lib', 'dev_compiler', 'kernel', 'amd', 'dart_sdk.js'),
+          url: 'example/app/dart_sdk.js'))
+      .add(createFileHandler(
+          p.join(sdkDir, 'lib', 'dev_compiler', 'web',
+              'dart_stack_trace_mapper.js'),
+          url: 'example/app/dart_stack_trace_mapper.js'))
+      .add(createFileHandler(
+          p.join(sdkDir, 'lib', 'dev_compiler', 'kernel', 'amd', 'require.js'),
+          url: 'example/app/require.js'))
+      .add(packagesDirHandler());
+  final server = await shelf_io.serve(cascade.handler, 'localhost', 8080);
+  _print('server ready');
+
+  // The file we will be editing in the repl
   var appFile = File(app);
   var originalContent = await appFile.readAsString();
-  var newContent = originalContent.replaceFirst('hello', 'goodbye');
-  await appFile.writeAsString(newContent);
+  var appLines = const LineSplitter().convert(originalContent);
+  var getterText = 'String get message =>';
+  var messageLine = appLines.indexWhere((line) => line.startsWith(getterText));
 
-  _print('recompiling $app with edits');
-  await client.compile([Uri.parse('org-dartlang-root:///$app')]);
-  client.accept();
-  _print('done recompiling $app');
+  var stdinQueue = StreamQueue(
+      stdin.transform(utf8.decoder).transform(const LineSplitter()));
+  _prompt();
+  while (await stdinQueue.hasNext) {
+    var newMessage = await stdinQueue.next;
+    if (newMessage == 'quit') {
+      await server.close();
+      await stdinQueue.cancel();
+      break;
+    }
+    _print('editing $app');
+    appLines[messageLine] = '$getterText "$newMessage";';
+    var newContent = appLines.join('\n');
+    await appFile.writeAsString(newContent);
+
+    _print('recompiling $app with edits');
+    await client.compile([Uri.parse('org-dartlang-root:///$app')]);
+    client.accept();
+    _print('done recompiling $app');
+
+    // TODO: support hot restart
+    print('reload app to see the new message');
+
+    _prompt();
+  }
 
   _print('restoring $app');
   await appFile.writeAsString(originalContent);
@@ -38,9 +85,21 @@ void main(List<String> args) async {
   await client.shutdown();
 }
 
+Handler _clientHandler(DartDevcFrontendServerClient client) {
+  return (Request request) {
+    var assetBytes = client.assetBytes(request.requestedUri.path);
+    if (assetBytes == null) return Response.notFound('path not found');
+    return Response.ok(assetBytes,
+        headers: {HttpHeaders.contentTypeHeader: 'application/javascript'});
+  };
+}
+
 void _print(String message) {
   print('${watch.elapsed}: $message');
 }
+
+void _prompt() => stdout.write(
+    'Enter a new message to print and recompile, or type `quit` to exit:');
 
 final app = 'example/app/main.dart';
 final outputDill = p.join('.dart_tool', 'out', 'example_app.dill');

--- a/frontend_server_client/lib/src/dartdevc_bootstrap_amd.dart
+++ b/frontend_server_client/lib/src/dartdevc_bootstrap_amd.dart
@@ -57,11 +57,7 @@ require(["$entrypoint.lib.js", "dart_sdk"], function(app, dart_sdk) {
   dart_sdk._debugger.registerDevtoolsFormatter();
 
   // See the generateMainModule doc comment.
-  var child = {};
-  child.main = app[Object.keys(app)[0]].main;
-
-  /* MAIN_EXTENSION_MARKER */
-  child.main();
+  app[Object.keys(app)[0]].main();
 });
 ''';
 }

--- a/frontend_server_client/lib/src/dartdevc_bootstrap_amd.dart
+++ b/frontend_server_client/lib/src/dartdevc_bootstrap_amd.dart
@@ -1,0 +1,85 @@
+// Copyright 2020 The Dart Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+/// The JavaScript bootstrap script to support in-browser hot restart.
+///
+/// The [requireUrl] loads our cached RequireJS script file. The [mapperUrl]
+/// loads the special Dart stack trace mapper.
+///
+/// This file is served when the browser requests `$entrypoint.js` in debug
+/// mode, and is responsible for bootstrapping the RequireJS modules and
+/// attaching the hot reload hooks.
+String generateAmdBootstrapScript({
+  @required String requireUrl,
+  @required String mapperUrl,
+  @required String entrypoint,
+}) {
+  return '''
+"use strict";
+
+// Attach source mapping.
+var mapperEl = document.createElement("script");
+mapperEl.defer = true;
+mapperEl.async = false;
+mapperEl.src = "$mapperUrl";
+document.head.appendChild(mapperEl);
+
+// Attach require JS.
+var requireEl = document.createElement("script");
+requireEl.defer = true;
+requireEl.async = false;
+requireEl.src = "$requireUrl";
+
+// This attribute tells require JS what to load as main (defined below).
+requireEl.setAttribute("data-main", "$entrypoint.bootstrap");
+document.head.appendChild(requireEl);
+''';
+}
+
+/// Generate a synthetic main module which captures the application's main
+/// method.
+///
+/// RE: Object.keys usage in app.main:
+/// This attaches the main entrypoint and hot reload functionality to the window.
+/// The app module will have a single property which contains the actual application
+/// code. The property name is based off of the entrypoint that is generated, for example
+/// the file `foo/bar/baz.dart` will generate a property named approximately
+/// `foo__bar__baz`. Rather than attempt to guess, we assume the first property of
+/// this object is the module.
+String generateAmdMainModule({@required String entrypoint}) {
+  return '''/* ENTRYPOINT_EXTENTION_MARKER */
+// Create the main module loaded below.
+require(["$entrypoint.lib.js", "dart_sdk"], function(app, dart_sdk) {
+  dart_sdk.dart.setStartAsyncSynchronously(true);
+  dart_sdk._debugger.registerDevtoolsFormatter();
+
+  // See the generateMainModule doc comment.
+  var child = {};
+  child.main = app[Object.keys(app)[0]].main;
+
+  /* MAIN_EXTENSION_MARKER */
+  child.main();
+
+  window.\$dartLoader = {};
+  window.\$dartLoader.rootDirectories = [];
+  if (window.\$requireLoader) {
+    window.\$requireLoader.getModuleLibraries = dart_sdk.dart.getModuleLibraries;
+    if (window.\$dartStackTraceUtility && !window.\$dartStackTraceUtility.ready) {
+      window.\$dartStackTraceUtility.ready = true;
+      let dart = dart_sdk.dart;
+      window.\$dartStackTraceUtility.setSourceMapProvider(function(url) {
+        url = url.replace(window.\$dartUriBase + '/', '');
+        if (url == 'dart_sdk.js') {
+          return dart.getSourceMap('dart_sdk');
+        }
+        url = url.replace(".lib.js", "");
+        return dart.getSourceMap(url);
+      });
+    }
+  }
+});
+''';
+}

--- a/frontend_server_client/lib/src/dartdevc_bootstrap_amd.dart
+++ b/frontend_server_client/lib/src/dartdevc_bootstrap_amd.dart
@@ -63,8 +63,6 @@ require(["$entrypoint.lib.js", "dart_sdk"], function(app, dart_sdk) {
   /* MAIN_EXTENSION_MARKER */
   child.main();
 
-  window.\$dartLoader = {};
-  window.\$dartLoader.rootDirectories = [];
   if (window.\$requireLoader) {
     window.\$requireLoader.getModuleLibraries = dart_sdk.dart.getModuleLibraries;
     if (window.\$dartStackTraceUtility && !window.\$dartStackTraceUtility.ready) {

--- a/frontend_server_client/lib/src/dartdevc_bootstrap_amd.dart
+++ b/frontend_server_client/lib/src/dartdevc_bootstrap_amd.dart
@@ -62,22 +62,6 @@ require(["$entrypoint.lib.js", "dart_sdk"], function(app, dart_sdk) {
 
   /* MAIN_EXTENSION_MARKER */
   child.main();
-
-  if (window.\$requireLoader) {
-    window.\$requireLoader.getModuleLibraries = dart_sdk.dart.getModuleLibraries;
-    if (window.\$dartStackTraceUtility && !window.\$dartStackTraceUtility.ready) {
-      window.\$dartStackTraceUtility.ready = true;
-      let dart = dart_sdk.dart;
-      window.\$dartStackTraceUtility.setSourceMapProvider(function(url) {
-        url = url.replace(window.\$dartUriBase + '/', '');
-        if (url == 'dart_sdk.js') {
-          return dart.getSourceMap('dart_sdk');
-        }
-        url = url.replace(".lib.js", "");
-        return dart.getSourceMap(url);
-      });
-    }
-  }
 });
 ''';
 }

--- a/frontend_server_client/lib/src/frontend_server_client.dart
+++ b/frontend_server_client/lib/src/frontend_server_client.dart
@@ -44,6 +44,7 @@ class FrontendServerClient {
     String entrypoint,
     String outputDillPath,
     String platformKernel, {
+    String dartdevcModuleFormat = 'amd',
     bool debug = false,
     bool enableHttpUris = false,
     List<String> fileSystemRoots = const [], // For `fileSystemScheme` uris,
@@ -60,6 +61,8 @@ class FrontendServerClient {
       sdkDir ?? sdkRoot,
       '--platform=$platformKernel',
       '--target=$target',
+      if (target == 'dartdevc')
+        '--dartdevc-module-format=$dartdevcModuleFormat',
       for (var root in fileSystemRoots) '--filesystem-root=$root',
       '--filesystem-scheme',
       fileSystemScheme,

--- a/frontend_server_client/pubspec.yaml
+++ b/frontend_server_client/pubspec.yaml
@@ -12,6 +12,9 @@ dependencies:
   uuid: ^2.0.0
 dev_dependencies:
   package_config: ^1.9.2
+  shelf: ^0.7.5
+  shelf_packages_handler: ^2.0.0
+  shelf_static: ^0.2.8
   test: ^1.0.0
   test_descriptor: ^1.0.0
   vm_service: ^4.0.0


### PR DESCRIPTION
Also updates the web example with a repl so you can change the message and it will recompile the app, which you can reload and see the new message.

This bootstrapping mostly mirrors the flutter web bootstrapping code.