### PR TITLE
remove file dependency

### DIFF
--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   # devtools_server indirectly depends on devtools so keep this around.
   devtools: ^0.8.0
   devtools_server: ^0.8.0
-  file: ^5.1.0
   http: ^0.12.0
   http_multi_server: ^2.0.0
   logging: ^0.11.3

--- a/frontend_server_client/pubspec.yaml
+++ b/frontend_server_client/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   meta: ^1.1.0
   path: ^1.7.0
   uuid: ^2.0.0
+  file: ^5.1.0
 dev_dependencies:
   package_config: ^1.9.2
   shelf: ^0.7.5

--- a/frontend_server_common/pubspec.yaml
+++ b/frontend_server_common/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
+  file: ^5.1.0
   dwds:
     path: ../dwds
 


### PR DESCRIPTION
The dependency on file will block the roll to null-safe file, process, platform deps in the Flutter SDK, which required a major version bump due to the removal of record/replay functionality.

If this package was being used, it would be safe to increase the range to <= 7.0.0, but there were no uses I could find.