### PR TITLE
Set breakpoints by regex URL

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 **Breaking Changes:**
 - Require access to the `.ddc_merged_metadata` file.
+- Remove deprecated parameter `restoreBreakpoints` as breakpoints are now
+  set by regex URL and Chrome automatically reestablishes them.
 
 ## 5.0.0
 

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -93,7 +93,6 @@ class Dwds {
     // TODO(annagrin): make expressionCompiler argument required
     // [issue 881](https://github.com/dart-lang/webdev/issues/881)
     ExpressionCompiler expressionCompiler,
-    @deprecated bool restoreBreakpoints,
   }) async {
     hostname ??= 'localhost';
     enableDebugging ??= true;
@@ -104,7 +103,6 @@ class Dwds {
     logWriter ??= (level, message) => print(message);
     verbose ??= false;
     globalLoadStrategy = loadStrategy;
-    restoreBreakpoints ??= false;
 
     DevTools devTools;
     String extensionUri;
@@ -148,7 +146,6 @@ class Dwds {
       logWriter,
       extensionBackend,
       urlEncoder,
-      restoreBreakpoints,
       useSseForDebugProxy,
       serveDevTools,
       expressionCompiler,

--- a/dwds/lib/src/debugging/location.dart
+++ b/dwds/lib/src/debugging/location.dart
@@ -21,16 +21,20 @@ class Location {
 
   final DartLocation dartLocation;
 
+  final String modulePath;
+
   /// An arbitrary integer value used to represent this location.
   final int tokenPos;
 
   Location._(
     this.jsLocation,
     this.dartLocation,
+    this.modulePath,
   ) : tokenPos = _startTokenId++;
 
   static Location from(
     String scriptId,
+    String modulePath,
     TargetLineEntry lineEntry,
     TargetEntry entry,
     DartUri dartUri,
@@ -41,8 +45,11 @@ class Location {
     var jsColumn = entry.column;
     // lineEntry data is 0 based according to:
     // https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k
-    return Location._(JsLocation.fromZeroBased(scriptId, jsLine, jsColumn),
-        DartLocation.fromZeroBased(dartUri, dartLine, dartColumn));
+    return Location._(
+      JsLocation.fromZeroBased(scriptId, jsLine, jsColumn),
+      DartLocation.fromZeroBased(dartUri, dartLine, dartColumn),
+      modulePath,
+    );
   }
 
   @override
@@ -259,6 +266,7 @@ class Locations {
           var dartUri = DartUri(path, _root);
           result.add(Location.from(
             scriptId,
+            modulePath,
             lineEntry,
             entry,
             dartUri,

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -63,7 +63,6 @@ class DevHandler {
   final StreamController<DebugConnection> extensionDebugConnections =
       StreamController<DebugConnection>();
   final UrlEncoder _urlEncoder;
-  final bool _restoreBreakpoints;
   final bool _useSseForDebugProxy;
   final bool _serveDevTools;
   final ExpressionCompiler _expressionCompiler;
@@ -87,7 +86,6 @@ class DevHandler {
       this._logWriter,
       this._extensionBackend,
       this._urlEncoder,
-      this._restoreBreakpoints,
       this._useSseForDebugProxy,
       this._serveDevTools,
       this._expressionCompiler,
@@ -197,7 +195,6 @@ class DevHandler {
       metadataProvider,
       appConnection,
       _logWriter,
-      _restoreBreakpoints,
       onResponse: (response) {
         if (_verbose) {
           if (response['error'] == null) return;
@@ -473,7 +470,6 @@ class DevHandler {
             metadataProvider,
             connection,
             _logWriter,
-            _restoreBreakpoints,
             onResponse: _verbose
                 ? (response) {
                     if (response['error'] == null) return;

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -224,16 +224,9 @@ class ChromeProxyService implements VmServiceInterface {
   }
 
   Future<void> _refreshBreakpoints() async {
-    await (await _debugger).reestablishBreakpoints(_previousBreakpoints, uri);
-
-    for (var breakpoint in _disabledBreakpoints) {
-      var lineNumber = lineNumberFor(breakpoint);
-      var oldRef = (breakpoint.location as SourceLocation).script;
-      var dartUri = DartUri(oldRef.uri, uri);
-      var newRef = await _inspector.scriptRefFor(dartUri.serverPath);
-      await (await _debugger)
-          .addBreakpoint(_inspector.isolate.id, newRef.id, lineNumber);
-    }
+    await (await _debugger)
+        .reestablishBreakpoints(_previousBreakpoints, _disabledBreakpoints);
+    _disabledBreakpoints.clear();
     _disabledBreakpoints.clear();
   }
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -227,7 +227,6 @@ class ChromeProxyService implements VmServiceInterface {
     await (await _debugger)
         .reestablishBreakpoints(_previousBreakpoints, _disabledBreakpoints);
     _disabledBreakpoints.clear();
-    _disabledBreakpoints.clear();
   }
 
   /// Should be called when there is a hot restart or full page refresh.

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -179,7 +179,9 @@ class ChromeProxyService implements VmServiceInterface {
       executionContext,
     );
 
-    await _refreshBreakpoints();
+    await (await _debugger)
+        .reestablishBreakpoints(_previousBreakpoints, _disabledBreakpoints);
+    _disabledBreakpoints.clear();
 
     unawaited(appConnection.onStart.then((_) async {
       await (await _debugger).resumeFromStart();
@@ -221,12 +223,6 @@ class ChromeProxyService implements VmServiceInterface {
 
     // The service is considered initialized when the first isolate is created.
     if (!_initializedCompleter.isCompleted) _initializedCompleter.complete();
-  }
-
-  Future<void> _refreshBreakpoints() async {
-    await (await _debugger)
-        .reestablishBreakpoints(_previousBreakpoints, _disabledBreakpoints);
-    _disabledBreakpoints.clear();
   }
 
   /// Should be called when there is a hot restart or full page refresh.

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -179,7 +179,7 @@ class ChromeProxyService implements VmServiceInterface {
       executionContext,
     );
 
-    (await _debugger).reestablishBreakpoints(_previousBreakpoints, uri);
+    await (await _debugger).reestablishBreakpoints(_previousBreakpoints, uri);
 
     unawaited(appConnection.onStart.then((_) async {
       await (await _debugger).resumeFromStart();

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -134,7 +134,6 @@ class DebugService {
       MetadataProvider metadataProvider,
       AppConnection appConnection,
       LogWriter logWriter,
-      bool restoreBreakpoints,
       {void Function(Map<String, dynamic>) onRequest,
       void Function(Map<String, dynamic>) onResponse,
       bool useSse,
@@ -148,7 +147,6 @@ class DebugService {
         metadataProvider,
         appConnection,
         logWriter,
-        restoreBreakpoints,
         executionContext,
         expressionCompiler);
     var authToken = _makeAuthToken();

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -58,6 +58,7 @@ void main() async {
     var lineEntry = TargetLineEntry(92, [entry]);
     var location = Location.from(
       'foo.dart',
+      'foo.ddc.js',
       lineEntry,
       entry,
       DartUri('package:foo/foo.dart'),

--- a/dwds/test/fixtures/server.dart
+++ b/dwds/test/fixtures/server.dart
@@ -106,8 +106,6 @@ class TestServer {
       hostname: hostname,
       verbose: true,
       urlEncoder: urlEncoder,
-      // ignore: deprecated_member_use_from_same_package
-      restoreBreakpoints: restoreBreakpoints,
       expressionCompiler: expressionCompiler,
     );
 

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -182,7 +182,8 @@ void main() {
       isolateId = vm.isolates.first.id;
       var isolate = await client.getIsolate(isolateId);
       expect(isolate.pauseEvent.kind, EventKind.kResume);
-      expect(isolate.breakpoints.isEmpty, isTrue);
+      // Previous breakpoint should still exist.
+      expect(isolate.breakpoints.isNotEmpty, isTrue);
     });
   });
 


### PR DESCRIPTION
- Use `setBreakpointsByUrl` to set breakpoints using a regex based on the module path
- Chrome now handles re-establishing breakpoints upon refresh so remove the corresponding deprecated argument

Closes https://github.com/dart-lang/webdev/issues/1076