### PR TITLE
optimize the backend calls we make for frame creation

### DIFF
--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -44,8 +44,8 @@ Future<List<Property>> visibleProperties({
     );
   }
 
-  allProperties.removeWhere((each) {
-    final value = each.value;
+  allProperties.removeWhere((property) {
+    final value = property.value;
 
     // TODO(#786) Handle these correctly rather than just suppressing them.
     // We should never see a raw JS class. The only case where this happens is a
@@ -62,6 +62,8 @@ Future<List<Property>> visibleProperties({
 /// Filters the provided scope chain into those that are pertinent for Dart
 /// debugging.
 List<WipScope> _filterScopes(Iterable<WipScope> scopeChain) {
+  var reportedScope = false;
+
   // Iterate to least specific scope last to help preserve order in the
   // local variables view when stepping.
   return scopeChain.toList().reversed.where((scope) {
@@ -71,8 +73,10 @@ List<WipScope> _filterScopes(Iterable<WipScope> scopeChain) {
     // We typically see 'local' and 'block' scopes here. Some, like 'closure',
     // contain hundreds of DDC implementation specific properties.
     if (scope.scope == 'global') return false;
-    if (scope.scope == 'closure') return false;
+    if (scope.scope == 'closure' && !reportedScope) return false;
     if (scope.scope == 'script') return false;
+
+    reportedScope = true;
 
     return true;
   }).toList();

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -2,93 +2,78 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../loaders/strategy.dart';
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
 import '../utilities/objects.dart';
 import 'debugger.dart';
 
 /// Find the visible Dart properties from a JS Scope Chain, coming from the
-/// scopeChain attribute of a Chrome CallFrame corresponding to [callFrameId].
+/// scopeChain attribute of a Chrome CallFrame corresponding to [frame].
 ///
-/// See
-/// https://chromedevtools.github.io/devtools-protocol/tot/Debugger#type-CallFrame
-///
-/// The [scopeList] is a List of Maps corresponding to Chrome Scope objects.
-/// https://chromedevtools.github.io/devtools-protocol/tot/Debugger#type-Scope
-Future<List<Property>> visibleProperties(
-    {List<Map<String, dynamic>> scopeList,
-    Debugger debugger,
-    String callFrameId}) async {
-  var scopes = await _filterScopes(scopeList, debugger);
-  if (scopes.isEmpty) return [];
-  var propertyLists = scopes
-      .map((scope) async =>
-          await debugger.getProperties(scope['object']['objectId'] as String))
-      .toList();
-  var allProperties = [for (var list in propertyLists) ...await list];
-  // We should never see a raw JS class. The only case where this happens is a
-  // Dart generic function, where the type arguments get passed in as
-  // parameters. Hide those.
-  // TODO(#786) Handle these correctly rather than just suppressing them.
-  var existingThis =
-      allProperties.firstWhere((x) => x.name == 'this', orElse: () => null);
-  if (existingThis == null) {
-    var syntheticThis = await _findMissingThis(callFrameId, debugger);
-    if (syntheticThis != null) {
-      allProperties.add(syntheticThis);
-    }
+/// See chromedevtools.github.io/devtools-protocol/tot/Debugger#type-CallFrame.
+Future<List<Property>> visibleProperties({
+  Debugger debugger,
+  WipCallFrame frame,
+}) async {
+  var allProperties = <Property>[];
+
+  if (frame.thisObject != null && frame.thisObject.type != 'undefined') {
+    allProperties.add(
+      Property({
+        'name': 'this',
+        'value': frame.thisObject,
+      }),
+    );
   }
-  allProperties.removeWhere((each) =>
-      (each.value.type == 'function' &&
-          each.value.description.startsWith('class ')) ||
-      (each.value.type == 'object' &&
-          each.value.description == 'dart.LegacyType.new'));
+
+  // TODO: Try and populate all the property info for the scopes in one backend
+  // call. Along with some other optimizations (caching classRef lookups), we'd
+  // end up averaging one backend call per frame.
+
+  for (var scope in _filterScopes(frame.getScopeChain())) {
+    final properties = await debugger.getProperties(scope.object.objectId);
+    allProperties.addAll(properties);
+  }
+
+  if (frame.returnValue != null && frame.returnValue.type != 'undefined') {
+    allProperties.add(
+      Property({
+        'name': 'return',
+        'value': frame.returnValue,
+      }),
+    );
+  }
+
+  allProperties.removeWhere((each) {
+    final value = each.value;
+
+    // TODO(#786) Handle these correctly rather than just suppressing them.
+    // We should never see a raw JS class. The only case where this happens is a
+    // Dart generic function, where the type arguments get passed in as
+    // parameters. Hide those.
+    return (value.type == 'function' &&
+            value.description.startsWith('class ')) ||
+        (value.type == 'object' && value.description == 'dart.LegacyType.new');
+  });
+
   return allProperties;
 }
 
 /// Filters the provided scope chain into those that are pertinent for Dart
 /// debugging.
-Future<List<Map<String, dynamic>>> _filterScopes(
-    List<Map<String, dynamic>> scopeList, Debugger debugger) async {
-  var foundDartSdk = false;
-  var result = <Map<String, dynamic>>[];
-  // Iterate through the outermost scope to the inner most scope.
-  for (var scope in scopeList.reversed) {
-    var properties =
-        await debugger.getProperties(scope['object']['objectId'] as String);
-    if (!foundDartSdk) {
-      var propertyNames = properties.map((element) => element.name).toSet();
-      // TODO(sdk/issues/40774) - This appears brittle.
-      if (propertyNames.containsAll(['core', 'dart'])) foundDartSdk = true;
-    } else {
-      // Scopes after the Dart SDK is defined contain application logic.
-      result.add(scope);
-    }
-  }
-  return result;
-}
+List<WipScope> _filterScopes(Iterable<WipScope> scopeChain) {
+  // Iterate to least specific scope last to help preserve order in the
+  // local variables view when stepping.
+  return scopeChain.toList().reversed.where((scope) {
+    // The possible values are: global, local, with, closure, catch, block,
+    // script, eval, and module.
 
-/// Find the `this` in scope if it wasn't in the provided data from Chrome.
-///
-/// If we were not given a `this` value in the Chrome scopes that might mean
-/// we're in a nested closure, or we might be a top-level function. Find it by evaluating
-/// code in the JS frame. If it's null/undefined or is a Dart library scope, then
-/// return null. Otherwise make a property for `this` and return it.
-Future<Property> _findMissingThis(String callFrameId, Debugger debugger) async {
-  // If 'this' is a library return null, otherwise
-  // return 'this'.
-  final findCurrent = '''
-        (function (THIS) {
-           if (THIS === window) { return null; }
-           ${globalLoadStrategy.loadLibrariesSnippet}
-           for (let lib of libs) {
-             if (lib === THIS) {
-                return null;
-            }
-            } return THIS; })(this)''';
+    // We typically see 'local' and 'block' scopes here. Some, like 'closure',
+    // contain hundreds of DDC implementation specific properties.
+    if (scope.scope == 'global') return false;
+    if (scope.scope == 'closure') return false;
+    if (scope.scope == 'script') return false;
 
-  var actualThis =
-      await debugger.evaluateJsOnCallFrame(callFrameId, findCurrent);
-  return (actualThis.type == 'undefined')
-      ? null
-      : Property({'name': 'this', 'value': actualThis});
+    return true;
+  }).toList();
 }

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -62,7 +62,13 @@ Future<List<Property>> visibleProperties({
 /// Filters the provided scope chain into those that are pertinent for Dart
 /// debugging.
 List<WipScope> _filterScopes(Iterable<WipScope> scopeChain) {
-  var reportedScope = false;
+  // The last three scopes are generally [closure] [script] [global] in that
+  // order. We never want the global and script scopes. We don't want the last
+  // closure scope - that's a DDC implementation specific scope, and contains
+  // hundreds or thousands of properties (as does the global scope).
+
+  // We filter all script and global scopes, and any unnamed closure scopes. We
+  // could instead just filter out the last closure scope.
 
   // Iterate to least specific scope last to help preserve order in the
   // local variables view when stepping.
@@ -73,10 +79,8 @@ List<WipScope> _filterScopes(Iterable<WipScope> scopeChain) {
     // We typically see 'local' and 'block' scopes here. Some, like 'closure',
     // contain hundreds of DDC implementation specific properties.
     if (scope.scope == 'global') return false;
-    if (scope.scope == 'closure' && !reportedScope) return false;
     if (scope.scope == 'script') return false;
-
-    reportedScope = true;
+    if (scope.scope == 'closure' && scope.name == null) return false;
 
     return true;
   }).toList();

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -78,11 +78,7 @@ class Debugger extends Domain {
   /// The most important thing here is that frames are identified by
   /// frameIndex in the Dart API, but by frame Id in Chrome, so we need
   /// to keep the JS frames and their Ids around.
-  // TODO(alanknight): It would be nice to keep these as CallFrame instances,
-  // but they don't map enough of the data yet.
-  List<Map<String, dynamic>> _pausedJsStack;
-
-  List<Map<String, dynamic>> getJsStack() => _pausedJsStack;
+  StackComputer stackComputer;
 
   bool _isStepping = false;
 
@@ -152,8 +148,9 @@ class Debugger extends Domain {
   /// Returns null if the debugger is not paused.
   Future<Stack> getStack(String isolateId) async {
     checkIsolate('getStack', isolateId);
-    if (_pausedJsStack == null) return null;
-    var frames = await dartFramesFor(_pausedJsStack);
+    if (stackComputer == null) return null;
+
+    var frames = await stackComputer.calculateFrames();
     return Stack(frames: frames, messages: []);
   }
 
@@ -252,7 +249,7 @@ class Debugger extends Domain {
 
   /// Notify the debugger the [Isolate] is paused at the application start.
   void notifyPausedAtStart() async {
-    _pausedJsStack = [];
+    stackComputer = StackComputer(this, []);
   }
 
   /// Add a breakpoint at the given position.
@@ -327,55 +324,21 @@ class Debugger extends Domain {
     return _locations.locationForJs(jsLocation.scriptId, jsLocation.line);
   }
 
-  /// Translates Chrome callFrames contained in [DebuggerPausedEvent] into Dart
-  /// [Frame]s.
-  Future<List<Frame>> dartFramesFor(List<Map<String, dynamic>> frames) async {
-    var dartFrames = <Frame>[];
-    var index = 0;
-    for (var frame in frames) {
-      // TODO(grouma) - We can prevent duplicate work of calculating the top
-      // frame by pulling the frame logic out into a more complex class which
-      // has proper caching.
-      var dartFrame = await _dartFrameFor(frame, index);
-      if (dartFrame != null) {
-        index++;
-        dartFrames.add(dartFrame);
-      }
-    }
-    return dartFrames;
-  }
-
-  /// Returns the top Dart frame for the Chrome callFrames contained in
-  /// a [DebuggerPausedEvent].
-  Future<Frame> dartTopFrame(List<Map<String, dynamic>> frames) async {
-    for (var frame in frames) {
-      var dartFrame = await _dartFrameFor(frame, 0);
-      if (dartFrame != null) {
-        return dartFrame;
-      }
-    }
-    return null;
-  }
-
   /// The variables visible in a frame in Dart protocol [BoundVariable] form.
-  Future<List<BoundVariable>> variablesFor(
-      List<dynamic> scopeChain, String callFrameId) async {
+  Future<List<BoundVariable>> variablesFor(WipCallFrame frame) async {
     // TODO(alanknight): Can these be moved to dart_scope.dart?
-    var properties = await visibleProperties(
-        scopeList: scopeChain.cast<Map<String, dynamic>>().toList(),
-        debugger: this,
-        callFrameId: callFrameId);
+    var properties = await visibleProperties(debugger: this, frame: frame);
+
     var boundVariables = await Future.wait(
-        properties.map((property) async => await _boundVariable(property)));
-    // Filter out variables that do not come from dart code,
-    // such as native JavaScript objects
-    boundVariables = boundVariables
+      properties.map((property) async => await _boundVariable(property)),
+    );
+    // Filter out variables that do not come from dart code, such as native
+    // JavaScript objects
+    return boundVariables
         .where((bv) =>
             bv != null &&
             !_isNativeJsObject(bv.value as vm_service.InstanceRef))
         .toList();
-    boundVariables.sort((a, b) => a.name.compareTo(b.name));
-    return boundVariables;
   }
 
   bool _isNativeJsObject(vm_service.InstanceRef instanceRef) =>
@@ -390,13 +353,15 @@ class Debugger extends Domain {
     // properties that are getter/setter pairs.
     // TODO(alanknight): Handle these properly.
     if (instanceRef == null) return null;
+
     return BoundVariable(
-        name: property.name,
-        value: instanceRef,
-        // TODO(grouma) - Provide actual token positions.
-        declarationTokenPos: -1,
-        scopeStartTokenPos: -1,
-        scopeEndTokenPos: -1);
+      name: property.name,
+      value: instanceRef,
+      // TODO(grouma) - Provide actual token positions.
+      declarationTokenPos: -1,
+      scopeStartTokenPos: -1,
+      scopeEndTokenPos: -1,
+    );
   }
 
   /// Find a sub-range of the entries for a Map/List when offset and/or count
@@ -436,18 +401,18 @@ class Debugger extends Domain {
     return await inspector.jsCallFunctionOn(receiver, expression, args);
   }
 
-  /// Calls the Chrome Runtime.getProperties API for the object with [id].
+  /// Calls the Chrome Runtime.getProperties API for the object with [objectId].
   ///
   /// Note that the property names are JS names, e.g.
   /// Symbol(DartClass.actualName) and will need to be converted. For a system
   /// List or Map, [offset] and/or [count] can be provided to indicate a desired
   /// range of entries. If those are provided, then [length] should also be
   /// provided to indicate the total length of the List/Map.
-  Future<List<Property>> getProperties(String id,
+  Future<List<Property>> getProperties(String objectId,
       {int offset, int count, int length}) async {
-    var rangeId = id;
+    var rangeId = objectId;
     if (offset != null || count != null) {
-      var range = await _subrange(id, offset ?? 0, count, length);
+      var range = await _subrange(objectId, offset ?? 0, count, length);
       rangeId = range.objectId;
     }
     var response =
@@ -463,12 +428,11 @@ class Debugger extends Domain {
   }
 
   /// Returns a Dart [Frame] for a JS [frame].
-  Future<Frame> _dartFrameFor(
-      Map<String, dynamic> frame, int frameIndex) async {
-    var location = frame['location'];
+  Future<Frame> _dartFrameFor(WipCallFrame frame, int frameIndex) async {
+    var location = frame.location;
     // Chrome is 0 based. Account for this.
-    var jsLocation = JsLocation.fromZeroBased(location['scriptId'] as String,
-        location['lineNumber'] as int, location['columnNumber'] as int);
+    var jsLocation = JsLocation.fromZeroBased(
+        location.scriptId, location.lineNumber, location.columnNumber);
     // TODO(sdk/issues/37240) - ideally we look for an exact location instead
     // of the closest location on a given line.
     Location bestLocation;
@@ -485,13 +449,13 @@ class Debugger extends Domain {
 
     var script =
         await inspector?.scriptRefFor(bestLocation.dartLocation.uri.serverPath);
-    // We think we found a location, but for some reason we can't find the script.
-    // Just drop the frame.
+    // We think we found a location, but for some reason we can't find the
+    // script. Just drop the frame.
     // TODO(#700): Understand when this can happen and have a better fix.
     if (script == null) return null;
 
-    var functionName = _prettifyMember(
-        (frame['functionName'] as String ?? '').split('.').last);
+    var functionName =
+        _prettifyMember((frame.functionName ?? '').split('.').last);
     var codeRefName = functionName.isEmpty ? '<closure>' : functionName;
 
     var dartFrame = Frame(
@@ -505,8 +469,7 @@ class Debugger extends Domain {
       kind: FrameKind.kRegular,
     );
 
-    dartFrame.vars = await variablesFor(
-        frame['scopeChain'] as List<dynamic>, frame['callFrameId'] as String);
+    dartFrame.vars = await variablesFor(frame);
 
     return dartFrame;
   }
@@ -514,8 +477,10 @@ class Debugger extends Domain {
   /// Handles pause events coming from the Chrome connection.
   Future<void> _pauseHandler(DebuggerPausedEvent e) async {
     if (inspector == null) return;
+
     var isolate = inspector.isolate;
     if (isolate == null) return;
+
     Event event;
     var timestamp = DateTime.now().millisecondsSinceEpoch;
     var params = e.params;
@@ -551,33 +516,29 @@ class Debugger extends Domain {
           timestamp: timestamp,
           isolate: inspector.isolateRef);
     }
-    var jsFrames =
-        (e.params['callFrames'] as List).cast<Map<String, dynamic>>();
+
+    // Calculate the frames (and handle any exceptions that may occur).
+    stackComputer = StackComputer(this, e.getCallFrames().toList());
+
     try {
-      var frame = await dartTopFrame(jsFrames);
-      _pausedJsStack = jsFrames;
-      event.topFrame = frame;
-      isolate.pauseEvent = event;
-      _streamNotify('Debug', event);
-    } on ChromeDebugException catch (e, s) {
-      if (e.exception.description.contains('require is not defined')) {
-        logger.warning(
-            'Error handling pause event, app does not appear to be loaded',
-            e,
-            s);
-      } else {
-        rethrow;
-      }
+      event.topFrame = await stackComputer.calculateTopFrame();
+    } catch (e, s) {
+      // TODO: Return information about the error to the user.
+      logger.warning('Error calculating Dart frames', e, s);
     }
+
+    isolate.pauseEvent = event;
+    _streamNotify('Debug', event);
   }
 
   /// Handles resume events coming from the Chrome connection.
   Future<void> _resumeHandler(DebuggerResumedEvent _) async {
-    // We can receive a resume event in the middle of a reload which will
-    // result in a null isolate.
+    // We can receive a resume event in the middle of a reload which will result
+    // in a null isolate.
     var isolate = inspector?.isolate;
     if (isolate == null) return;
-    _pausedJsStack = null;
+
+    stackComputer = null;
     var event = Event(
         kind: EventKind.kResume,
         timestamp: DateTime.now().millisecondsSinceEpoch,
@@ -593,12 +554,12 @@ class Debugger extends Domain {
   /// [StateError].
   Future<RemoteObject> evaluateJsOnCallFrameIndex(
       int frameIndex, String expression) {
-    if (_pausedJsStack == null) {
+    if (stackComputer == null) {
       throw RPCError('evaluateInFrame', 106,
           'Cannot evaluate on a call frame when the program is not paused');
     }
     return evaluateJsOnCallFrame(
-        _pausedJsStack[frameIndex]['callFrameId'] as String, expression);
+        stackComputer.jsFrameForIndex(frameIndex).callFrameId, expression);
   }
 
   /// Evaluate [expression] by calling Chrome's Runtime.evaluateOnCallFrame on
@@ -786,4 +747,54 @@ String _unescape(String name) {
       RegExp(r'\$[0-9]+'),
       (m) =>
           String.fromCharCode(int.parse(name.substring(m.start + 1, m.end))));
+}
+
+class StackComputer {
+  final Debugger debugger;
+
+  final List<WipCallFrame> _callFrames;
+
+  StackComputer(this.debugger, this._callFrames);
+
+  /// Given a frame index, return the corresponding JS frame.
+  WipCallFrame jsFrameForIndex(int frameIndex) {
+    return _callFrames[frameIndex];
+  }
+
+  /// Returns the top Dart frame for the Chrome callFrames contained in a
+  /// [DebuggerPausedEvent].
+  ///
+  /// This will return null if there are no suitable frames.
+  Future<Frame> calculateTopFrame() async {
+    for (var frameIndex = 0; frameIndex < _callFrames.length; frameIndex++) {
+      final callFrame = _callFrames[frameIndex];
+      var dartFrame = await debugger._dartFrameFor(callFrame, frameIndex);
+      if (dartFrame != null) {
+        return dartFrame;
+      }
+    }
+    return null;
+  }
+
+  /// Translates Chrome callFrames contained in [DebuggerPausedEvent] into Dart
+  /// [Frame]s.
+  Future<List<Frame>> calculateFrames() async {
+    // TODO: Investigate the use of package:pool to request information for ~6
+    // frames at a time.
+
+    var dartFrames = <Frame>[];
+
+    // Here, we continue to increment the dart frame index even if we don't
+    // create a dart frame; this lets the dart frame index match the javascript
+    // ones.
+    for (var frameIndex = 0; frameIndex < _callFrames.length; frameIndex++) {
+      final callFrame = _callFrames[frameIndex];
+      var dartFrame = await debugger._dartFrameFor(callFrame, frameIndex);
+      if (dartFrame != null) {
+        dartFrames.add(dartFrame);
+      }
+    }
+
+    return dartFrames;
+  }
 }

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -484,7 +484,7 @@ class Debugger extends Domain {
     Event event;
     var timestamp = DateTime.now().millisecondsSinceEpoch;
     var params = e.params;
-    var jsBreakpointIds = (params['hitBreakpoints'] as List).toSet();
+    var jsBreakpointIds = (params['hitBreakpoints'] as List) ?? [];
     if (jsBreakpointIds.isNotEmpty) {
       var breakpointIds = jsBreakpointIds
           .map((id) => _breakpoints._dartIdByJsId[id])

--- a/dwds/lib/src/debugging/frame_computer.dart
+++ b/dwds/lib/src/debugging/frame_computer.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
+    hide StackTrace;
+
+import '../utilities/wrapped_service.dart';
+import 'dart_scope.dart';
+import 'debugger.dart';
+
+class FrameComputer {
+  final Debugger debugger;
+
+  final List<WipCallFrame> _callFrames;
+
+  FrameComputer(this.debugger, this._callFrames);
+
+  /// Given a frame index, return the corresponding JS frame.
+  WipCallFrame jsFrameForIndex(int frameIndex) {
+    return _callFrames[frameIndex];
+  }
+
+  /// Return the WipScopes for the given JavaScript frame index that are
+  /// pertinent for Dart debugging.
+  List<WipScope> getWipScopesForFrameIndex(int frameIndex) {
+    return filterScopes(jsFrameForIndex(frameIndex));
+  }
+
+  /// Returns the top Dart frame for the Chrome callFrames contained in a
+  /// [DebuggerPausedEvent].
+  ///
+  /// This will return null if there are no suitable frames.
+  Future<Frame> calculateTopFrame() async {
+    for (var frameIndex = 0; frameIndex < _callFrames.length; frameIndex++) {
+      final callFrame = _callFrames[frameIndex];
+      var dartFrame =
+          await debugger.calculateDartFrameFor(callFrame, frameIndex);
+      if (dartFrame != null) {
+        return dartFrame;
+      }
+    }
+    return null;
+  }
+
+  /// Translates Chrome callFrames contained in [DebuggerPausedEvent] into Dart
+  /// [Frame]s.
+  Future<List<Frame>> calculateFrames() async {
+    // TODO: Investigate the use of package:pool to request information for ~6
+    // frames at a time.
+
+    var dartFrames = <Frame>[];
+
+    // Here, we continue to increment the dart frame index even if we don't
+    // create a dart frame; this lets the dart frame index match the javascript
+    // ones.
+    for (var frameIndex = 0; frameIndex < _callFrames.length; frameIndex++) {
+      final callFrame = _callFrames[frameIndex];
+      var dartFrame =
+          await debugger.calculateDartFrameFor(callFrame, frameIndex);
+      if (dartFrame != null) {
+        dartFrames.add(dartFrame);
+      }
+    }
+
+    return dartFrames;
+  }
+}

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -84,6 +84,9 @@ class InstanceHelper extends Domain {
     if (primitive != null) {
       return primitive;
     }
+
+    // TODO: This is checking the JS object ID for the dart pattern we use for
+    // VM objects, which seems wrong (and, we catch 'string' types above).
     if (isStringId(remoteObject.objectId)) {
       return _stringInstanceFor(remoteObject, offset, count);
     }
@@ -94,6 +97,7 @@ class InstanceHelper extends Domain {
     if (metaData.jsName == 'Function') {
       return _closureInstanceFor(remoteObject);
     }
+
     var properties = await inspector.debugger.getProperties(
         remoteObject.objectId,
         offset: offset,
@@ -319,6 +323,7 @@ class InstanceHelper extends Domain {
     if (remoteObject == null) {
       return _primitiveInstanceRef(InstanceKind.kNull, remoteObject);
     }
+
     switch (remoteObject.type) {
       case 'string':
         var stringValue = remoteObject.value as String;

--- a/dwds/lib/src/debugging/metadata.dart
+++ b/dwds/lib/src/debugging/metadata.dart
@@ -49,7 +49,6 @@ class ClassMetaData {
   /// Returns null if the [remoteObject] is not a Dart class.
   static Future<ClassMetaData> metaDataFor(RemoteDebugger remoteDebugger,
       RemoteObject remoteObject, AppInspector inspector) async {
-
     // TODO: We should cache ClassRef info based on remoteObject.className. This
     // would save ~one call per JS property, and significantly reduce the work
     // to populate JS frames.

--- a/dwds/lib/src/debugging/metadata.dart
+++ b/dwds/lib/src/debugging/metadata.dart
@@ -49,6 +49,11 @@ class ClassMetaData {
   /// Returns null if the [remoteObject] is not a Dart class.
   static Future<ClassMetaData> metaDataFor(RemoteDebugger remoteDebugger,
       RemoteObject remoteObject, AppInspector inspector) async {
+
+    // TODO: We should cache ClassRef info based on remoteObject.className. This
+    // would save ~one call per JS property, and significantly reduce the work
+    // to populate JS frames.
+
     try {
       var evalExpression = '''
       function(arg) {

--- a/dwds/lib/src/servers/extension_debugger.dart
+++ b/dwds/lib/src/servers/extension_debugger.dart
@@ -16,8 +16,7 @@ import '../debugging/execution_context.dart';
 import '../debugging/remote_debugger.dart';
 import '../services/chrome_proxy_service.dart';
 
-/// A remote debugger backed by the Dart Debug Extension
-/// with an SSE connection.
+/// A remote debugger backed by the Dart Debug Extension with an SSE connection.
 class ExtensionDebugger implements RemoteDebugger {
   /// A connection between the debugger and the background of
   /// Dart Debug Extension
@@ -54,12 +53,13 @@ class ExtensionDebugger implements RemoteDebugger {
 
   @override
   Stream<ConsoleAPIEvent> get onConsoleAPICalled => eventStream(
-      'Runtime.consoleAPICalled', (WipEvent event) => ConsoleAPIEvent(event));
+      'Runtime.consoleAPICalled',
+      (WipEvent event) => ConsoleAPIEvent(event.json));
 
   @override
   Stream<ExceptionThrownEvent> get onExceptionThrown => eventStream(
       'Runtime.exceptionThrown',
-      (WipEvent event) => ExceptionThrownEvent(event));
+      (WipEvent event) => ExceptionThrownEvent(event.json));
 
   final _scripts = <String, WipScript>{};
 
@@ -257,15 +257,16 @@ class ExtensionDebugger implements RemoteDebugger {
 
   @override
   Stream<DebuggerPausedEvent> get onPaused => eventStream(
-      'Debugger.paused', (WipEvent event) => DebuggerPausedEvent(event));
+      'Debugger.paused', (WipEvent event) => DebuggerPausedEvent(event.json));
 
   @override
   Stream<DebuggerResumedEvent> get onResumed => eventStream(
-      'Debugger.resumed', (WipEvent event) => DebuggerResumedEvent(event));
+      'Debugger.resumed', (WipEvent event) => DebuggerResumedEvent(event.json));
 
   @override
   Stream<ScriptParsedEvent> get onScriptParsed => eventStream(
-      'Debugger.scriptParsed', (WipEvent event) => ScriptParsedEvent(event));
+      'Debugger.scriptParsed',
+      (WipEvent event) => ScriptParsedEvent(event.json));
 
   @override
   Map<String, WipScript> get scripts => UnmodifiableMapView(_scripts);

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -15,6 +15,7 @@ import 'expression_compiler.dart';
 
 class ErrorKind {
   const ErrorKind._(this._kind);
+
   final String _kind;
   static const ErrorKind compilation = ErrorKind._('CompilationError');
   static const ErrorKind reference = ErrorKind._('ReferenceError');
@@ -71,8 +72,7 @@ class ExpressionEvaluator {
 
     // 1. get js scope and current JS location
 
-    var jsStack = _debugger.getJsStack();
-    var jsFrame = WipCallFrame(jsStack[frameIndex]);
+    var jsFrame = _debugger.stackComputer.jsFrameForIndex(frameIndex);
 
     var functionName = jsFrame.functionName;
     var jsLocation = JsLocation.fromZeroBased(jsFrame.location.scriptId,

--- a/dwds/lib/src/utilities/objects.dart
+++ b/dwds/lib/src/utilities/objects.dart
@@ -10,9 +10,12 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 /// Represents a property of an object.
 class Property {
   final Map<String, dynamic> _map;
+
   RemoteObject _remoteObjectValue;
 
   Property(this._map);
+
+  Map<String, dynamic> get map => _map;
 
   /// The remote object value in unwrapped form.
   ///

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -54,4 +54,3 @@ dev_dependencies:
   test: ^1.6.0
   uuid: ^2.0.0
   webdriver: ^2.0.0
-  

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   sse: ^3.5.0
   vm_service: ^4.0.3
   web_socket_channel: ^1.0.0
-  webkit_inspection_protocol: '>=0.5.4 <0.7.0'
+  webkit_inspection_protocol: ^0.7.0
 
 dev_dependencies:
   args: ^1.0.0
@@ -54,3 +54,4 @@ dev_dependencies:
   test: ^1.6.0
   uuid: ^2.0.0
   webdriver: ^2.0.0
+  

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -87,6 +87,7 @@ void main() async {
       // Add a DebuggerPausedEvent with a null parameter to provoke an error.
       pausedController.sink.add(DebuggerPausedEvent({
         'params': {
+          'reason': 'other',
           'callFrames': [
             null,
           ],

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -6,6 +6,7 @@
 import 'dart:async';
 
 import 'package:dwds/src/debugging/debugger.dart';
+import 'package:dwds/src/debugging/frame_computer.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/debugging/location.dart';
 import 'package:dwds/src/debugging/modules.dart';
@@ -67,7 +68,7 @@ void main() async {
     // frame.
     locations.noteLocation('dart', location, '69');
 
-    var stackComputer = StackComputer(debugger, frames1);
+    var stackComputer = FrameComputer(debugger, frames1);
     var frames = await stackComputer.calculateFrames();
     expect(frames, isNotNull);
 

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -67,8 +67,10 @@ void main() async {
     // frame.
     locations.noteLocation('dart', location, '69');
 
-    var frames = await debugger.dartFramesFor(frames1);
+    var stackComputer = StackComputer(debugger, frames1);
+    var frames = await stackComputer.calculateFrames();
     expect(frames, isNotNull);
+
     var firstFrame = frames[0];
     var frame1Variables = firstFrame.vars.map((each) => each.name).toList();
     expect(frame1Variables, ['a', 'b']);

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -85,11 +85,17 @@ void main() async {
 
     test('errors in the zone are caught and logged', () async {
       // Add a DebuggerPausedEvent with a null parameter to provoke an error.
-      pausedController.sink.add(DebuggerPausedEvent(null));
+      pausedController.sink.add(DebuggerPausedEvent({
+        'params': {
+          'callFrames': [
+            null,
+          ],
+        }
+      }));
       expect(
           Debugger.logger.onRecord,
           emitsThrough(predicate(
-              (log) => log.message == 'Error handling Chrome event')));
+              (log) => log.message == 'Error calculating Dart frames')));
     });
   });
 }

--- a/dwds/test/extension_debugger_test.dart
+++ b/dwds/test/extension_debugger_test.dart
@@ -52,12 +52,12 @@ void main() async {
     test('an ExtensionEvent', () async {
       var extensionEvent = ExtensionEvent((b) => b
         ..method = jsonEncode('Debugger.paused')
-        ..params = jsonEncode(frames1[0]));
+        ..params = jsonEncode(frames1Json[0]));
       connection.controllerIncoming.sink
           .add(jsonEncode(serializers.serialize(extensionEvent)));
       var wipEvent = await extensionDebugger.onNotification.first;
       expect(wipEvent.method, 'Debugger.paused');
-      expect(wipEvent.params, frames1[0]);
+      expect(wipEvent.params, frames1Json[0]);
     });
 
     test('a BatchedEvents', () async {

--- a/dwds/test/fixtures/debugger_data.dart
+++ b/dwds/test/fixtures/debugger_data.dart
@@ -87,7 +87,8 @@ List<Map<String, dynamic>> frames1Json = [
   }
 ];
 
-/// Data in the form returned from getProperties called twice on successive elements of a scope chain.
+/// Data in the form returned from getProperties called twice on successive
+/// elements of a scope chain.
 ///
 /// It has two variables named 'a' and 'b' in the first scope.
 var variables1 = [
@@ -97,24 +98,6 @@ var variables1 = [
   }),
   WipResponse({
     'id': 2,
-    'result': {'result': []}
-  }),
-  // Fake that the SDK is loaded.
-  WipResponse({
-    'id': 3,
-    'result': {
-      'result': [
-        {'name': 'dart', 'value': null},
-        {'name': 'core', 'value': null}
-      ]
-    }
-  }),
-  WipResponse({
-    'id': 4,
-    'result': {'result': []}
-  }),
-  WipResponse({
-    'id': 5,
     'result': {
       'result': [
         {
@@ -127,6 +110,24 @@ var variables1 = [
         }
       ]
     }
+  }),
+  WipResponse({
+    'id': 3,
+    'result': {'result': []}
+  }),
+  // Fake that the SDK is loaded.
+  WipResponse({
+    'id': 4,
+    'result': {
+      'result': [
+        {'name': 'dart', 'value': null},
+        {'name': 'core', 'value': null}
+      ]
+    }
+  }),
+  WipResponse({
+    'id': 5,
+    'result': {'result': []}
   }),
   WipResponse({
     'id': 6,

--- a/dwds/test/fixtures/debugger_data.dart
+++ b/dwds/test/fixtures/debugger_data.dart
@@ -8,12 +8,14 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 // ignore_for_file: prefer_single_quotes
 
-/// Stack frames in JSON format as they would be in a Chrome 'Debugger.paused'
-/// event.
+/// Stack frames as they would be in a Chrome 'Debugger.paused' event.
 ///
 /// This is taken from a real run, but truncated to two levels of scope and one
 /// level of stack.
-List<Map<String, dynamic>> frames1 = [
+List<WipCallFrame> frames1 =
+    frames1Json.map((json) => WipCallFrame(json)).toList();
+
+List<Map<String, dynamic>> frames1Json = [
   {
     "callFrameId": "{\"ordinal\":0,\"injectedScriptId\":2}",
     "functionName": "",

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   shelf_static: ^0.2.8
   sse: ^3.5.0
   vm_service: '>=3.0.0 <5.0.0'
-  webkit_inspection_protocol: '>=0.4.0 <0.6.0'
+  webkit_inspection_protocol: '>=0.4.0 <0.8.0'
   yaml: ^2.1.13
 
 dev_dependencies:


### PR DESCRIPTION
Optimize the backend calls we make for frame creation:
- rev to use the latest version of `package:webkit_inspection_protocol` (note: as package:test depends on webkit_inspection_protocol, this will select an older version of test until package:test is republished)
- use the `this` object from the JS frame instead of making a remote eval call
- don't iterate over the (very large) DDC closure scopes in JS frames
- add the synthetic 'return value' variable to a returned frame if its available (this isn't done by the VM implementation, but will be useful to add to the VM)
- we now display local variables in the order they appear in the method (instead of sorted lexically); this maps well to how other debuggers work
- fix an issue where the dart frame index wouldn't align with the js frame we were using to do things like eval (they would get out of alignment if we didn't create a dart frame for a JS frame on the call stack)
- when encountering an exception while computing the stack frames, we still send the paused event to the client (w/o frame info)

### Times
For a reasonably sized flutter web app (flutter/gallery), creating frames when paused at a breakpoint or stepping took around 23s-24s (23,299ms). Flutter apps typically have deep call stacks - for this case, the call stack was 170-180 frames, and each frame took around 140ms to populate.

After this change, the total frame population time is around 700-800ms; stepping takes 2-3s, with perhaps 1,500ms taken by the JS VM to resume execution, hit the next breakpoint, and send us the JS frame info. DDC changes to create smaller closures may help here? Other improvements we can make on the package:dwds side are listed below.

### Some possible improvements in the future:
- caching classrefs - this is likely the single biggest remaining win. We call a backend eval call ~per JS property to populate the ClassRef info for that BoundVariable. These computed ClassRefs could be cached per JS class name, which would save us many backend calls per frame
- we call many backend eval calls when populating a frame; we should look as creating a single optimized JS eval in order to populate the frame info in one backend call
- investigate the use of `package:pool` to create ~6 frames at a time instead of each frame sequentially
- the JS frame now includes info about async frames; we could choose to use this to display additional dart frames. This could help users puzzle out the logical call chain for async calls
