### PR TITLE
add logging for vm_service and chrome debugging traffic

### DIFF
--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -38,7 +38,7 @@ import 'injector.dart';
 /// traffic to disk.
 ///
 /// Note: this should not be checked in enabled.
-const _enableLogging = true;
+const _enableLogging = false;
 
 /// SSE handler to enable development features like hot reload and
 /// opening DevTools.

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   sse: ^3.5.0
   vm_service: ^4.0.3
   web_socket_channel: ^1.0.0
-  webkit_inspection_protocol: '>=0.5.1 <0.6.0'
+  webkit_inspection_protocol: '>=0.5.4 <0.7.0'
 
 dev_dependencies:
   args: ^1.0.0


### PR DESCRIPTION
- add logging for vm_service and chrome debugging traffic
- rev to a new version of `package: webkit_inspection_protocol` to use the `onSend` and `onReceive` APIs
- use the new `WipRuntime.onExecutionContextCreated` API (instead of filtering general eventStream events)

cc @grouma @DanTup 
