### PR TITLE
Update dev_handler.dart

### DIFF
--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -116,7 +116,8 @@ class DevHandler {
     WipConnection tabConnection;
     var appInstanceId = appConnection.request.instanceId;
     for (var tab in await chromeConnection.getTabs()) {
-      if (tab.url.startsWith('chrome-extensions:')) continue;
+      if (tab.isChromeExtension || tab.isBackgroundPage) continue;
+
       tabConnection = await tab.connect();
       var contextQueue = StreamQueue<int>(tabConnection.runtime.eventStream(
           'Runtime.executionContextCreated',


### PR DESCRIPTION
- fix an issue where we were iterating through chrome extensions looking for a debug target (note the issue in the string literal - we were looking for `'chrome-extensions:'` but should have been looking for `'chrome-extension:'`)

This will reduce the number of round trips to the chrome process when starting up.
