### PR TITLE
Don't always build everything with serve

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 2.5.8-dev
+## 2.5.8
 
 - Depend on the latest `package:dwds`.
-
+- Fix an issue where all directories were built when using the `serve` command.
 
 ## 2.5.7
 

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -134,14 +134,11 @@ void _registerBuildTargets(
   }
   // Empty string indicates we should build everything, register a corresponding
   // target.
-  if (configuration.outputInput == '') {
-    OutputLocation outputLocation;
-    if (configuration.outputPath != null) {
-      outputLocation = OutputLocation((b) => b
-        ..output = configuration.outputPath
-        ..useSymlinks = true
-        ..hoist = false);
-    }
+  if (configuration.outputInput == '' && configuration.outputPath != null) {
+    var outputLocation = OutputLocation((b) => b
+      ..output = configuration.outputPath
+      ..useSymlinks = true
+      ..hoist = false);
     client.registerBuildTarget(DefaultBuildTarget((b) => b
       ..target = ''
       ..outputLocation = outputLocation?.toBuilder()));

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.5.8-dev';
+const packageVersion = '2.5.8';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.5.8-dev
+version: 2.5.8
 homepage: https://github.com/dart-lang/webdev
 description: >-
   A CLI for Dart web development. Provides an easy and consistent set of
@@ -45,7 +45,3 @@ dev_dependencies:
 
 executables:
   webdev:
-
-dependency_overrides:
-  dwds:
-    path: ../dwds


### PR DESCRIPTION
- Fix an issue where we would always build all directories when using the `serve` command
- Prep for publish

Closes https://github.com/dart-lang/webdev/issues/1023