### PR TITLE
`streamListen` changes

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Update the `require_restarter` to rerun main after a hot restart to align with
   the legacy strategy. We therefore no longer send a `RunRequest` after a hot
   restart.
+- Change `streamListen` to return an `RPCError` / error code `-32601` for streams
+  that are not handled.
 
 ## 3.1.1
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -499,28 +499,35 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   Stream<Event> onEvent(String streamId) {
     return _streamControllers.putIfAbsent(streamId, () {
       switch (streamId) {
-        case 'Extension':
-        // TODO: right now we only support the `ServiceExtensionAdded` event for
-        // the Isolate stream.
-        case 'Isolate':
-        case 'VM':
-        // TODO: https://github.com/dart-lang/webdev/issues/168
-        case 'GC':
-        // TODO: https://github.com/dart-lang/webdev/issues/168
-        case 'Timeline':
-        case '_Service':
+        case EventStreams.kExtension:
           return StreamController<Event>.broadcast();
-        case 'Debug':
+        case EventStreams.kIsolate:
+          // TODO: right now we only support the `ServiceExtensionAdded` event
+          // for the Isolate stream.
           return StreamController<Event>.broadcast();
-        case 'Stdout':
+        case EventStreams.kVM:
+          return StreamController<Event>.broadcast();
+        case EventStreams.kGC:
+          return StreamController<Event>.broadcast();
+        case EventStreams.kTimeline:
+          return StreamController<Event>.broadcast();
+        case EventStreams.kService:
+          return StreamController<Event>.broadcast();
+        case EventStreams.kDebug:
+          return StreamController<Event>.broadcast();
+        case EventStreams.kStdout:
           return _chromeConsoleStreamController(
               (e) => _stdoutTypes.contains(e.type));
-        case 'Stderr':
+        case EventStreams.kStderr:
           return _chromeConsoleStreamController(
               (e) => _stderrTypes.contains(e.type),
               includeExceptions: true);
         default:
-          throw UnimplementedError('The stream `$streamId` is not supported.');
+          throw RPCError(
+            'streamListen',
+            RPCError.kMethodNotFound,
+            'The stream `$streamId` is not supported on web devices',
+          );
       }
     }).stream;
   }

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -956,7 +956,7 @@ void main() {
     });
 
     test('onEvent', () {
-      expect(() => service.onEvent(null), throwsUnimplementedError);
+      expect(() => service.onEvent(null), throwsRPCError);
     });
 
     test('pause / resume', () async {


### PR DESCRIPTION
- use constants for stream names
- change `streamListen` to return an `RPCError` / error code `-32601` for streams that are not handled
- remove references to a closed issue
