### PR TITLE
Rollback 2.6.0

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.6.1
+
+- Rollback release so that we no longer require a dev version of
+  `package:build_web_compilers`.
+
 ## 2.6.0
 
 - Require at least `build_web_compilers` version `2.12.0-dev.1`.

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -185,8 +185,8 @@ Future<void> checkPubspecLock(PubspecLock pubspecLock,
   issues.addAll(buildRunnerIssues);
 
   if (requireBuildWebCompilers) {
-    issues.addAll(pubspecLock.checkPackage('build_web_compilers',
-        VersionConstraint.parse('>=2.12.0-dev.1 <3.0.0')));
+    issues.addAll(pubspecLock.checkPackage(
+        'build_web_compilers', VersionConstraint.parse('>=2.6.1 <3.0.0')));
   }
 
   if (buildRunnerIssues.isEmpty) {

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.6.0';
+const packageVersion = '2.6.1';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.6.0
+version: 2.6.1
 homepage: https://github.com/dart-lang/webdev
 description: >-
   A CLI for Dart web development. Provides an easy and consistent set of
@@ -15,7 +15,7 @@ dependencies:
   build_daemon: ^2.0.0
   browser_launcher: ^0.1.5
   crypto: ^2.0.6
-  dwds: ^6.0.0
+  dwds: ^5.0.0
   http: ^0.12.0
   http_multi_server: ^2.1.0
   io: ^0.3.2+1
@@ -45,7 +45,3 @@ dev_dependencies:
 
 executables:
   webdev:
-
-dependency_overrides:
-  dwds:
-    path: ../dwds

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -302,7 +302,7 @@ dependencies:
 }
 
 const _supportedBuildRunnerVersion = '1.6.2';
-const _supportedWebCompilersVersion = '2.12.0-dev.1';
+const _supportedWebCompilersVersion = '2.6.1';
 const _supportedBuildDaemonVersion = '2.0.0';
 
 String _pubspecLock(


### PR DESCRIPTION
Once published this will resolve https://github.com/dart-lang/build/pull/2809.

Note this backs out changes in https://github.com/dart-lang/webdev/pull/1070.

I'll follow up with a dev release version of webdev.