### PR TITLE
Configurable Metadata Collection

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.2.0-dev
+
 ## 3.1.3
 
 - Fix an issue where the injected client served under `https` assumed the

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -10,7 +10,7 @@ import '../utilities/domain.dart';
 import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
 import 'inspector.dart';
-import 'metadata.dart';
+import 'metadata/class.dart';
 
 /// A hard-coded ClassRef for the Closure class.
 final classRefForClosure = classRefFor('dart:core', 'Closure');

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -14,7 +14,8 @@ import '../utilities/shared.dart';
 import '../utilities/wrapped_service.dart';
 import 'classes.dart';
 import 'inspector.dart';
-import 'metadata.dart';
+import 'metadata/class.dart';
+import 'metadata/function.dart';
 
 /// Contains a set of methods for getting [Instance]s and [InstanceRef]s.
 class InstanceHelper extends Domain {

--- a/dwds/lib/src/debugging/metadata/function.dart
+++ b/dwds/lib/src/debugging/metadata/function.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.import 'dart:async';
+
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import '../../loaders/strategy.dart';
+import '../../utilities/shared.dart';
+import '../remote_debugger.dart';
+
+/// Meta data for a remote Dart function in Chrome.
+class FunctionMetaData {
+  final String name;
+  FunctionMetaData(this.name);
+
+  /// Returns the [FunctionMetaData] for the Chrome [remoteObject].
+  static Future<FunctionMetaData> metaDataFor(
+      RemoteDebugger remoteDebugger, RemoteObject remoteObject) async {
+    var evalExpression = '''
+      function(remoteObject) {
+        var sdkUtils = ${globalLoadStrategy.loadModuleSnippet}('dart_sdk').dart;
+        var name = remoteObject.name;
+        if(remoteObject._boundObject) {
+         name = sdkUtils.getType(remoteObject._boundObject).name +
+                 '.' + remoteObject._boundMethod.name;
+        }
+        return name;
+      }
+    ''';
+    var arguments = [
+      {'objectId': remoteObject.objectId}
+    ];
+    var response =
+        await remoteDebugger.sendCommand('Runtime.callFunctionOn', params: {
+      'functionDeclaration': evalExpression,
+      'arguments': arguments,
+      'objectId': remoteObject.objectId,
+      'returnByValue': true,
+    });
+    handleErrorIfPresent(
+      response,
+      evalContents: evalExpression,
+    );
+    var name = response.result['result']['value'] as String;
+    if (name.isEmpty) name = 'Closure';
+    return FunctionMetaData(name);
+  }
+}

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.import 'dart:async';
+
+import 'dart:convert';
+
+import '../../debugging/execution_context.dart';
+import '../../debugging/remote_debugger.dart';
+import '../../loaders/strategy.dart';
+import '../../utilities/shared.dart';
+
+/// Provider of DDC meta data for a compiled application.
+abstract class MetadataProvider {
+  Future<List<String>> get libraries;
+
+  /// A map of script to corresponding parts.
+  Future<Map<String, List<String>>> get scripts;
+
+  /// A map of script to containing module.
+  Future<Map<String, String>> get scriptToModule;
+}
+
+/// A provider of meta data in which data is collected from the running
+/// application in Chrome.
+class ChromeMetadataProvider implements MetadataProvider {
+  final RemoteDebugger _remoteDebugger;
+  final ExecutionContext _executionContext;
+
+  ChromeMetadataProvider(this._remoteDebugger, this._executionContext);
+
+  @override
+  Future<List<String>> get libraries async {
+    var expression = '''
+      (function() {
+        ${globalLoadStrategy.loadLibrariesSnippet}
+        return libs;
+      })()
+     ''';
+    var result = await _remoteDebugger.sendCommand('Runtime.evaluate', params: {
+      'expression': expression,
+      'returnByValue': true,
+      'contextId': await _executionContext.id,
+    });
+    handleErrorIfPresent(result, evalContents: expression);
+    var libraries = List<String>.from(result.result['result']['value'] as List);
+    // Filter out any non-Dart libraries, which basically means the .bootstrap
+    // library from build_web_runners.
+    return libraries
+        .where((name) => name.startsWith('dart:') || name.endsWith('.dart'))
+        .toList();
+  }
+
+  @override
+  Future<Map<String, String>> get scriptToModule async {
+    var result = <String, String>{};
+    var expression = '''
+    (function() {
+      var dart = ${globalLoadStrategy.loadModuleSnippet}('dart_sdk').dart;
+      var result = {};
+      for (module of dart.getModuleNames()) {
+        for (script of Object.keys(dart.getModuleLibraries(module))) {
+          result[script] = module;
+        }
+      }
+      return result;
+    })();
+      ''';
+    var response =
+        await _remoteDebugger.sendCommand('Runtime.evaluate', params: {
+      'expression': expression,
+      'returnByValue': true,
+      'contextId': await _executionContext.id,
+    });
+    handleErrorIfPresent(response);
+    var value = response.result['result']['value'] as Map<String, dynamic>;
+    for (var dartScript in value.keys) {
+      if (!dartScript.endsWith('.dart')) continue;
+      result[dartScript] = value[dartScript] as String;
+    }
+    return result;
+  }
+
+  @override
+  Future<Map<String, List<String>>> get scripts async {
+    var libraryUris = await libraries;
+    // We can't pass parameters to an eval, so encode the list and inline it in
+    // the expression.
+    var listAsJson = jsonEncode(libraryUris);
+    var expression = '''
+    (function() {
+      var uris = JSON.parse('$listAsJson');
+      var allScripts = {};
+      var sdkUtils = ${globalLoadStrategy.loadModuleSnippet}('dart_sdk').dart;
+      for (var uri of uris) {
+        var parts = sdkUtils.getParts(uri);
+        allScripts[uri] = parts;
+      }
+      return allScripts;
+    })()
+    ''';
+    var result = await _remoteDebugger.sendCommand('Runtime.evaluate', params: {
+      'expression': expression,
+      'returnByValue': true,
+      'contextId': await _executionContext.id,
+    });
+    handleErrorIfPresent(result, evalContents: expression);
+    var allScripts = result.result['result']['value'] as Map<String, dynamic>;
+    var scripts = <String, List<String>>{};
+    for (var script in allScripts.keys) {
+      scripts[script] = (allScripts[script] as List).cast<String>();
+    }
+    return scripts;
+  }
+}
+
+/// A provider of metadata in which data is collected through DDC outputs.
+class FileMetadataProvider implements MetadataProvider {
+  @override
+  Future<List<String>> get libraries => throw UnimplementedError();
+
+  @override
+  Future<Map<String, String>> get scriptToModule => throw UnimplementedError();
+
+  @override
+  Future<Map<String, List<String>>> get scripts => throw UnimplementedError();
+}

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -131,7 +131,7 @@ class ChromeProxyService implements VmServiceInterface {
       architectureBits: -1,
       pid: -1,
     );
-    // TODO(grouma) - Make this confiugrable when the FileMetadataProvider is
+    // TODO(grouma) - Make this configurable when the FileMetadataProvider is
     // complete.
     var metadataProvider =
         ChromeMetadataProvider(remoteDebugger, executionContext);

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.1.3';
+const packageVersion = '3.2.0-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dwds
-version: 3.1.3
+version: 3.2.0-dev
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -9,7 +9,6 @@ import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/frame_computer.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/debugging/location.dart';
-import 'package:dwds/src/debugging/modules.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:source_maps/parser.dart';
 import 'package:test/test.dart';
@@ -33,8 +32,7 @@ void main() async {
     pausedController = StreamController<DebuggerPausedEvent>();
     webkitDebugger.onPaused = pausedController.stream;
     var root = 'fakeRoot';
-    var modules = Modules(webkitDebugger, root, null);
-    locations = Locations(null, modules, root);
+    locations = Locations(null, FakeModules(), root);
     debugger = await Debugger.create(
       webkitDebugger,
       null,

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -9,6 +9,7 @@ import 'package:dwds/dwds.dart';
 import 'package:dwds/src/debugging/execution_context.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/debugging/instance.dart';
+import 'package:dwds/src/debugging/modules.dart';
 import 'package:dwds/src/debugging/webkit_debugger.dart';
 import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/services/expression_compiler.dart';
@@ -136,6 +137,39 @@ class FakeSseConnection implements SseConnection {
   void shutdown() {}
 }
 
+class FakeModules implements Modules {
+  @override
+  void initialize() {}
+
+  @override
+  Future<Uri> libraryForSource(String serverPath) {
+    throw UnimplementedError();
+  }
+
+  @override
+  String moduleForScriptId(String serverId) => '';
+
+  @override
+  Future<String> moduleForSource(String serverPath) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Map<String, String>> modules() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Null> noteModule(String url, String scriptId) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  String scriptIdForModule(String server) {
+    throw UnimplementedError();
+  }
+}
+
 class FakeWebkitDebugger implements WebkitDebugger {
   @override
   Future disable() => null;
@@ -197,32 +231,6 @@ class FakeWebkitDebugger implements WebkitDebugger {
     if (method == 'Runtime.getProperties') {
       return results[resultsReturned++];
     }
-
-    if (method == 'Runtime.evaluate') {
-      // Fake response adapted from modules query at google3
-      return WipResponse({
-        'id': 42,
-        'result': {
-          'result': <String, dynamic>{
-            'type': 'object',
-            'value': <String, dynamic>{
-              // dart source Uri : js module name
-              'dart:io': 'dart_sdk',
-              'org-dartlang-app:///dart/tools/iblaze/web/hello_world.dart':
-                  'dart/tools/iblaze/web/hello_world_angular_library',
-              'package:ads.acx2.rpc.proto_mixin/ess_proto_mixin.dart':
-                  'ads/acx2/rpc/proto_mixin/lib/proto_mixin',
-              'package:collection/collection.dart: ':
-                  'third_party/dart/collection/lib/collection',
-              'package:collection/src/algorithms.dart':
-                  'third_party/dart/collection/lib/collection',
-              'package:shelf/shelf.dart': 'packages/shelf/shelf',
-            }
-          }
-        }
-      });
-    }
-
     return null;
   }
 

--- a/dwds/test/metadata/class_test.dart
+++ b/dwds/test/metadata/class_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dwds/src/debugging/metadata.dart';
+import 'package:dwds/src/debugging/metadata/class.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -45,3 +45,7 @@ dev_dependencies:
 
 executables:
   webdev:
+
+dependency_overrides:
+  dwds:
+    path: ../dwds


### PR DESCRIPTION
- Split `metadata.dart` into `metadata/function.dart` and `metadata/class.dart`
- Create abstract `MetadataProvider` which provides:
  - Libraries
  - Scripts and parts
  - Modules
- Create `ChromeMetadataProvider` which collects metadata through a running application in Chrome
- Create boilerplate for `FileMetadataProvider` which will collect data through DDC output
  - See https://dart-review.googlesource.com/c/sdk/+/144243
