### PR TITLE
Reduce devtools_test.dart flakiness

### DIFF
--- a/dwds/test/devtools_test.dart
+++ b/dwds/test/devtools_test.dart
@@ -14,6 +14,19 @@ final context = TestContext(
   path: 'append_body/index.html',
 );
 
+Future<Alert> _waitForAlert(TestContext context) async {
+  Alert alert;
+  var attempts = 5;
+  while (attempts-- >= 0) {
+    try {
+      alert = context.webDriver.driver.switchTo.alert;
+      break;
+    } catch (_) {}
+    await Future.delayed(const Duration(seconds: 2));
+  }
+  return alert;
+}
+
 void main() {
   group('Injected client', () {
     setUp(() async {
@@ -49,8 +62,7 @@ void main() {
 
       // Try to open devtools and check for the alert.
       await context.webDriver.driver.keyboard.sendChord([Keyboard.alt, 'd']);
-      await Future.delayed(const Duration(seconds: 2));
-      var alert = context.webDriver.driver.switchTo.alert;
+      var alert = await _waitForAlert(context);
       expect(alert, isNotNull);
       expect(await alert.text,
           contains('This app is already being debugged in a different tab'));

--- a/dwds/test/devtools_test.dart
+++ b/dwds/test/devtools_test.dart
@@ -18,7 +18,7 @@ Future<void> _waitForPageReady(TestContext context) async {
   var attempt = 100;
   while (attempt-- > 0) {
     var content = await context.webDriver.pageSource;
-    if (content.contains('Hello World!')) break;
+    if (content.contains('Hello World!')) return;
     await Future.delayed(const Duration(milliseconds: 100));
   }
   throw StateError('Page never initialized');

--- a/dwds/test/devtools_test.dart
+++ b/dwds/test/devtools_test.dart
@@ -16,13 +16,13 @@ final context = TestContext(
 
 Future<Alert> _waitForAlert(TestContext context) async {
   Alert alert;
-  var attempts = 5;
+  var attempts = 100;
   while (attempts-- >= 0) {
     try {
       alert = context.webDriver.driver.switchTo.alert;
       break;
     } catch (_) {}
-    await Future.delayed(const Duration(seconds: 2));
+    await Future.delayed(const Duration(milliseconds: 100));
   }
   return alert;
 }


### PR DESCRIPTION
The `can not launch devtools for the same app in multiple tabs` test appears to be flaky because we attempt to launch DevTools before the page is fully loaded. There isn't a good asynchronous signal for this so as an alternative we wait for the page content to say `Hello World!`. This  closes https://github.com/dart-lang/webdev/issues/1084.