### PR TITLE
Add initial DDS support

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Add support for the Dart Development Service (DDS). Introduces 'single
+  client mode', which prevents additional direct connections to DWDS when
+  DDS is connected.
+
 ## 6.0.0
 
 - Depend on the latest `package:devtools` and `package:devtools_server`.

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -100,6 +100,12 @@ class DwdsVmClient {
     });
     await client.registerService('ext.dwds.screenshot', 'DWDS');
 
+    // TODO(#1091) add support for single client mode.
+    client.registerServiceCallback('_yieldControlToDDS', (_) async {
+      return {'result': Success().toJson()};
+    });
+    await client.registerService('_yieldControlToDDS', 'DWDS');
+
     return DwdsVmClient(client, requestController, responseController);
   }
 }

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -21,6 +21,9 @@ class DwdsVmClient {
   final StreamController<Map<String, Object>> _requestController;
   final StreamController<Map<String, Object>> _responseController;
 
+  static const int kFeatureDisabled = 100;
+  static const String kFeatureDisabledMessage = 'Feature is disabled.';
+
   /// Null until [close] is called.
   ///
   /// All subsequent calls to [close] will return this future.
@@ -100,9 +103,25 @@ class DwdsVmClient {
     });
     await client.registerService('ext.dwds.screenshot', 'DWDS');
 
-    // TODO(#1091) add support for single client mode.
-    client.registerServiceCallback('_yieldControlToDDS', (_) async {
-      return {'result': Success().toJson()};
+    client.registerServiceCallback('_yieldControlToDDS', (request) async {
+      final ddsUri = request['uri'] as String;
+      if (ddsUri == null) {
+        return RPCError(
+          request['method'] as String,
+          RPCError.kInvalidParams,
+          "'Missing parameter: 'uri'",
+        ).toMap();
+      }
+      return DebugService.yieldControlToDDS(ddsUri)
+          ? {'result': Success().toJson()}
+          : {
+              'error': {
+                'code': kFeatureDisabled,
+                'message': kFeatureDisabledMessage,
+                'details':
+                    'Existing VM service clients prevent DDS from taking control.',
+              },
+            };
     });
     await client.registerService('_yieldControlToDDS', 'DWDS');
 


### PR DESCRIPTION
Creates a service extension, `_yieldControlToDDS`, which always returns
`Success`. This extension should place DWDS in single client mode so VM
service clients are required to connect through DDS.

See https://github.com/dart-lang/webdev/issues/1091