### PR TITLE
Hot Restart with no changed modules

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.1
+
+- Ensure we run main on a hot restart request even if no modules were
+  updated. 
+
+
 ## 5.0.0
 
 - Have unimplemented VM service protocol methods return the RPC error

--- a/dwds/lib/src/injected/client.js
+++ b/dwds/lib/src/injected/client.js
@@ -22686,28 +22686,28 @@
                   C.JSArray_methods.add$1(modulesToLoad, t4);
                 }
               }
-              $async$goto = modulesToLoad.length !== 0 ? 7 : 8;
+              $async$goto = modulesToLoad.length !== 0 ? 7 : 9;
               break;
             case 7:
               // then
               $async$self._updateGraph$0();
-              $async$goto = 9;
+              $async$goto = 10;
               return P._asyncAwait($async$self._reload$1(modulesToLoad), $async$restart$0);
-            case 9:
+            case 10:
               // returning from await.
               result = $async$result;
-              t1 = self.$loadModuleConfig.call$1("dart_sdk").dart;
-              t1.hotRestart.apply(t1, H.setRuntimeTypeInfo([], t2));
-              V.runMain();
-              $async$returnValue = result;
-              // goto return
-              $async$goto = 1;
+              // goto join
+              $async$goto = 8;
               break;
+            case 9:
+              // else
+              result = true;
             case 8:
               // join
               t1 = self.$loadModuleConfig.call$1("dart_sdk").dart;
               t1.hotRestart.apply(t1, H.setRuntimeTypeInfo([], t2));
-              $async$returnValue = true;
+              V.runMain();
+              $async$returnValue = result;
               // goto return
               $async$goto = 1;
               break;

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.0.0';
+const packageVersion = '5.0.1';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 5.0.0
+version: 5.0.1
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/web/reloader/require_restarter.dart
+++ b/dwds/web/reloader/require_restarter.dart
@@ -120,16 +120,15 @@ class RequireRestarter implements Restarter {
       }
     }
 
+    var result = true;
     if (modulesToLoad.isNotEmpty) {
       _updateGraph();
-      var result = await _reload(modulesToLoad);
-      callMethod(getProperty(require('dart_sdk'), 'dart'), 'hotRestart', []);
-      runMain();
-      return result;
+      result = await _reload(modulesToLoad);
     }
 
     callMethod(getProperty(require('dart_sdk'), 'dart'), 'hotRestart', []);
-    return true;
+    runMain();
+    return result;
   }
 
   List<String> _allModules() => keys(requireLoader.moduleParentsGraph);


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/60273

We previously used to call `runMain` on the server side after a `hotRestart` request. This resulted in the main method getting requested even with no module updates. We [aligned](https://github.com/dart-lang/webdev/pull/997) the `legacy` and the `require` module strategies to call `runMain` on the client side as a part of the `hotRestar` request. This resulted in the linked issue above.