### PR TITLE
Add capability to spawn a Dart Developer Service instance from DWDS and webdev serve

### DIFF
--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -90,6 +90,7 @@ class Dwds {
     bool verbose,
     UrlEncoder urlEncoder,
     bool useFileProvider = false,
+    bool spawnDds = true,
     // TODO(annagrin): make expressionCompiler argument required
     // [issue 881](https://github.com/dart-lang/webdev/issues/881)
     ExpressionCompiler expressionCompiler,
@@ -150,6 +151,7 @@ class Dwds {
       serveDevTools,
       expressionCompiler,
       injected,
+      spawnDds,
     );
 
     return Dwds._(

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -98,8 +98,12 @@ class AppInspector extends Domain {
     isolate.extensionRPCs.addAll(await _getExtensionRpcs());
   }
 
-  static IsolateRef _toIsolateRef(Isolate isolate) =>
-      IsolateRef(id: isolate.id, name: isolate.name, number: isolate.number);
+  static IsolateRef _toIsolateRef(Isolate isolate) => IsolateRef(
+        id: isolate.id,
+        name: isolate.name,
+        number: isolate.number,
+        isSystemIsolate: isolate.isSystemIsolate,
+      );
 
   static Future<AppInspector> initialize(
     AppConnection appConnection,
@@ -124,11 +128,17 @@ class AppInspector extends Domain {
         pauseEvent: Event(
             kind: EventKind.kPauseStart,
             timestamp: time,
-            isolate: IsolateRef(id: id, name: name, number: id)),
+            isolate: IsolateRef(
+              id: id,
+              name: name,
+              number: id,
+              isSystemIsolate: false,
+            )),
         livePorts: 0,
         libraries: [],
         breakpoints: [],
-        exceptionPauseMode: debugger.pauseState)
+        exceptionPauseMode: debugger.pauseState,
+        isSystemIsolate: false)
       ..extensionRPCs = [];
     AppInspector appInspector;
     var provider = () => appInspector;

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -124,6 +124,8 @@ class ChromeProxyService implements VmServiceInterface {
       version: Platform.version,
       isolates: [],
       isolateGroups: [],
+      systemIsolates: [],
+      systemIsolateGroups: [],
       targetCPU: 'Web',
       hostCPU: 'DWDS',
       architectureBits: -1,
@@ -815,22 +817,6 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   }
 
   @override
-  Future<ClientName> getClientName() {
-    return _rpcNotSupportedFuture('getClientName');
-  }
-
-  @override
-  Future<Success> setClientName(String name) {
-    return _rpcNotSupportedFuture('setClientName');
-  }
-
-  @override
-  Future<Success> requirePermissionToResume(
-      {bool onPauseStart, bool onPauseReload, bool onPauseExit}) {
-    return _rpcNotSupportedFuture('requirePermissionToResume');
-  }
-
-  @override
   Future<ProtocolList> getSupportedProtocols() async {
     var version = semver.Version.parse(vmServiceVersion);
     return ProtocolList(protocols: [
@@ -862,10 +848,6 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   @override
   Future<ProcessMemoryUsage> getProcessMemoryUsage() =>
       _rpcNotSupportedFuture('getProcessMemoryUsage');
-
-  @override
-  Future<WebSocketTarget> getWebSocketTarget() =>
-      _rpcNotSupportedFuture('getWebSocketTarget');
 }
 
 /// The `type`s of [ConsoleAPIEvent]s that are treated as `stderr` logs.

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -144,12 +144,15 @@ class DebugService {
   Future<void> startDartDevelopmentService() async {
     // Note: DDS can handle both web socket and SSE connections with no
     // additional configuration.
-    _dds = await DartDevelopmentService.startDartDevelopmentService(Uri(
-      scheme: 'http',
-      host: hostname,
-      port: port,
-      path: '$authToken',
-    ));
+    _dds = await DartDevelopmentService.startDartDevelopmentService(
+      Uri(
+        scheme: 'http',
+        host: hostname,
+        port: port,
+        path: '$authToken',
+      ),
+      ipv6: await useIPv6,
+    );
   }
 
   String get uri {

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -157,9 +157,7 @@ class DebugService {
 
   String get uri {
     if (_spawnDds && _dds != null) {
-      // TODO(bkonyi): set the scheme to sse in package:dds.
-      return (_useSse ? _dds.sseUri.replace(scheme: 'sse') : _dds.wsUri)
-          .toString();
+      return (_useSse ? _dds.sseUri : _dds.wsUri).toString();
     }
     return (_useSse
             ? Uri(

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -117,10 +117,9 @@ class DebugService {
   final VmServiceInterface chromeProxyService;
   final String hostname;
   final ServiceExtensionRegistry serviceExtensionRegistry;
-  int get port => _port;
-  int _port;
+  final int port;
+  final String authToken;
   final HttpServer _server;
-  String _authToken;
   final bool _useSse;
   final bool _spawnDds;
   DartDevelopmentService _dds;
@@ -133,8 +132,8 @@ class DebugService {
   DebugService._(
       this.chromeProxyService,
       this.hostname,
-      this._port,
-      this._authToken,
+      this.port,
+      this.authToken,
       this.serviceExtensionRegistry,
       this._server,
       this._useSse,
@@ -149,7 +148,7 @@ class DebugService {
       scheme: 'http',
       host: hostname,
       port: port,
-      path: '$_authToken',
+      path: '$authToken',
     ));
   }
 
@@ -164,13 +163,13 @@ class DebugService {
                 scheme: 'sse',
                 host: hostname,
                 port: port,
-                path: '$_authToken/\$debugHandler',
+                path: '$authToken/\$debugHandler',
               )
             : Uri(
                 scheme: 'ws',
                 host: hostname,
                 port: port,
-                path: '$_authToken',
+                path: '$authToken',
               ))
         .toString();
   }

--- a/dwds/lib/src/utilities/shared.dart
+++ b/dwds/lib/src/utilities/shared.dart
@@ -20,6 +20,14 @@ String createId() {
   return '$_nextId';
 }
 
+bool _useIPv6;
+Future<bool> get useIPv6 async {
+  if (_useIPv6 == null) {
+    await findUnusedPort();
+  }
+  return _useIPv6;
+}
+
 /// Returns a port that is probably, but not definitely, not in use.
 ///
 /// This has a built-in race condition: another process may bind this port at
@@ -30,8 +38,10 @@ Future<int> findUnusedPort() async {
   try {
     socket =
         await ServerSocket.bind(InternetAddress.loopbackIPv6, 0, v6Only: true);
+    _useIPv6 = true;
   } on SocketException {
     socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    _useIPv6 = false;
   }
   port = socket.port;
   await socket.close();

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   built_value: '>=6.7.0 <8.0.0'
   crypto: ^2.0.6
   # devtools_server indirectly depends on devtools so keep this around.
+  dds: ^1.3.1
   devtools: ^0.8.0
   devtools_server: ^0.8.0
   http: ^0.12.0

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
   crypto: ^2.0.6
   # devtools_server indirectly depends on devtools so keep this around.
   dds: ^1.3.1
-  devtools: ^0.8.0
-  devtools_server: ^0.8.0
+  devtools: ^0.9.2
+  devtools_server: ^0.9.2
   http: ^0.12.0
   http_multi_server: ^2.0.0
   logging: ^0.11.3
@@ -34,7 +34,7 @@ dependencies:
   source_maps: ^0.10.0
   sse: ^3.5.0
   # We pin the version because we implement the interface.
-  vm_service: 4.2.0
+  vm_service: 5.0.0+1
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: ^0.7.3
 

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   source_maps: ^0.10.0
   sse: ^3.5.0
   # We pin the version because we implement the interface.
-  vm_service: 5.0.0+1
+  vm_service: 5.2.0
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: ^0.7.3
 

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -37,14 +37,6 @@ void main() {
       await context.tearDown();
     });
 
-    test('getClientName', () async {
-      expect(() => service.getClientName(), throwsRPCError);
-    });
-
-    test('setClientName', () async {
-      expect(() => service.setClientName('foo'), throwsRPCError);
-    });
-
     group('breakpoints', () {
       VM vm;
       Isolate isolate;

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -37,6 +37,7 @@ Isolate get simpleIsolate => Isolate(
       startTime: 0,
       livePorts: 0,
       runnable: false,
+      isSystemIsolate: false,
     );
 
 class FakeInspector extends Domain implements AppInspector {

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7.0 - UNRELEASED
+
+- Add support for the Dart Development Service (DDS).
+- Expand `package:vm_service` to version `>=3.0.0 <6.0.0`.
+
 ## 2.6.2
 
 - Update min sdk constraint to `>=2.8.1`.

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -28,6 +28,7 @@ const outputNone = 'NONE';
 const releaseFlag = 'release';
 const requireBuildWebCompilersFlag = 'build-web-compilers';
 const verboseFlag = 'verbose';
+const disableDdsFlag = 'disable-dds';
 
 ReloadConfiguration _parseReloadConfiguration(ArgResults argResults) {
   var auto = argResults.options.contains(autoOption)
@@ -92,6 +93,7 @@ class Configuration {
   final ReloadConfiguration _reload;
   final bool _requireBuildWebCompilers;
   final bool _verbose;
+  final bool _disableDds;
 
   Configuration({
     bool autoRun,
@@ -112,6 +114,7 @@ class Configuration {
     bool release,
     bool requireBuildWebCompilers,
     bool verbose,
+    bool disableDds,
   })  : _autoRun = autoRun,
         _chromeDebugPort = chromeDebugPort,
         _debugExtension = debugExtension,
@@ -127,7 +130,8 @@ class Configuration {
         _release = release,
         _reload = reload,
         _requireBuildWebCompilers = requireBuildWebCompilers,
-        _verbose = verbose {
+        _verbose = verbose,
+        _disableDds = disableDds {
     _validateConfiguration();
   }
 
@@ -190,7 +194,8 @@ class Configuration {
       reload: other._reload ?? _reload,
       requireBuildWebCompilers:
           other._requireBuildWebCompilers ?? _requireBuildWebCompilers,
-      verbose: other._verbose ?? _verbose);
+      verbose: other._verbose ?? _verbose,
+      disableDds: other._disableDds ?? _disableDds);
 
   factory Configuration.noInjectedClientDefaults() =>
       Configuration(autoRun: false, debug: false, debugExtension: false);
@@ -203,6 +208,8 @@ class Configuration {
   bool get debugExtension => _debugExtension ?? false;
 
   bool get debug => _debug ?? false;
+
+  bool get disableDds => _disableDds ?? false;
 
   bool get enableInjectedClient => _enableInjectedClient ?? true;
 
@@ -326,6 +333,10 @@ class Configuration {
         ? argResults[verboseFlag] as bool
         : defaultConfiguration.verbose;
 
+    var disableDds = argResults.options.contains(disableDdsFlag)
+        ? argResults[disableDdsFlag] as bool
+        : defaultConfiguration.disableDds;
+
     return Configuration(
         autoRun: defaultConfiguration.autoRun,
         chromeDebugPort: chromeDebugPort,
@@ -344,7 +355,8 @@ class Configuration {
         release: release,
         reload: _parseReloadConfiguration(argResults),
         requireBuildWebCompilers: requireBuildWebCompilers,
-        verbose: verbose);
+        verbose: verbose,
+        disableDds: disableDds);
   }
 }
 

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -47,7 +47,8 @@ refresh: Performs a full page refresh.
     ..addFlag(disableDdsFlag,
         negatable: false,
         help: 'Disable the Dart Development Service (DDS). Disabling DDS may '
-        'result in a degraded developer experience in some tools.')
+        'result in a degraded developer experience in some tools.',
+        hide: true)
     ..addOption(hostnameFlag,
         help: 'Specify the hostname to serve on.', defaultsTo: 'localhost')
     ..addFlag(hotRestartFlag,

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -10,7 +10,6 @@ import 'package:args/command_runner.dart';
 import '../logging.dart';
 import '../serve/dev_workflow.dart';
 import 'configuration.dart';
-import 'configuration.dart';
 import 'shared.dart';
 
 /// Command to run a server for local web development with the build daemon.

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -10,6 +10,7 @@ import 'package:args/command_runner.dart';
 import '../logging.dart';
 import '../serve/dev_workflow.dart';
 import 'configuration.dart';
+import 'configuration.dart';
 import 'shared.dart';
 
 /// Command to run a server for local web development with the build daemon.
@@ -44,6 +45,10 @@ refresh: Performs a full page refresh.
         help: 'Specify which port the Chrome debugger is listening on. '
             'If used with $launchInChromeFlag Chrome will be started with the'
             ' debugger listening on this port.')
+    ..addFlag(disableDdsFlag,
+        negatable: false,
+        help: 'Disable the Dart Development Service (DDS). Disabling DDS may '
+        'result in a degraded developer experience in some tools.')
     ..addOption(hostnameFlag,
         help: 'Specify the hostname to serve on.', defaultsTo: 'localhost')
     ..addFlag(hotRestartFlag,

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -118,6 +118,7 @@ class WebDevServer {
         verbose: options.configuration.verbose,
         enableDebugExtension: options.configuration.debugExtension,
         enableDebugging: options.configuration.debug,
+        spawnDds: !options.configuration.disableDds,
       );
       pipeline = pipeline.addMiddleware(dwds.middleware);
       cascade = cascade.add(dwds.handler);

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.6.2';
+const packageVersion = '2.7.0';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   build_daemon: ^2.0.0
   browser_launcher: ^0.1.5
   crypto: ^2.0.6
+  dds: ^1.3.1
   dwds: ^6.0.0
   http: ^0.12.0
   http_multi_server: ^2.1.0

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   shelf_proxy: ^0.1.0+5
   shelf_static: ^0.2.8
   sse: ^3.5.0
-  vm_service: '>=3.0.0 <5.0.0'
+  vm_service: '>=3.0.0 <6.0.0'
   webkit_inspection_protocol: '>=0.4.0 <0.8.0'
   yaml: ^2.1.13
 

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,8 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.6.2
+version: 2.7.0
+# TODO: remove when ready to publish.
+publish_to: none
 homepage: https://github.com/dart-lang/webdev
 description: >-
   A CLI for Dart web development. Provides an easy and consistent set of


### PR DESCRIPTION
Users can prevent DDS from being spawned by providing the --disable-dds flag to `webdev serve`.