### PR TITLE
Fix type error with GlobalObjectClearedEvents

### DIFF
--- a/dwds/lib/src/servers/extension_debugger.dart
+++ b/dwds/lib/src/servers/extension_debugger.dart
@@ -253,7 +253,7 @@ class ExtensionDebugger implements RemoteDebugger {
   @override
   Stream<GlobalObjectClearedEvent> get onGlobalObjectCleared => eventStream(
       'Page.frameStartedLoading',
-      (WipEvent event) => GlobalObjectClearedEvent(event));
+      (WipEvent event) => GlobalObjectClearedEvent(event.json));
 
   @override
   Stream<DebuggerPausedEvent> get onPaused => eventStream(


### PR DESCRIPTION
This is an error as of https://github.com/google/webkit_inspection_protocol.dart/pull/61