### PR TITLE
address a todo and use the types from package:webkit_inspection_protocol

### DIFF
--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -72,7 +72,7 @@ class ExpressionEvaluator {
     // 1. get js scope and current JS location
 
     var jsStack = _debugger.getJsStack();
-    var jsFrame = WipCallFrame(jsStack[frameIndex]);
+    var jsFrame = jsStack[frameIndex];
 
     var functionName = jsFrame.functionName;
     var jsLocation = JsLocation.fromZeroBased(jsFrame.location.scriptId,

--- a/dwds/test/extension_debugger_test.dart
+++ b/dwds/test/extension_debugger_test.dart
@@ -52,12 +52,12 @@ void main() async {
     test('an ExtensionEvent', () async {
       var extensionEvent = ExtensionEvent((b) => b
         ..method = jsonEncode('Debugger.paused')
-        ..params = jsonEncode(frames1[0]));
+        ..params = jsonEncode(frames1Json[0]));
       connection.controllerIncoming.sink
           .add(jsonEncode(serializers.serialize(extensionEvent)));
       var wipEvent = await extensionDebugger.onNotification.first;
       expect(wipEvent.method, 'Debugger.paused');
-      expect(wipEvent.params, frames1[0]);
+      expect(wipEvent.params, frames1Json[0]);
     });
 
     test('a BatchedEvents', () async {

--- a/dwds/test/fixtures/debugger_data.dart
+++ b/dwds/test/fixtures/debugger_data.dart
@@ -13,7 +13,10 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 ///
 /// This is taken from a real run, but truncated to two levels of scope and one
 /// level of stack.
-List<WipCallFrame> frames1 = [
+List<WipCallFrame> frames1 =
+    frames1Json.map((json) => WipCallFrame(json)).toList();
+
+List<Map<String, dynamic>> frames1Json = [
   {
     "callFrameId": "{\"ordinal\":0,\"injectedScriptId\":2}",
     "functionName": "",
@@ -83,7 +86,7 @@ List<WipCallFrame> frames1 = [
     ],
     "this": {"type": "undefined"}
   }
-].map((json) => WipCallFrame(json)).toList();
+];
 
 /// Data in the form returned from getProperties called twice on successive elements of a scope chain.
 ///

--- a/dwds/test/fixtures/debugger_data.dart
+++ b/dwds/test/fixtures/debugger_data.dart
@@ -13,7 +13,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 ///
 /// This is taken from a real run, but truncated to two levels of scope and one
 /// level of stack.
-List<Map<String, dynamic>> frames1 = [
+List<WipCallFrame> frames1 = [
   {
     "callFrameId": "{\"ordinal\":0,\"injectedScriptId\":2}",
     "functionName": "",
@@ -83,7 +83,7 @@ List<Map<String, dynamic>> frames1 = [
     ],
     "this": {"type": "undefined"}
   }
-];
+].map((json) => WipCallFrame(json)).toList();
 
 /// Data in the form returned from getProperties called twice on successive elements of a scope chain.
 ///


### PR DESCRIPTION
- address a todo: related to populating the `index` field for a VM service protocol `Frame` (it turns out we'd already been populating it later in the code)
- use the `WipCallFrame` and related types from `package:webkit_inspection_protocol` instead of maps

This PR just adds types - it shouldn't introduce any behavior changes.
