### PR TITLE
Fix hot reloads

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 5.0.0-dev
+## 5.0.0
 
 - Have unimplemented VM service protocol methods return the RPC error
   'MethodNotFound' / `-32601`.
+- Fix an issue where the application main function was called before a
+  hot restart completed.
+- Breaking change `AssetReader` now requires a `metadataContents` implementation.
 
 ## 4.0.1
 

--- a/dwds/lib/src/injected/client.js
+++ b/dwds/lib/src/injected/client.js
@@ -22718,6 +22718,7 @@
               result = $async$result;
               t1 = self.$loadModuleConfig.call$1("dart_sdk").dart;
               t1.hotRestart.apply(t1, H.setRuntimeTypeInfo([], t2));
+              V.runMain();
               $async$returnValue = result;
               // goto return
               $async$goto = 1;
@@ -22895,7 +22896,6 @@
             case 11:
               // after for
               P.print(H.S(reloadedModules) + " module(s) were hot-reloaded.");
-              V.runMain();
               $async$self._running.complete$1(0, true);
               $async$handler = 2;
               // goto after finally

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.0.0-dev';
+const packageVersion = '5.0.0';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 5.0.0-dev
+version: 5.0.0
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/web/reloader/require_restarter.dart
+++ b/dwds/web/reloader/require_restarter.dart
@@ -124,6 +124,7 @@ class RequireRestarter implements Restarter {
       _updateGraph();
       var result = await _reload(modulesToLoad);
       callMethod(getProperty(require('dart_sdk'), 'dart'), 'hotRestart', []);
+      runMain();
       return result;
     }
 
@@ -206,7 +207,6 @@ class RequireRestarter implements Restarter {
         }
       }
       print('$reloadedModules module(s) were hot-reloaded.');
-      runMain();
       _running.complete(true);
     } on HotReloadFailedException catch (e) {
       print('Error during script reloading. Firing full page reload. $e');


### PR DESCRIPTION
The main function was prematurely called for a hot reload which could cause errors specifically with Flutter Web. Wait until after we call DDC's hot reload to call main.

Prepare for release and add missing changelog for:
https://github.com/dart-lang/webdev/pull/1055

Towards https://github.com/flutter/flutter/issues/59718