### PR TITLE
Handle metadata parse errors

### DIFF
--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -87,7 +87,12 @@ class FileMetadataProvider implements MetadataProvider {
       if (merged != null) {
         // read merged metadata if exists
         for (var contents in merged.split('\n')) {
-          _addMetadata(contents);
+          try {
+            _addMetadata(contents);
+          } catch (_) {
+            // DDC intentionally writes invalid metadata for some modules.
+            // Skip these errors.
+          }
         }
       }
       _logWriter(Level.INFO, 'Loaded debug metadata');

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -87,12 +87,8 @@ class FileMetadataProvider implements MetadataProvider {
       if (merged != null) {
         // read merged metadata if exists
         for (var contents in merged.split('\n')) {
-          try {
-            _addMetadata(contents);
-          } catch (_) {
-            // DDC intentionally writes invalid metadata for some modules.
-            // Skip these errors.
-          }
+          if (contents.startsWith('// intentionally empty:')) continue;
+          _addMetadata(contents);
         }
       }
       _logWriter(Level.INFO, 'Loaded debug metadata');

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dwds/dwds.dart';
+import 'package:dwds/src/debugging/metadata/provider.dart';
+import 'package:test/test.dart';
+
+class FakeAssetReader implements AssetReader {
+  @override
+  Future<String> dartSourceContents(String serverPath) =>
+      throw UnimplementedError();
+
+  @override
+  Future<String> metadataContents(String serverPath) async =>
+      '{"version":"1.0.0","name":"web/main","closureName":"load__web__main",'
+      '"sourceMapUri":"foo/web/main.ddc.js.map",'
+      '"moduleUri":"foo/web/main.ddc.js",'
+      '"libraries":[{"name":"main",'
+      '"importUri":"org-dartlang-app:///web/main.dart",'
+      '"fileUri":"org-dartlang-app:///web/main.dart","partUris":[]}]}\n'
+      '// intentionally empty: package blah has no dart sources';
+
+  @override
+  Future<String> sourceMapContents(String serverPath) =>
+      throw UnimplementedError();
+}
+
+void main() {
+  test('can parse metadata with empty sources', () async {
+    var provider = FileMetadataProvider(
+        FakeAssetReader(), (level, message) => printOnFailure(message));
+    await provider.initialize('foo.bootstrap.js');
+    expect(await provider.libraries,
+        contains('org-dartlang-app:///web/main.dart'));
+  });
+}


### PR DESCRIPTION
We incorrectly removed the error handling in a previous PR. Add it back with a corresponding test.