### PR TITLE
Remove frame dependency on ScriptID

### DIFF
--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -23,7 +23,6 @@ import '../utilities/shared.dart';
 import 'dart_scope.dart';
 import 'frame_computer.dart';
 import 'location.dart';
-import 'modules.dart';
 import 'remote_debugger.dart';
 
 /// Converts from ExceptionPauseMode strings to [PauseState] enums.
@@ -46,7 +45,6 @@ class Debugger extends Domain {
 
   final StreamNotify _streamNotify;
   final AssetReader _assetReader;
-  final Modules _modules;
   final Locations _locations;
   final String _root;
 
@@ -55,7 +53,6 @@ class Debugger extends Domain {
     this._streamNotify,
     AppInspectorProvider provider,
     this._assetReader,
-    this._modules,
     this._locations,
     this._root,
   )   : _breakpoints = _Breakpoints(
@@ -161,7 +158,6 @@ class Debugger extends Domain {
     StreamNotify streamNotify,
     AppInspectorProvider appInspectorProvider,
     AssetReader assetReader,
-    Modules modules,
     Locations locations,
     String root,
   ) async {
@@ -170,7 +166,6 @@ class Debugger extends Domain {
       streamNotify,
       appInspectorProvider,
       assetReader,
-      modules,
       locations,
       root,
     );

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -185,7 +185,6 @@ class Debugger extends Domain {
     runZoned(() {
       _remoteDebugger?.onScriptParsed?.listen((e) {
         _blackBoxIfNecessary(e.script);
-        _modules.noteModule(e.script.url, e.script.scriptId);
       });
       _remoteDebugger?.onPaused?.listen(_pauseHandler);
       _remoteDebugger?.onResumed?.listen(_resumeHandler);
@@ -361,9 +360,8 @@ class Debugger extends Domain {
   Future<Location> _sourceLocation(DebuggerPausedEvent e) {
     var frame = e.params['callFrames'][0];
     var location = frame['location'];
-    var jsLocation = JsLocation.fromZeroBased(location['scriptId'] as String,
-        location['lineNumber'] as int, location['columnNumber'] as int);
-    return _locations.locationForJs(jsLocation.scriptId, jsLocation.line);
+    return _locations.locationForJs(
+        frame['url'] as String, (location['lineNumber'] as int) + 1);
   }
 
   /// The variables visible in a frame in Dart protocol [BoundVariable] form.
@@ -477,16 +475,16 @@ class Debugger extends Domain {
   }) async {
     var location = frame.location;
     // Chrome is 0 based. Account for this.
-    var jsLocation = JsLocation.fromZeroBased(
-        location.scriptId, location.lineNumber, location.columnNumber);
+    var line = location.lineNumber + 1;
+    var column = location.columnNumber + 1;
     // TODO(sdk/issues/37240) - ideally we look for an exact location instead
     // of the closest location on a given line.
     Location bestLocation;
-    for (var location in await _locations.locationsForJs(jsLocation.scriptId)) {
-      if (location.jsLocation.line == jsLocation.line) {
+    for (var location in await _locations.locationsForUrl(frame.url)) {
+      if (location.jsLocation.line == line) {
         bestLocation ??= location;
-        if ((location.jsLocation.column - jsLocation.column).abs() <
-            (bestLocation.jsLocation.column - jsLocation.column).abs()) {
+        if ((location.jsLocation.column - column).abs() <
+            (bestLocation.jsLocation.column - column).abs()) {
           bestLocation = location;
         }
       }
@@ -736,7 +734,7 @@ class _Breakpoints extends Domain {
     // https://chromedevtools.github.io/devtools-protocol/tot/Debugger#type-Location
 
     // The module can be loaded from a nested path and contain an ETAG suffix.
-    var urlRegex = '.*${location.modulePath}.*';
+    var urlRegex = '.*${location.jsLocation.module}.*';
     var response = await remoteDebugger
         .sendCommand('Debugger.setBreakpointByUrl', params: {
       'urlRegex': urlRegex,

--- a/dwds/lib/src/debugging/frame_computer.dart
+++ b/dwds/lib/src/debugging/frame_computer.dart
@@ -90,6 +90,7 @@ class FrameComputer {
           callFrame.scriptId, callFrame.lineNumber,
           columnNumber: callFrame.columnNumber);
       var tempWipFrame = WipCallFrame({
+        'url': callFrame.url,
         'functionName': callFrame.functionName,
         'location': location.json,
         'scopeChain': [],

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -406,7 +406,7 @@ function($argsString) {
     final dartUri = DartUri(scriptRef.uri, _root);
     final mappedLocations =
         await _locations.locationsForDart(dartUri.serverPath);
-    // Unlike the Dart VM, the tokem positions match exactly to the possible
+    // Unlike the Dart VM, the token positions match exactly to the possible
     // breakpoints. This is because the token positions are derived from the
     // DDC source maps which Chrome also uses.
     var tokenPositions = <int>[

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -404,31 +404,14 @@ function($argsString) {
     }
 
     final dartUri = DartUri(scriptRef.uri, _root);
-    final jsModule =
-        await _locations.modules.moduleForSource(dartUri.serverPath);
-    final jsScriptId = _locations.modules.scriptIdForModule(jsModule);
-
-    final possibleLocations = await remoteDebugger
-        .getPossibleBreakpoints(WipLocation.fromValues(jsScriptId, 0));
-
     final mappedLocations =
         await _locations.locationsForDart(dartUri.serverPath);
-
-    // Currently, there's not exact alignment between the source map information
-    // that DDC generates and the locations that V8 believes are executable.
-    // The 'possible breakpoints' source report is currently used by clients in
-    // order to visualize the lines at which the user can set breakpoints. In
-    // order to not under report or over report lines, we don't try and look for
-    // exact matches here, but instead report all DDC token position for lines
-    // where V8 thinks there is something executable.
-    final jsLines =
-        Set<int>.from(possibleLocations.map((loc) => loc.lineNumber + 1));
-    var tokenPositions = <int>[];
-    for (var location in mappedLocations) {
-      if (jsLines.contains(location.jsLocation.line)) {
-        tokenPositions.add(location.tokenPos);
-      }
-    }
+    // Unlike the Dart VM, the tokem positions match exactly to the possible
+    // breakpoints. This is because the token positions are derived from the
+    // DDC source maps which Chrome also uses.
+    var tokenPositions = <int>[
+      for (var location in mappedLocations) location.tokenPos
+    ];
     tokenPositions.sort();
 
     final range = SourceReportRange(

--- a/dwds/lib/src/debugging/modules.dart
+++ b/dwds/lib/src/debugging/modules.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:async/async.dart';
 
-import '../loaders/strategy.dart';
 import '../utilities/dart_uri.dart';
 import 'metadata/provider.dart';
 
@@ -24,9 +23,6 @@ class Modules {
 
   // The Chrome script ID to corresponding module.
   final _scriptIdToModule = <String, String>{};
-
-  // The module to corresponding Chrome script ID.
-  final _moduleToScriptId = <String, String>{};
 
   Modules(this._metadataProvider, String root)
       : _root = root == '' ? '/' : root;
@@ -46,9 +42,6 @@ class Modules {
   /// Returns the module for the Chrome script ID.
   String moduleForScriptId(String scriptId) => _scriptIdToModule[scriptId];
 
-  /// Returns the Chrome script ID for the provided module.
-  String scriptIdForModule(String module) => _moduleToScriptId[module];
-
   /// Returns the containing module for the provided Dart server path.
   Future<String> moduleForSource(String serverPath) async {
     await _moduleMemoizer.runOnce(_initializeMapping);
@@ -65,16 +58,6 @@ class Modules {
   Future<Map<String, String>> modules() async {
     await _moduleMemoizer.runOnce(_initializeMapping);
     return _sourceToModule;
-  }
-
-  /// Checks if the [url] correspond to a module and stores meta data.
-  Future<Null> noteModule(String url, String scriptId) async {
-    var path = Uri.parse(url).path;
-    if (path == null) return;
-    var module = globalLoadStrategy.moduleForServerPath(path);
-    if (module == null) return;
-    _scriptIdToModule[scriptId] = module;
-    _moduleToScriptId[module] = scriptId;
   }
 
   /// Initializes [_sourceToModule] and [_sourceToLibrary].

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -102,7 +102,6 @@ class ChromeProxyService implements VmServiceInterface {
       _streamNotify,
       appInspectorProvider,
       _assetReader,
-      _modules,
       _locations,
       uri,
     ));

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -81,11 +81,11 @@ class ExpressionEvaluator {
     }
 
     var functionName = jsFrame.functionName;
-    var jsLocation = JsLocation.fromZeroBased(jsFrame.location.scriptId,
-        jsFrame.location.lineNumber, jsFrame.location.columnNumber);
+
+    var jsLine = jsFrame.location.lineNumber + 1;
 
     _printTrace('Expression evaluator: JS location: '
-        '$functionName, $jsLocation');
+        '$functionName, $jsLine');
 
     var jsScope = await _collectLocalJsScope(jsFrame);
     _printTrace('Expression evaluator: Local JS Scope: $jsScope');
@@ -97,15 +97,15 @@ class ExpressionEvaluator {
     // so this will result in expressions not evaluated in some
     // cases. Invent location matching strategy for those cases.
     // [issue 890](https://github.com/dart-lang/webdev/issues/890)
-    var locationMap =
-        await _locations.locationForJs(jsLocation.scriptId, jsLocation.line);
+    var locationMap = await _locations.locationForJs(jsFrame.url, jsLine);
 
     if (locationMap == null) {
       return _createError(
           ErrorKind.internal,
           'Cannot find Dart location for JS location: '
+          'url: ${jsFrame.url}'
           'function: $functionName, '
-          'location: $jsLocation');
+          'line: $jsLine');
     }
 
     var dartLocation = locationMap.dartLocation;

--- a/dwds/test/dart_uri_test.dart
+++ b/dwds/test/dart_uri_test.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dwds/src/loaders/strategy.dart';
 @TestOn('vm')
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:test/test.dart';
 

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -70,7 +70,6 @@ void main() async {
       null,
       () => inspector,
       null,
-      null,
       locations,
       root,
     );

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -5,12 +5,12 @@
 @TestOn('vm')
 import 'dart:async';
 
+import 'package:dwds/dwds.dart';
 import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/frame_computer.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/debugging/location.dart';
-import 'package:dwds/src/utilities/dart_uri.dart';
-import 'package:source_maps/parser.dart';
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:test/test.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     show DebuggerPausedEvent;
@@ -26,13 +26,45 @@ FakeWebkitDebugger webkitDebugger;
 StreamController<DebuggerPausedEvent> pausedController;
 Locations locations;
 
+class TestStrategy extends FakeStrategy {
+  @override
+  String moduleForServerPath(String appUri) {
+    return 'foo.ddc.js';
+  }
+
+  @override
+  String serverPathForModule(String module) {
+    return 'foo/ddc';
+  }
+}
+
+class FakeAssetReader implements AssetReader {
+  @override
+  Future<String> dartSourceContents(String serverPath) =>
+      throw UnimplementedError();
+
+  @override
+  Future<String> metadataContents(String serverPath) =>
+      throw UnimplementedError();
+
+  @override
+  Future<String> sourceMapContents(String serverPath) async =>
+      '{"version":3,"sourceRoot":"","sources":["main.dart"],"names":[],'
+      '"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAUwB,IAAtB,WAAM;AAKJ,'
+      'IAHF,4BAAkB,aAAa,SAAC,GAAG;AACb,MAApB,WAAM;AACN,YAAgC,+CAAO,AAAK,oBAAO,'
+      'yCAAC,WAAW;IAChE;AAC0D,IAA3D,AAAS,AAAK,0DAAO;AAAe,kBAAO;;;AAEvC,gBAAQ;'
+      'AAGV,IAFI,kCAAqC,QAAC;AACX,MAA/B,WAAM,AAAwB,0BAAP,QAAF,AAAE,KAAK,GAAP;'
+      ';EAEzB","file":"main.ddc.js"}';
+}
+
 void main() async {
   setUpAll(() async {
     webkitDebugger = FakeWebkitDebugger();
     pausedController = StreamController<DebuggerPausedEvent>();
     webkitDebugger.onPaused = pausedController.stream;
+    globalLoadStrategy = TestStrategy();
     var root = 'fakeRoot';
-    locations = Locations(null, FakeModules(), root);
+    locations = Locations(FakeAssetReader(), FakeModules(), root);
     debugger = await Debugger.create(
       webkitDebugger,
       null,
@@ -50,22 +82,6 @@ void main() async {
   test('frames 1', () async {
     // TODO: Generalize this and make it clearer and easier to test
     // different cases.
-
-    // Target entry for Dart source line 12 (zero-based), column 0
-    var entry = TargetEntry(0, 0, 12, 0, 0);
-
-    // Entries for the JS line 92 (zero-based), with just one actual entry
-    var lineEntry = TargetLineEntry(92, [entry]);
-    var location = Location.from(
-      'foo.dart',
-      'foo.ddc.js',
-      lineEntry,
-      entry,
-      DartUri('package:foo/foo.dart'),
-    );
-    // Create a single location in the JS script the location in our hard-coded
-    // frame.
-    locations.noteLocation('dart', location, '69');
 
     var stackComputer = FrameComputer(debugger, frames1);
     var frames = await stackComputer.calculateFrames();

--- a/dwds/test/fixtures/debugger_data.dart
+++ b/dwds/test/fixtures/debugger_data.dart
@@ -24,8 +24,8 @@ List<Map<String, dynamic>> frames1Json = [
       "lineNumber": 88,
       "columnNumber": 72
     },
-    "location": {"scriptId": "69", "lineNumber": 92, "columnNumber": 8},
-    "url": "http://127.0.0.1:8081/scopes_main.ddc.js",
+    "location": {"scriptId": "69", "lineNumber": 37, "columnNumber": 0},
+    "url": "http://127.0.0.1:8081/foo.ddc.js",
     "scopeChain": [
       {
         "type": "local",

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -124,16 +124,6 @@ class FakeModules implements Modules {
   Future<Map<String, String>> modules() {
     throw UnimplementedError();
   }
-
-  @override
-  Future<Null> noteModule(String url, String scriptId) async {
-    throw UnimplementedError();
-  }
-
-  @override
-  String scriptIdForModule(String server) {
-    throw UnimplementedError();
-  }
 }
 
 class FakeWebkitDebugger implements WebkitDebugger {


### PR DESCRIPTION
Sending all `scriptParsedEvent`s is on the critical path for DevTools IPL. These events are used to blackbox the SDK and translate paused frames to Dart. With this change, we no longer need all events, just the `scriptParsedEvent` for the Dart SDK. I'll follow this change by modifying the Dart Debug Extension to only send that single event. 