### PR TITLE
Update metadata version

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Add support for the Dart Development Service (DDS). Introduces 'single
   client mode', which prevents additional direct connections to DWDS when
   DDS is connected.
+- Update metadata reader version to `2.0.0`. Support reading metadata
+  versions `2.0.0` and `1.0.0`.
 
 ## 6.0.0
 

--- a/dwds/lib/src/debugging/metadata/module_metadata.dart
+++ b/dwds/lib/src/debugging/metadata/module_metadata.dart
@@ -151,8 +151,7 @@ class ModuleMetadata {
       throw Exception('Unsupported metadata version $version. '
           '\n  Supported versions: '
           '\n    ${ModuleMetadataVersion.current.version} '
-          '\n    ${ModuleMetadataVersion.previous.version} '
-          '\n  Please upgrade dwds package.');
+          '\n    ${ModuleMetadataVersion.previous.version}');
     }
 
     for (var l in json['libraries'] as List<dynamic>) {

--- a/dwds/lib/src/debugging/metadata/module_metadata.dart
+++ b/dwds/lib/src/debugging/metadata/module_metadata.dart
@@ -27,7 +27,10 @@ class ModuleMetadataVersion {
   ///
   /// TODO(annagrin): create metadata package, make version the same as the
   /// metadata package version, automate updating with the package update
-  static const ModuleMetadataVersion current = ModuleMetadataVersion(1, 0, 0);
+  static const ModuleMetadataVersion current = ModuleMetadataVersion(2, 0, 0);
+
+  /// Previous version supported by the metadata reader
+  static const ModuleMetadataVersion previous = ModuleMetadataVersion(1, 0, 0);
 
   /// Current metadata version created by the reader
   String get version => '$majorVersion.$minorVersion.$patchVersion';
@@ -36,7 +39,7 @@ class ModuleMetadataVersion {
   ///
   /// The minor and patch version changes never remove any fields that current
   /// version supports, so the reader can create current metadata version from
-  /// any file created with a later reader, as long as the major version does
+  /// any file created with a later writer, as long as the major version does
   /// not change.
   bool isCompatibleWith(String version) {
     var parts = version.split('.');
@@ -143,9 +146,13 @@ class ModuleMetadata {
         closureName = json['closureName'] as String,
         sourceMapUri = json['sourceMapUri'] as String,
         moduleUri = json['moduleUri'] as String {
-    var fileVersion = json['version'] as String;
-    if (!ModuleMetadataVersion.current.isCompatibleWith(version)) {
-      throw Exception('Unsupported metadata version $fileVersion');
+    if (!ModuleMetadataVersion.current.isCompatibleWith(version) &&
+        !ModuleMetadataVersion.previous.isCompatibleWith(version)) {
+      throw Exception('Unsupported metadata version $version. '
+          '\n  Supported versions: '
+          '\n    ${ModuleMetadataVersion.current.version} '
+          '\n    ${ModuleMetadataVersion.previous.version} '
+          '\n  Please upgrade dwds package.');
     }
 
     for (var l in json['libraries'] as List<dynamic>) {

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -87,13 +87,10 @@ class FileMetadataProvider implements MetadataProvider {
       if (merged != null) {
         // read merged metadata if exists
         for (var contents in merged.split('\n')) {
-          try {
-            _addMetadata(contents);
-          } catch (e) {
-            _logWriter(Level.SEVERE, 'Error reading metadata: ${e.message}');
-          }
+          _addMetadata(contents);
         }
       }
+      _logWriter(Level.INFO, 'Loaded debug metadata');
     }
   }
 
@@ -112,5 +109,7 @@ class FileMetadataProvider implements MetadataProvider {
         _scripts[library.importUri].add(path);
       }
     }
+    _logWriter(
+        Level.FINEST, 'Loaded debug metadata for module: ${metadata.name}');
   }
 }

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -179,7 +179,7 @@ class DevHandler {
 
     var webkitDebugger = WebkitDebugger(WipDebugger(tabConnection));
 
-    var metadataProvider = FileMetadataProvider(_assetReader);
+    var metadataProvider = FileMetadataProvider(_assetReader, _logWriter);
 
     return DebugService.start(
       // We assume the user will connect to the debug service on the same
@@ -458,7 +458,7 @@ class DevHandler {
       }
       var appId = devToolsRequest.appId;
       if (_servicesByAppId[appId] == null) {
-        var metadataProvider = FileMetadataProvider(_assetReader);
+        var metadataProvider = FileMetadataProvider(_assetReader, _logWriter);
 
         var debugService = await DebugService.start(
             _hostname,

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/services/chrome_proxy_service.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
@@ -29,7 +30,8 @@ void main() {
     setUpAll(() async {
       await context.setUp(
           compilationMode: CompilationMode.frontendServer,
-          useFileMetadataProvider: true);
+          useFileMetadataProvider: true,
+          logWriter: (Level level, String message) => printOnFailure(message));
     });
 
     tearDownAll(() async {


### PR DESCRIPTION
Update metadata in preparation for metadata version change in the SDK
- Update metadata version to 2.0.0
- Add support for version 2.0.0 and 1.0.0
- Log error on failure to read metadata
- Skip reading empty metadata
- Update changelog. 

**Note**

The original code ignored exceptions on metadata read so the debugger would start but fail to
set breakpoints or do expression evaluation later.  This change makes debugger fail to start if 
the metadata reading fails.

Related: https://github.com/dart-lang/sdk/issues/43458
