### PR TITLE
change what we report as the isolate's root library

### DIFF
--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -75,19 +75,23 @@ class AppInspector extends Domain {
   )   : isolateRef = _toIsolateRef(isolate),
         super.forInspector();
 
-  @override
-
   /// We are the inspector, so this getter is trivial.
+  @override
   AppInspector get inspector => this;
 
   Future<void> _initialize() async {
     var libraries = await libraryHelper.libraryRefs;
     isolate.libraries.addAll(libraries);
+
     await DartUri.recordAbsoluteUris(libraries.map((lib) => lib.uri));
 
-    // TODO: Something more robust here, right now we rely on the 2nd to last
-    // library being the root one (the last library is the bootstrap lib).
-    isolate.rootLib = isolate.libraries[isolate.libraries.length - 1];
+    // This relies on the convention that the 2nd to last library is the root
+    // library (and the last one is the bootstrap library).
+    if (libraries.length >= 2) {
+      isolate.rootLib = libraries[libraries.length - 2];
+    } else {
+      isolate.rootLib = libraries.last;
+    }
 
     isolate.extensionRPCs.addAll(await _getExtensionRpcs());
   }

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -94,22 +94,22 @@ void main() {
   });
 
   group('invoke', () {
-    // We test these here because the test fixture has more complicated members to
-    // exercise.
+    // We test these here because the test fixture has more complicated members
+    // to exercise.
 
     String isolateId;
-    String libraryId;
+    LibraryRef bootstrapLibrary;
     RemoteObject instance;
 
     setUp(() async {
       isolateId = inspector.isolate.id;
-      libraryId = inspector.isolate.rootLib.id;
-      instance =
-          await inspector.evaluate(isolateId, libraryId, 'libraryPublicFinal');
+      bootstrapLibrary = inspector.isolate.libraries.last;
+      instance = await inspector.evaluate(
+          isolateId, bootstrapLibrary.id, 'libraryPublicFinal');
     });
 
     test('invoke top-level private', () async {
-      var remote = await inspector.invoke(isolateId, libraryId,
+      var remote = await inspector.invoke(isolateId, bootstrapLibrary.id,
           '_libraryPrivateFunction', [dartIdFor(2), dartIdFor(3)]);
       expect(
           remote,
@@ -134,9 +134,10 @@ void main() {
           const TypeMatcher<RemoteObject>()
               .having((instance) => instance.value, 'result', true));
     });
+
     test('invoke instance method with object parameter 2', () async {
-      var libraryPrivateList =
-          await inspector.evaluate(isolateId, libraryId, '_libraryPrivate');
+      var libraryPrivateList = await inspector.evaluate(
+          isolateId, bootstrapLibrary.id, '_libraryPrivate');
       var remote = await inspector.invoke(isolateId, instance.objectId,
           'equals', [libraryPrivateList.objectId]);
       expect(


### PR DESCRIPTION
- change what we report as the isolate's root library (instead of reporting the generated bootstrap library, we report the app entry point library)

Most of the change here is just changing which library we use when running tests.

DevTools uses the `isolate.rootLib` to know which file to open initially when debugging an app.