### PR TITLE
Update dwds version/changelog for WebSocket support in debug backend

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.1.0-dev
+
+- Support using WebSockets for the debug backend by passing
+  `useSseForDebugBackend: false` to `Dwds.start()`
+
 ## 5.0.0
 
 - Have unimplemented VM service protocol methods return the RPC error

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.0.0';
+const packageVersion = '5.1.0-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 5.0.0
+version: 5.1.0-dev
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM


### PR DESCRIPTION
@grouma I noticed I'd only updated changelog/version for the Chrome extension in #1067, and not dwds. Wasn't sure whether to include `-dev` here or not though!