### PR TITLE
Require MetadataProvider

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -12,7 +12,7 @@
     module assets (JavaScript code and source maps).
 
 **Breaking changes:**
-- Change `Dwds.start` to include `MetadataProvider` as a parameter.
+- Change `Dwds.start` to require `MetadataProvider` as a parameter.
   This enables connecting metadata provider with require strategy
   so we can remove heuristucs and rely on metadata in mapping modules
   to paths.

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -83,6 +83,7 @@ class Dwds {
     @required ConnectionProvider chromeConnection,
     @required LoadStrategy loadStrategy,
     @required bool enableDebugging,
+    @required MetadataProvider metadataProvider,
     bool enableDebugExtension,
     String hostname,
     bool useSseForDebugProxy,
@@ -92,7 +93,6 @@ class Dwds {
     bool verbose,
     UrlEncoder urlEncoder,
     bool spawnDds = true,
-    MetadataProvider metadataProvider,
     // TODO(annagrin): make expressionCompiler argument required
     // [issue 881](https://github.com/dart-lang/webdev/issues/881)
     ExpressionCompiler expressionCompiler,


### PR DESCRIPTION
This is actually required as DWDS will fail in unexpected ways if it is null.