### PR TITLE
implement the getMemoryUsage API call

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -11,6 +11,7 @@
   that are not handled.
 - Prompt users to install the Dart Debug Extension if local debugging does not work.
 - Allow for the injected client to run with CSP enforced.
+- Implement the `getMemoryUsage()` call.
 
 ## 3.1.1
 

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -343,6 +343,19 @@ function($argsString) {
       ..source = source;
   }
 
+  Future<MemoryUsage> getMemoryUsage(String isolateId) async {
+    checkIsolate('getMemoryUsage', isolateId);
+
+    final response = await remoteDebugger.sendCommand('Runtime.getHeapUsage');
+
+    final jsUsage = HeapUsage(response.result);
+    return MemoryUsage.parse({
+      'heapUsage': jsUsage.usedSize,
+      'heapCapacity': jsUsage.totalSize,
+      'externalUsage': 0,
+    });
+  }
+
   /// Returns the [ScriptRef] for the provided Dart server path [uri].
   Future<ScriptRef> scriptRefFor(String uri) async {
     if (_serverPathToScriptRef.isEmpty) {

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -424,8 +424,8 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   Future<Isolate> getIsolate(String isolateId) async => _getIsolate(isolateId);
 
   @override
-  Future<MemoryUsage> getMemoryUsage(String isolateId) async {
-    throw UnimplementedError();
+  Future<MemoryUsage> getMemoryUsage(String isolateId) {
+    return _inspector.getMemoryUsage(isolateId);
   }
 
   @override

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -187,16 +187,39 @@ void main() {
       });
     });
 
-    test('clearVMTimeline', () {
-      expect(() => service.clearVMTimeline(), throwsUnimplementedError);
+    group('VMTimeline', () {
+      test('clearVMTimeline', () {
+        expect(() => service.clearVMTimeline(), throwsUnimplementedError);
+      });
+
+      test('getVMTimelineMicros', () {
+        expect(() => service.getVMTimelineMicros(), throwsUnimplementedError);
+      });
+
+      test('getVMTimeline', () {
+        expect(() => service.getVMTimeline(), throwsUnimplementedError);
+      });
+
+      test('getVMTimelineFlags', () {
+        expect(() => service.getVMTimelineFlags(), throwsUnimplementedError);
+      });
+
+      test('setVMTimelineFlags', () {
+        expect(
+            () => service.setVMTimelineFlags(null), throwsUnimplementedError);
+      });
     });
 
-    test('clearVMTimeline', () {
-      expect(() => service.clearVMTimeline(), throwsUnimplementedError);
-    });
+    test('getMemoryUsage', () async {
+      var vm = await service.getVM();
+      var isolate = await service.getIsolate(vm.isolates.first.id);
 
-    test('clearVMTimeline', () {
-      expect(() => service.clearVMTimeline(), throwsUnimplementedError);
+      var memoryUsage = await service.getMemoryUsage(isolate.id);
+
+      expect(memoryUsage.heapUsage, isNotNull);
+      expect(memoryUsage.heapUsage, greaterThan(0));
+      expect(memoryUsage.heapCapacity, greaterThan(0));
+      expect(memoryUsage.externalUsage, equals(0));
     });
 
     group('evaluate', () {
@@ -602,10 +625,6 @@ void main() {
           scripts.scripts.map((s) => s.uri), contains(endsWith('part.dart')));
       expect(scripts.scripts.map((s) => s.uri),
           contains('package:intl/src/intl/date_format_helpers.dart'));
-    });
-
-    test('clearVMTimeline', () {
-      expect(() => service.clearVMTimeline(), throwsUnimplementedError);
     });
 
     group('getSourceReport', () {
@@ -1030,10 +1049,6 @@ void main() {
       expect(service.setVMName('foo'), completion(_isSuccess));
       var vm = await service.getVM();
       expect(vm.name, 'foo');
-    });
-
-    test('setVMTimelineFlags', () {
-      expect(() => service.setVMTimelineFlags(null), throwsUnimplementedError);
     });
 
     test('streamCancel', () {


### PR DESCRIPTION
- implement the getMemoryUsage API call
- some misc fixes to the `VMTimeline` tests (looks like there was a likely copy paste error with the clearVMTimeline calls)
