### PR TITLE
Make DDS bind to the provided hostname instead of localhost

### DIFF
--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -151,7 +151,7 @@ class DebugService {
         port: port,
         path: '$authToken',
       ),
-      ipv6: await useIPv6,
+      ipv6: await useIPv6ForHost(hostname),
     );
   }
 

--- a/dwds/lib/src/utilities/shared.dart
+++ b/dwds/lib/src/utilities/shared.dart
@@ -24,7 +24,7 @@ String createId() {
 Future<bool> useIPv6ForHost(String hostname) async {
   final addresses = await InternetAddress.lookup(hostname);
   final address = addresses.firstWhere(
-    (a) => (a.type == InternetAddressType.IPv6),
+    (a) => a.type == InternetAddressType.IPv6,
     orElse: () => null,
   );
   return address != null;

--- a/dwds/lib/src/utilities/shared.dart
+++ b/dwds/lib/src/utilities/shared.dart
@@ -20,12 +20,14 @@ String createId() {
   return '$_nextId';
 }
 
-bool _useIPv6;
-Future<bool> get useIPv6 async {
-  if (_useIPv6 == null) {
-    await findUnusedPort();
-  }
-  return _useIPv6;
+/// Returns `true` if [hostname] is bound to an IPv6 address.
+Future<bool> useIPv6ForHost(String hostname) async {
+  final addresses = await InternetAddress.lookup(hostname);
+  final address = addresses.firstWhere(
+    (a) => (a.type == InternetAddressType.IPv6),
+    orElse: () => null,
+  );
+  return address != null;
 }
 
 /// Returns a port that is probably, but not definitely, not in use.
@@ -38,10 +40,8 @@ Future<int> findUnusedPort() async {
   try {
     socket =
         await ServerSocket.bind(InternetAddress.loopbackIPv6, 0, v6Only: true);
-    _useIPv6 = true;
   } on SocketException {
     socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-    _useIPv6 = false;
   }
   port = socket.port;
   await socket.close();


### PR DESCRIPTION
Corp hostnames are bound to IPv4 addresses, so attempting to bind to a hostname with `ipv6: true` causes an exception to be thrown.