### PR TITLE
Fix webdev: implement getSupportedProtocols required by VmServiceInterface

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -158,7 +158,8 @@ class ChromeProxyService implements VmServiceInterface {
   /// supported by the current server.
   @override
   Future<ProtocolList> getSupportedProtocols() {
-    return ProtocolList( Protocol({protocolName: 'jsonrpc', major: 2, minor: 0}) ) ;
+    return ProtocolList(
+      Protocol({protocolName: 'jsonrpc', major: 2, minor: 0}) ) ;
   }
 
   /// Creates expression evaluator to use in [evaluateInFrame]

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -152,6 +152,14 @@ class ChromeProxyService implements VmServiceInterface {
     await service.createEvaluator(expressionCompiler);
     return service;
   }
+  
+
+  /// The `getSupportedProtocols` RPC is used to determine which protocols are
+  /// supported by the current server.
+  @override
+  Future<ProtocolList> getSupportedProtocols() {
+    return ProtocolList( Protocol({protocolName: 'jsonrpc', major: 2, minor: 0}) ) ;
+  }
 
   /// Creates expression evaluator to use in [evaluateInFrame]
   ///


### PR DESCRIPTION
Still need to confirm if the protocol is really `jsonrpc/2.0`