### PR TITLE
return RPCError.kMethodNotFound from unimplemented methods

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,10 +1,15 @@
+## 4.0.2-dev
+
+- Have unimplemented VM service protocol methods return the RPC error
+  'MethodNotFound' / `-32601`.
+
 ## 4.0.1
 
 - Fixed issue where `getSupportedProtocols` would return the wrong protocol.
 
 ## 4.0.0
 
-- Pin the `package:vm_service` version to prevent uninteded breaks.
+- Pin the `package:vm_service` version to prevent unintended breaks.
 
 ## 3.1.3
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -284,7 +284,7 @@ class ChromeProxyService implements VmServiceInterface {
 
   @override
   Future<Breakpoint> addBreakpointAtEntry(String isolateId, String functionId) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('addBreakpointAtEntry');
   }
 
   @override
@@ -335,7 +335,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
   @override
   Future<Success> clearVMTimeline() {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('clearVMTimeline');
   }
 
   @override
@@ -355,6 +355,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
     if (_expressionEvaluator != null) {
       var isolate = _inspector?.isolate;
       if (isolate?.id != isolateId) {
+        // TODO: Throw an RPC error here.
         throw ArgumentError.value(
             isolateId, 'isolateId', 'Unrecognized isolate id');
       }
@@ -399,6 +400,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
       }
     }
 
+    // TODO: Change this to a RPC error.
     throw UnimplementedError(
         'Expression evaluation is not supported for this configuration');
   }
@@ -406,17 +408,13 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   @override
   Future<AllocationProfile> getAllocationProfile(String isolateId,
       {bool gc, bool reset}) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('getAllocationProfile');
   }
 
   @override
   Future<ClassList> getClassList(String isolateId) {
     // See dart-lang/webdev/issues/971.
-    return Future.error(RPCError(
-      'getClassList',
-      RPCError.kMethodNotFound,
-      'Not supported on web devices',
-    ));
+    return _rpcNotSupportedFuture('getClassList');
   }
 
   @override
@@ -428,7 +426,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   @override
   Future<InstanceSet> getInstances(
       String isolateId, String classId, int limit) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('getInstances');
   }
 
   /// Sync version of [getIsolate] for internal use, also has stronger typing
@@ -436,6 +434,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   Isolate _getIsolate(String isolateId) {
     var isolate = _inspector?.isolate;
     if (isolate?.id == isolateId) return isolate;
+    // TODO: Throw an RPC error here.
     throw ArgumentError.value(
         isolateId, 'isolateId', 'Unrecognized isolate id');
   }
@@ -482,12 +481,12 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
   @override
   Future<Timeline> getVMTimeline({int timeOriginMicros, int timeExtentMicros}) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('getVMTimeline');
   }
 
   @override
   Future<TimelineFlags> getVMTimelineFlags() {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('getVMTimelineFlags');
   }
 
   @override
@@ -513,7 +512,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
   @override
   Future<Success> kill(String isolateId) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('kill');
   }
 
   @override
@@ -560,7 +559,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
   @override
   Future<Success> registerService(String service, String alias) async {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('registerService');
   }
 
   @override
@@ -594,18 +593,19 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   }
 
   @override
-  Future<Success> setExceptionPauseMode(String isolateId, String mode) async =>
-      (await _debugger).setExceptionPauseMode(isolateId, mode);
+  Future<Success> setExceptionPauseMode(String isolateId, String mode) async {
+    return (await _debugger).setExceptionPauseMode(isolateId, mode);
+  }
 
   @override
   Future<Success> setFlag(String name, String value) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('setFlag');
   }
 
   @override
   Future<Success> setLibraryDebuggable(
       String isolateId, String libraryId, bool isDebuggable) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('setLibraryDebuggable');
   }
 
   @override
@@ -631,29 +631,33 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
   @override
   Future<Success> setVMTimelineFlags(List<String> recordedStreams) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('setVMTimelineFlags');
   }
 
   @override
   Future<Success> streamCancel(String streamId) {
-    throw UnimplementedError();
+    // TODO: We should implement this (as we've already implemented
+    // streamListen).
+    return _rpcNotSupportedFuture('streamCancel');
   }
 
   @override
   Future<Success> streamListen(String streamId) async {
+    // TODO: This should return an error if the stream is already being listened
+    // to.
     onEvent(streamId);
     return Success();
   }
 
   @override
   Future<Success> clearCpuSamples(String isolateId) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('clearCpuSamples');
   }
 
   @override
   Future<CpuSamples> getCpuSamples(
       String isolateId, int timeOriginMicros, int timeExtentMicros) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('getCpuSamples');
   }
 
   /// Returns a streamController that listens for console logs from chrome and
@@ -802,46 +806,51 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
   @override
   Future<Timestamp> getVMTimelineMicros() {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('getVMTimelineMicros');
   }
 
   @override
   Future<InboundReferences> getInboundReferences(
       String isolateId, String targetId, int limit) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('getInboundReferences');
   }
 
   @override
   Future<RetainingPath> getRetainingPath(
       String isolateId, String targetId, int limit) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('getRetainingPath');
   }
 
   @override
   Future<Success> requestHeapSnapshot(String isolateId) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('requestHeapSnapshot');
   }
 
   @override
   Future<IsolateGroup> getIsolateGroup(String isolateGroupId) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('getIsolateGroup');
   }
 
   @override
   Future<MemoryUsage> getIsolateGroupMemoryUsage(String isolateGroupId) {
-    throw UnimplementedError();
+    return _rpcNotSupportedFuture('getIsolateGroupMemoryUsage');
   }
 
   @override
-  Future<ClientName> getClientName() => throw UnimplementedError();
+  Future<ClientName> getClientName() {
+    return _rpcNotSupportedFuture('getClientName');
+  }
 
   @override
-  Future<Success> setClientName(String name) => throw UnimplementedError();
+  Future<Success> setClientName(String name) {
+    return _rpcNotSupportedFuture('setClientName');
+  }
 
   @override
   Future<Success> requirePermissionToResume(
-          {bool onPauseStart, bool onPauseReload, bool onPauseExit}) =>
-      throw UnimplementedError();
+      {bool onPauseStart, bool onPauseReload, bool onPauseExit}) {
+    return _rpcNotSupportedFuture('requirePermissionToResume');
+  }
 
   @override
   Future<ProtocolList> getSupportedProtocols() async {
@@ -861,6 +870,15 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
     } else {
       return _inspector.instanceHelper.instanceRefFor(obj);
     }
+  }
+
+  static RPCError _rpcNotSupported(String method) {
+    return RPCError(
+        method, RPCError.kMethodNotFound, 'Not supported on web devices');
+  }
+
+  static Future<T> _rpcNotSupportedFuture<T>(String method) {
+    return Future.error(_rpcNotSupported(method));
   }
 }
 

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 4.0.1
+version: 4.0.2-dev
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -37,9 +37,12 @@ void main() {
       await context.tearDown();
     });
 
-    test('client name', () async {
-      expect(() => service.getClientName(), throwsUnimplementedError);
-      expect(() => service.setClientName('foo'), throwsUnimplementedError);
+    test('getClientName', () async {
+      expect(() => service.getClientName(), throwsRPCError);
+    });
+
+    test('setClientName', () async {
+      expect(() => service.setClientName('foo'), throwsRPCError);
     });
 
     group('breakpoints', () {
@@ -91,8 +94,7 @@ void main() {
       });
 
       test('addBreakpointAtEntry', () {
-        expect(() => service.addBreakpointAtEntry(null, null),
-            throwsUnimplementedError);
+        expect(() => service.addBreakpointAtEntry(null, null), throwsRPCError);
       });
 
       test('addBreakpointWithScriptUri', () async {
@@ -125,8 +127,8 @@ void main() {
       });
 
       test("removeBreakpoint doesn't exist", () {
-        expect(() => service.removeBreakpoint(isolate.id, '1234'),
-            throwsA(isA<RPCError>()));
+        expect(
+            () => service.removeBreakpoint(isolate.id, '1234'), throwsRPCError);
       });
 
       test('add and remove breakpoint', () async {
@@ -189,24 +191,23 @@ void main() {
 
     group('VMTimeline', () {
       test('clearVMTimeline', () {
-        expect(() => service.clearVMTimeline(), throwsUnimplementedError);
+        expect(() => service.clearVMTimeline(), throwsRPCError);
       });
 
       test('getVMTimelineMicros', () {
-        expect(() => service.getVMTimelineMicros(), throwsUnimplementedError);
+        expect(() => service.getVMTimelineMicros(), throwsRPCError);
       });
 
       test('getVMTimeline', () {
-        expect(() => service.getVMTimeline(), throwsUnimplementedError);
+        expect(() => service.getVMTimeline(), throwsRPCError);
       });
 
       test('getVMTimelineFlags', () {
-        expect(() => service.getVMTimelineFlags(), throwsUnimplementedError);
+        expect(() => service.getVMTimelineFlags(), throwsRPCError);
       });
 
       test('setVMTimelineFlags', () {
-        expect(
-            () => service.setVMTimelineFlags(null), throwsUnimplementedError);
+        expect(() => service.setVMTimelineFlags(null), throwsRPCError);
       });
     });
 
@@ -327,13 +328,11 @@ void main() {
     });
 
     test('getAllocationProfile', () {
-      expect(
-          () => service.getAllocationProfile(null), throwsUnimplementedError);
+      expect(() => service.getAllocationProfile(null), throwsRPCError);
     });
 
     test('getClassList', () {
-      expect(() => service.getClassList(null),
-          throwsA(const TypeMatcher<RPCError>()));
+      expect(() => service.getClassList(null), throwsRPCError);
     });
 
     test('getFlagList', () async {
@@ -341,8 +340,7 @@ void main() {
     });
 
     test('getInstances', () {
-      expect(() => service.getInstances(null, null, null),
-          throwsUnimplementedError);
+      expect(() => service.getInstances(null, null, null), throwsRPCError);
     });
 
     group('getIsolate', () {
@@ -633,7 +631,7 @@ void main() {
         var isolateId = vm.isolates.first.id;
 
         expect(() => service.getSourceReport(isolateId, ['Coverage']),
-            throwsA(isA<RPCError>()));
+            throwsRPCError);
       });
 
       test('report type not understood', () async {
@@ -641,7 +639,7 @@ void main() {
         var isolateId = vm.isolates.first.id;
 
         expect(() => service.getSourceReport(isolateId, ['FooBar']),
-            throwsA(isA<RPCError>()));
+            throwsRPCError);
       });
 
       test('PossibleBreakpoints report', () async {
@@ -996,7 +994,7 @@ void main() {
     });
 
     test('kill', () {
-      expect(() => service.kill(null), throwsUnimplementedError);
+      expect(() => service.kill(null), throwsRPCError);
     });
 
     test('onEvent', () {
@@ -1032,23 +1030,21 @@ void main() {
     });
 
     test('getInboundReferences', () async {
-      expect(() => service.getInboundReferences(null, null, null),
-          throwsUnimplementedError);
+      expect(
+          () => service.getInboundReferences(null, null, null), throwsRPCError);
     });
 
     test('getRetainingPath', () async {
-      expect(() => service.getRetainingPath(null, null, null),
-          throwsUnimplementedError);
+      expect(() => service.getRetainingPath(null, null, null), throwsRPCError);
     });
 
     test('registerService', () async {
-      expect(() => service.registerService('ext.foo.bar', null),
-          throwsUnimplementedError);
+      expect(
+          () => service.registerService('ext.foo.bar', null), throwsRPCError);
     });
 
     test('reloadSources', () {
-      expect(() => service.reloadSources(null),
-          throwsA(const TypeMatcher<RPCError>()));
+      expect(() => service.reloadSources(null), throwsRPCError);
     });
 
     test('setExceptionPauseMode', () async {
@@ -1065,12 +1061,12 @@ void main() {
     });
 
     test('setFlag', () {
-      expect(() => service.setFlag(null, null), throwsUnimplementedError);
+      expect(() => service.setFlag(null, null), throwsRPCError);
     });
 
     test('setLibraryDebuggable', () {
-      expect(() => service.setLibraryDebuggable(null, null, null),
-          throwsUnimplementedError);
+      expect(
+          () => service.setLibraryDebuggable(null, null, null), throwsRPCError);
     });
 
     test('setName', () async {
@@ -1088,7 +1084,7 @@ void main() {
     });
 
     test('streamCancel', () {
-      expect(() => service.streamCancel(null), throwsUnimplementedError);
+      expect(() => service.streamCancel(null), throwsRPCError);
     });
 
     group('streamListen/onEvent', () {


### PR DESCRIPTION
- return RPCError.kMethodNotFound from unimplemented methods
- fix https://github.com/dart-lang/webdev/issues/781

