### PR TITLE
Fix webdev dependency of pre-release package

### DIFF
--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.0.0';
+const packageVersion = '6.0.1';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -43,7 +43,7 @@ dev_dependencies:
   build_runner: ^1.6.2
   build_daemon: ^2.0.0
   build_version: ^2.0.0
-  build_web_compilers: ^2.12.0-dev.1
+  build_web_compilers: ^2.11.0
   built_value_generator: '>=6.4.0 <8.0.0'
   graphs: ^0.2.0
   frontend_server_common:

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 6.0.0
+version: 6.0.1
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1
+
+- Rollback pre-release dependency of `build_web_compilers`: from `2.12.0-dev.1` to `2.11.0`.
+
 ## 2.6.0
 
 - Require at least `build_web_compilers` version `2.12.0-dev.1`.

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.6.0';
+const packageVersion = '2.6.1';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.6.0
+version: 2.6.1
 homepage: https://github.com/dart-lang/webdev
 description: >-
   A CLI for Dart web development. Provides an easy and consistent set of


### PR DESCRIPTION
`webdev` was depending on a pre-release package!

Fix:
- Rollback pre-release dependency of `build_web_compilers`: from `2.12.0-dev.1` to `2.11.0`.
