### PR TITLE
allow a custom frontend server path

### DIFF
--- a/frontend_server_client/lib/src/dartdevc_frontend_server_client.dart
+++ b/frontend_server_client/lib/src/dartdevc_frontend_server_client.dart
@@ -64,6 +64,7 @@ class DartDevcFrontendServerClient implements FrontendServerClient {
     List<String> fileSystemRoots = const [], // For `fileSystemScheme` uris,
     String fileSystemScheme =
         'org-dartlang-root', // Custom scheme for virtual `fileSystemRoots`.
+    String frontendServerPath, // Defaults to the snapshot in the sdk.
     String packagesJson = '.dart_tool/package_config.json',
     String platformKernel, // Defaults to the dartdevc platfrom from the sdk.
     String sdkRoot, // Defaults to the current SDK root.
@@ -78,6 +79,7 @@ class DartDevcFrontendServerClient implements FrontendServerClient {
       enableHttpUris: enableHttpUris,
       fileSystemRoots: fileSystemRoots,
       fileSystemScheme: fileSystemScheme,
+      frontendServerPath: frontendServerPath,
       packagesJson: packagesJson,
       sdkRoot: sdkRoot,
       target: 'dartdevc',

--- a/frontend_server_client/lib/src/frontend_server_client.dart
+++ b/frontend_server_client/lib/src/frontend_server_client.dart
@@ -52,6 +52,7 @@ class FrontendServerClient {
     List<String> fileSystemRoots = const [], // For `fileSystemScheme` uris,
     String fileSystemScheme =
         'org-dartlang-root', // Custom scheme for virtual `fileSystemRoots`.
+    String frontendServerPath, // Defaults to the snapshot in the sdk.
     String packagesJson = '.dart_tool/package_config.json',
     String sdkRoot, // Defaults to the current SDK root.
     String target = 'vm', // The kernel target type.
@@ -59,7 +60,7 @@ class FrontendServerClient {
   }) async {
     var feServer = await Process.start(Platform.resolvedExecutable, [
       if (debug) '--observe',
-      _feServerPath,
+      frontendServerPath ?? _feServerPath,
       '--sdk-root',
       sdkDir ?? sdkRoot,
       '--platform=$platformKernel',


### PR DESCRIPTION
we need this internally, and it can be nice for debugging to pass the dart entrypoint from your sdk