### PR TITLE
Handle null consoleSubscription

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -243,7 +243,7 @@ class ChromeProxyService implements VmServiceInterface {
     _inspector = null;
     _previousBreakpoints.clear();
     _previousBreakpoints.addAll(isolate.breakpoints);
-    _consoleSubscription.cancel();
+    _consoleSubscription?.cancel();
     _consoleSubscription = null;
   }
 


### PR DESCRIPTION
I tried to create a corresponding test for this but it was difficult given that the root cause is due to a race condition. It appears that client of the service may issue a `destroyIsolate` call prior to the previous `createIsolate` being fully instantiated.

cc @jonahwilliams 