### PR TITLE
Custom blackbox logic

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.1.0-dev
+
+- We no longer leverage the Chrome DevTools blackbox logic to black box
+  the Dart SDK. Instead we use our own custom black box logic.
+
 ## 6.0.0
 
 - Depend on the latest `package:devtools` and `package:devtools_server`.

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -535,6 +535,7 @@ class Debugger extends Domain {
       // before resorting to stepping out.
       if (_isStepping && (await _sourceLocation(e)) == null) {
         if (_stepInCount > _maxStepInCount) {
+          _stepInCount = 0;
           await _remoteDebugger.stepOut();
         } else {
           _stepInCount++;

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -13,7 +13,6 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     hide StackTrace;
 
 import '../loaders/strategy.dart';
-import '../readers/asset_reader.dart';
 import '../services/chrome_proxy_service.dart';
 import '../utilities/conversions.dart';
 import '../utilities/dart_uri.dart';
@@ -36,16 +35,12 @@ const _pauseModePauseStates = {
   'unhandled': PauseState.uncaught,
 };
 
-/// Paths to black box in the Chrome debugger.
-const _pathsToBlackBox = {'/packages/stack_trace/'};
-
 class Debugger extends Domain {
   static final logger = Logger('Debugger');
 
   final RemoteDebugger _remoteDebugger;
 
   final StreamNotify _streamNotify;
-  final AssetReader _assetReader;
   final Modules _modules;
   final Locations _locations;
   final String _root;
@@ -54,7 +49,6 @@ class Debugger extends Domain {
     this._remoteDebugger,
     this._streamNotify,
     AppInspectorProvider provider,
-    this._assetReader,
     this._modules,
     this._locations,
     this._root,
@@ -160,7 +154,6 @@ class Debugger extends Domain {
     RemoteDebugger remoteDebugger,
     StreamNotify streamNotify,
     AppInspectorProvider appInspectorProvider,
-    AssetReader assetReader,
     Modules modules,
     Locations locations,
     String root,
@@ -169,7 +162,6 @@ class Debugger extends Domain {
       remoteDebugger,
       streamNotify,
       appInspectorProvider,
-      assetReader,
       modules,
       locations,
       root,
@@ -184,7 +176,6 @@ class Debugger extends Domain {
     // Allow a null debugger/connection for unit tests.
     runZoned(() {
       _remoteDebugger?.onScriptParsed?.listen((e) {
-        _blackBoxIfNecessary(e.script);
         _modules.noteModule(e.script.url, e.script.scriptId);
       });
       _remoteDebugger?.onPaused?.listen(_pauseHandler);
@@ -201,52 +192,6 @@ class Debugger extends Domain {
         ?.sendCommand('Debugger.setAsyncCallStackDepth', params: {
       'maxDepth': 128,
     }));
-  }
-
-  /// Black boxes the Dart SDK and paths in [_pathsToBlackBox].
-  Future<void> _blackBoxIfNecessary(WipScript script) async {
-    // Ignore query parameters.
-    var url = script.url?.split('?')?.first ?? '';
-    if (url.endsWith('dart_sdk.js') || url.endsWith('dart_sdk.ddk.js')) {
-      await _blackBoxSdk(script);
-    } else if (_pathsToBlackBox.any(url.contains)) {
-      var content =
-          await _assetReader.dartSourceContents(DartUri(url).serverPath);
-      if (content == null) return;
-      var lines = content.split('\n');
-      await _blackBoxRanges(script.scriptId, [lines.length]);
-    }
-  }
-
-  /// Black boxes the SDK excluding the range which includes exception logic.
-  Future<void> _blackBoxSdk(WipScript script) async {
-    var content =
-        await _assetReader.dartSourceContents(DartUri(script.url).serverPath);
-    if (content == null) return;
-    var sdkSourceLines = content.split('\n');
-    // TODO(grouma) - Find a more robust way to identify this location.
-    var throwIndex = sdkSourceLines.indexWhere(
-        (line) => line.contains('dart.throw = function throw_(exception) {'));
-    if (throwIndex != -1) {
-      await _blackBoxRanges(script.scriptId, [throwIndex, throwIndex + 6]);
-    }
-  }
-
-  Future<void> _blackBoxRanges(String scriptId, List<int> lineNumbers) async {
-    try {
-      await _remoteDebugger
-          .sendCommand('Debugger.setBlackboxedRanges', params: {
-        'scriptId': scriptId,
-        'positions': [
-          {'lineNumber': 0, 'columnNumber': 0},
-          for (var line in lineNumbers) {'lineNumber': line, 'columnNumber': 0},
-        ]
-      });
-    } catch (_) {
-      // Attempting to set ranges immediately after a refresh can cause issues
-      // as the corresponding script will no longer exist. Silently ignore
-      // these failures.
-    }
   }
 
   /// Resumes the Isolate from start.
@@ -523,6 +468,13 @@ class Debugger extends Domain {
     return dartFrame;
   }
 
+  // The current number of 'step-in's into locations without source information.
+  var _stepInCount = 0;
+
+  // The maximum number of steps into locations without source information
+  // before we begin stepping out.
+  final _maxStepInCount = 5;
+
   /// Handles pause events coming from the Chrome connection.
   Future<void> _pauseHandler(DebuggerPausedEvent e) async {
     if (inspector == null) return;
@@ -579,11 +531,18 @@ class Debugger extends Domain {
         exception: exception,
       );
     } else {
-      // If we don't have source location continue stepping.
+      // If we don't have a source location, try to step in several times
+      // before resorting to stepping out.
       if (_isStepping && (await _sourceLocation(e)) == null) {
-        await _remoteDebugger.stepInto();
+        if (_stepInCount > _maxStepInCount) {
+          await _remoteDebugger.stepOut();
+        } else {
+          _stepInCount++;
+          await _remoteDebugger.stepInto();
+        }
         return;
       }
+      _stepInCount = 0;
       event = Event(
           kind: EventKind.kPauseInterrupted,
           timestamp: timestamp,

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -468,12 +468,12 @@ class Debugger extends Domain {
     return dartFrame;
   }
 
-  // The current number of 'step-in's into locations without source information.
+  // The current number of steps into locations without source information.
   var _stepInCount = 0;
 
   // The maximum number of steps into locations without source information
-  // before we begin stepping out.
-  final _maxStepInCount = 10;
+  // before we step out.
+  final _maxStepInCount = 7;
 
   /// Handles pause events coming from the Chrome connection.
   Future<void> _pauseHandler(DebuggerPausedEvent e) async {

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -473,7 +473,7 @@ class Debugger extends Domain {
 
   // The maximum number of steps into locations without source information
   // before we begin stepping out.
-  final _maxStepInCount = 5;
+  final _maxStepInCount = 10;
 
   /// Handles pause events coming from the Chrome connection.
   Future<void> _pauseHandler(DebuggerPausedEvent e) async {

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -101,7 +101,6 @@ class ChromeProxyService implements VmServiceInterface {
       remoteDebugger,
       _streamNotify,
       appInspectorProvider,
-      _assetReader,
       _modules,
       _locations,
       uri,

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.0.0';
+const packageVersion = '6.1.0-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 6.0.0
+version: 6.1.0-dev
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -38,7 +38,6 @@ void main() async {
       null,
       () => inspector,
       null,
-      null,
       locations,
       root,
     );


### PR DESCRIPTION
Long term we would like to remove our dependency on Chrome `scriptId`s. This will ultimately improve the DevTools IPL as we can forgo passing script parsed events. The first step to removing this dependency is to update the blackbox logic. Instead of relying on Chrome's logic, implement our own custom heuristic. Manual testing shows that this approach is performant enough but long term we may want to pester the Chrome team for an API that does not rely on `scriptId`s.