### PR TITLE
Close http connections on dwds and webdev_server exit

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -10,6 +10,7 @@
   module paths.
   - Fix issue where upgrading `build_web_compilers` would cause missing
     module assets (JavaScript code and source maps).
+- Fix issue where open http connections prevent the process for exiting.
 
 **Breaking changes:**
 - Change `Dwds.start` to require `MetadataProvider` as a parameter.

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -51,12 +51,14 @@ class Dwds {
   final Handler handler;
   final DevTools _devTools;
   final DevHandler _devHandler;
+  final AssetReader _assetReader;
   final bool _enableDebugging;
 
   Dwds._(
     this.middleware,
     this._devTools,
     this._devHandler,
+    this._assetReader,
     this._enableDebugging,
   ) : handler = _devHandler.handler;
 
@@ -68,6 +70,7 @@ class Dwds {
   Future<void> stop() async {
     await _devTools?.close();
     await _devHandler.close();
+    await _assetReader.close();
   }
 
   Future<DebugConnection> debugConnection(AppConnection appConnection) async {
@@ -161,6 +164,7 @@ class Dwds {
       injected.middleware,
       devTools,
       devHandler,
+      assetReader,
       enableDebugging,
     );
   }

--- a/dwds/lib/src/readers/asset_reader.dart
+++ b/dwds/lib/src/readers/asset_reader.dart
@@ -14,4 +14,7 @@ abstract class AssetReader {
 
   /// Returns the contents for the merged metadata output at the provided path.
   Future<String> metadataContents(String serverPath);
+
+  /// Closes connections
+  Future<void> close();
 }

--- a/dwds/lib/src/readers/frontend_server_asset_reader.dart
+++ b/dwds/lib/src/readers/frontend_server_asset_reader.dart
@@ -108,4 +108,7 @@ class FrontendServerAssetReader implements AssetReader {
     // TODO(grouma) - Implement the merged metadata reader.
     throw UnimplementedError();
   }
+
+  @override
+  Future<void> close() async => Future.value();
 }

--- a/dwds/lib/src/readers/frontend_server_asset_reader.dart
+++ b/dwds/lib/src/readers/frontend_server_asset_reader.dart
@@ -110,5 +110,5 @@ class FrontendServerAssetReader implements AssetReader {
   }
 
   @override
-  Future<void> close() async {};
+  Future<void> close() async {}
 }

--- a/dwds/lib/src/readers/frontend_server_asset_reader.dart
+++ b/dwds/lib/src/readers/frontend_server_asset_reader.dart
@@ -110,5 +110,5 @@ class FrontendServerAssetReader implements AssetReader {
   }
 
   @override
-  Future<void> close() async => Future.value();
+  Future<void> close() async {};
 }

--- a/dwds/lib/src/readers/proxy_server_asset_reader.dart
+++ b/dwds/lib/src/readers/proxy_server_asset_reader.dart
@@ -71,5 +71,5 @@ class ProxyServerAssetReader implements AssetReader {
       _readResource(serverPath);
 
   @override
-  Future<void> close() async => _client.close();
+  Future<void> close() => _client.close();
 }

--- a/dwds/lib/src/readers/proxy_server_asset_reader.dart
+++ b/dwds/lib/src/readers/proxy_server_asset_reader.dart
@@ -71,5 +71,5 @@ class ProxyServerAssetReader implements AssetReader {
       _readResource(serverPath);
 
   @override
-  Future<void> close() => _client.close();
+  Future<void> close() async => _client.close();
 }

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -57,7 +57,7 @@ class FakeAssetReader implements AssetReader {
       ';EAEzB","file":"main.ddc.js"}';
 
   @override
-  Future<void> close() async {};
+  Future<void> close() async {}
 }
 
 void main() async {

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -55,6 +55,9 @@ class FakeAssetReader implements AssetReader {
       'yCAAC,WAAW;IAChE;AAC0D,IAA3D,AAAS,AAAK,0DAAO;AAAe,kBAAO;;;AAEvC,gBAAQ;'
       'AAGV,IAFI,kCAAqC,QAAC;AACX,MAA/B,WAAM,AAAwB,0BAAP,QAAF,AAAE,KAAK,GAAP;'
       ';EAEzB","file":"main.ddc.js"}';
+
+  @override
+  Future<void> close() async => Future.value();
 }
 
 void main() async {

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -57,7 +57,7 @@ class FakeAssetReader implements AssetReader {
       ';EAEzB","file":"main.ddc.js"}';
 
   @override
-  Future<void> close() async => Future.value();
+  Future<void> close() async {};
 }
 
 void main() async {

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:http/http.dart' as http;
+import 'package:dwds/src/readers/proxy_server_asset_reader.dart';
 import 'package:build_daemon/client.dart';
 import 'package:build_daemon/data/build_status.dart';
 import 'package:build_daemon/data/build_target.dart';
@@ -51,6 +53,7 @@ class TestContext {
   AppConnection appConnection;
   DebugConnection debugConnection;
   WebkitDebugger webkitDebugger;
+  http.Client client;
   int port;
   Directory _outputDir;
   File _entryFile;
@@ -114,166 +117,175 @@ class TestContext {
     logWriter ??= (Level level, String message) => printOnFailure(message);
     spawnDds ??= true;
 
-    var systemTempDir = Directory.systemTemp;
-    _outputDir = systemTempDir.createTempSync('foo bar');
-
-    var chromeDriverPort = await findUnusedPort();
-    var chromeDriverUrlBase = 'wd/hub';
     try {
-      chromeDriver = await Process.start('chromedriver$_exeExt',
-          ['--port=$chromeDriverPort', '--url-base=$chromeDriverUrlBase']);
-      // On windows this takes a while to boot up, wait for the first line
-      // of stdout as a signal that it is ready.
-      await chromeDriver.stdout
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())
-          .first;
+      client = http.Client();
+
+      var systemTempDir = Directory.systemTemp;
+      _outputDir = systemTempDir.createTempSync('foo bar');
+
+      var chromeDriverPort = await findUnusedPort();
+      var chromeDriverUrlBase = 'wd/hub';
+      try {
+        chromeDriver = await Process.start('chromedriver$_exeExt',
+            ['--port=$chromeDriverPort', '--url-base=$chromeDriverUrlBase']);
+        // On windows this takes a while to boot up, wait for the first line
+        // of stdout as a signal that it is ready.
+        await chromeDriver.stdout
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .first;
+      } catch (e) {
+        throw StateError(
+            'Could not start ChromeDriver. Is it installed?\nError: $e');
+      }
+
+      await Process.run('pub$_batExt', ['upgrade'],
+          workingDirectory: workingDirectory);
+
+      ExpressionCompiler expressionCompiler;
+      AssetReader assetReader;
+      Handler assetHandler;
+      Stream<BuildResults> buildResults;
+      RequireStrategy requireStrategy;
+      MetadataProvider metadataProvider;
+
+      switch (compilationMode) {
+        case CompilationMode.buildDaemon:
+          {
+            daemonClient = await connectClient(
+                workingDirectory,
+                [],
+                (log) => logWriter(
+                    server_log.toLoggingLevel(log.level), log.message));
+            daemonClient.registerBuildTarget(
+                DefaultBuildTarget((b) => b..target = pathToServe));
+            daemonClient.startBuild();
+
+            await daemonClient.buildResults
+                .firstWhere((results) => results.results
+                    .any((result) => result.status == BuildStatus.succeeded))
+                .timeout(const Duration(seconds: 60));
+
+            var assetServerPort = daemonPort(workingDirectory);
+            assetHandler = proxyHandler(
+                'http://localhost:$assetServerPort/$pathToServe/',
+                client: client);
+            assetReader = ProxyServerAssetReader(assetServerPort, logWriter,
+                root: pathToServe);
+            metadataProvider = MetadataProvider(assetReader, logWriter);
+
+            requireStrategy = BuildRunnerRequireStrategyProvider(
+                    assetHandler, reloadConfiguration, metadataProvider)
+                .strategy;
+
+            buildResults = daemonClient.buildResults;
+          }
+          break;
+        case CompilationMode.frontendServer:
+          {
+            var fileSystemRoot = p.dirname(_packagesFilePath);
+            var entryPath =
+                _entryFile.path.substring(fileSystemRoot.length + 1);
+            webRunner = ResidentWebRunner(
+                '${Uri.file(entryPath)}',
+                urlEncoder,
+                fileSystemRoot,
+                _packagesFilePath,
+                [fileSystemRoot],
+                'org-dartlang-app',
+                _outputDir.path,
+                logWriter);
+
+            var assetServerPort = await findUnusedPort();
+            await webRunner.run(hostname, assetServerPort, pathToServe);
+
+            expressionCompiler = webRunner.expressionCompiler;
+            assetReader = webRunner.devFS.assetServer;
+            assetHandler = webRunner.devFS.assetServer.handleRequest;
+
+            metadataProvider = MetadataProvider(assetReader, logWriter);
+            requireStrategy = FrontendServerRequireStrategyProvider(
+                    reloadConfiguration, metadataProvider)
+                .strategy;
+
+            buildResults = const Stream<BuildResults>.empty();
+          }
+          break;
+        default:
+          throw Exception('Unsupported compilation mode: $compilationMode');
+      }
+
+      expressionCompiler = useFakeExpressionCompiler
+          ? FakeExpressionCompiler()
+          : expressionCompiler;
+
+      var debugPort = await findUnusedPort();
+      // If the environment variable DWDS_DEBUG_CHROME is set to the string true
+      // then Chrome will be launched with a UI rather than headless.
+      // If the extension is enabled, then Chrome will be launched with a UI
+      // since headless Chrome does not support extensions.
+      var headless = Platform.environment['DWDS_DEBUG_CHROME'] != 'true' &&
+          !enableDebugExtension;
+
+      var capabilities = Capabilities.chrome
+        ..addAll({
+          Capabilities.chromeOptions: {
+            'args': [
+              'remote-debugging-port=$debugPort',
+              if (enableDebugExtension) '--load-extension=debug_extension/web',
+              if (headless) '--headless'
+            ]
+          }
+        });
+      webDriver = await createDriver(
+          spec: WebDriverSpec.JsonWire,
+          desired: capabilities,
+          uri: Uri.parse(
+              'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/'));
+      var connection = ChromeConnection('localhost', debugPort);
+
+      port = await findUnusedPort();
+      testServer = await TestServer.start(
+          hostname,
+          port,
+          assetHandler,
+          assetReader,
+          requireStrategy,
+          metadataProvider,
+          pathToServe,
+          buildResults,
+          () async => connection,
+          serveDevTools,
+          enableDebugExtension,
+          autoRun,
+          enableDebugging,
+          useSse,
+          urlEncoder,
+          restoreBreakpoints,
+          expressionCompiler,
+          logWriter,
+          spawnDds);
+
+      appUrl = 'http://localhost:$port/$path';
+      await webDriver.get(appUrl);
+      var tab = await connection.getTab((t) => t.url == appUrl);
+      tabConnection = await tab.connect();
+      await tabConnection.runtime.enable();
+      await tabConnection.debugger.enable();
+
+      if (enableDebugExtension) {
+        var extensionTab = await _fetchDartDebugExtensionTab(connection);
+        extensionConnection = await extensionTab.connect();
+        await extensionConnection.runtime.enable();
+      }
+
+      appConnection = await testServer.dwds.connectedApps.first;
+      if (enableDebugging && !waitToDebug) {
+        await startDebugging();
+      }
     } catch (e) {
-      throw StateError(
-          'Could not start ChromeDriver. Is it installed?\nError: $e');
-    }
-
-    await Process.run('pub$_batExt', ['upgrade'],
-        workingDirectory: workingDirectory);
-
-    ExpressionCompiler expressionCompiler;
-    AssetReader assetReader;
-    Handler assetHandler;
-    Stream<BuildResults> buildResults;
-    RequireStrategy requireStrategy;
-    MetadataProvider metadataProvider;
-
-    switch (compilationMode) {
-      case CompilationMode.buildDaemon:
-        {
-          daemonClient = await connectClient(
-              workingDirectory,
-              [],
-              (log) =>
-                  logWriter(server_log.toLoggingLevel(log.level), log.message));
-          daemonClient.registerBuildTarget(
-              DefaultBuildTarget((b) => b..target = pathToServe));
-          daemonClient.startBuild();
-
-          await daemonClient.buildResults
-              .firstWhere((results) => results.results
-                  .any((result) => result.status == BuildStatus.succeeded))
-              .timeout(const Duration(seconds: 60));
-
-          var assetServerPort = daemonPort(workingDirectory);
-          assetHandler =
-              proxyHandler('http://localhost:$assetServerPort/$pathToServe/');
-          assetReader = ProxyServerAssetReader(assetServerPort, logWriter,
-              root: pathToServe);
-          metadataProvider = MetadataProvider(assetReader, logWriter);
-
-          requireStrategy = BuildRunnerRequireStrategyProvider(
-                  assetHandler, reloadConfiguration, metadataProvider)
-              .strategy;
-
-          buildResults = daemonClient.buildResults;
-        }
-        break;
-      case CompilationMode.frontendServer:
-        {
-          var fileSystemRoot = p.dirname(_packagesFilePath);
-          var entryPath = _entryFile.path.substring(fileSystemRoot.length + 1);
-          webRunner = ResidentWebRunner(
-              '${Uri.file(entryPath)}',
-              urlEncoder,
-              fileSystemRoot,
-              _packagesFilePath,
-              [fileSystemRoot],
-              'org-dartlang-app',
-              _outputDir.path,
-              logWriter);
-
-          var assetServerPort = await findUnusedPort();
-          await webRunner.run(hostname, assetServerPort, pathToServe);
-
-          expressionCompiler = webRunner.expressionCompiler;
-          assetReader = webRunner.devFS.assetServer;
-          assetHandler = webRunner.devFS.assetServer.handleRequest;
-
-          metadataProvider = MetadataProvider(assetReader, logWriter);
-          requireStrategy = FrontendServerRequireStrategyProvider(
-                  reloadConfiguration, metadataProvider)
-              .strategy;
-
-          buildResults = const Stream<BuildResults>.empty();
-        }
-        break;
-      default:
-        throw Exception('Unsupported compilation mode: $compilationMode');
-    }
-
-    expressionCompiler = useFakeExpressionCompiler
-        ? FakeExpressionCompiler()
-        : expressionCompiler;
-
-    var debugPort = await findUnusedPort();
-    // If the environment variable DWDS_DEBUG_CHROME is set to the string true
-    // then Chrome will be launched with a UI rather than headless.
-    // If the extension is enabled, then Chrome will be launched with a UI
-    // since headless Chrome does not support extensions.
-    var headless = Platform.environment['DWDS_DEBUG_CHROME'] != 'true' &&
-        !enableDebugExtension;
-
-    var capabilities = Capabilities.chrome
-      ..addAll({
-        Capabilities.chromeOptions: {
-          'args': [
-            'remote-debugging-port=$debugPort',
-            if (enableDebugExtension) '--load-extension=debug_extension/web',
-            if (headless) '--headless'
-          ]
-        }
-      });
-    webDriver = await createDriver(
-        spec: WebDriverSpec.JsonWire,
-        desired: capabilities,
-        uri: Uri.parse(
-            'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/'));
-    var connection = ChromeConnection('localhost', debugPort);
-
-    port = await findUnusedPort();
-    testServer = await TestServer.start(
-        hostname,
-        port,
-        assetHandler,
-        assetReader,
-        requireStrategy,
-        metadataProvider,
-        pathToServe,
-        buildResults,
-        () async => connection,
-        serveDevTools,
-        enableDebugExtension,
-        autoRun,
-        enableDebugging,
-        useSse,
-        urlEncoder,
-        restoreBreakpoints,
-        expressionCompiler,
-        logWriter,
-        spawnDds);
-
-    appUrl = 'http://localhost:$port/$path';
-    await webDriver.get(appUrl);
-    var tab = await connection.getTab((t) => t.url == appUrl);
-    tabConnection = await tab.connect();
-    await tabConnection.runtime.enable();
-    await tabConnection.debugger.enable();
-
-    if (enableDebugExtension) {
-      var extensionTab = await _fetchDartDebugExtensionTab(connection);
-      extensionConnection = await extensionTab.connect();
-      await extensionConnection.runtime.enable();
-    }
-
-    appConnection = await testServer.dwds.connectedApps.first;
-    if (enableDebugging && !waitToDebug) {
-      await startDebugging();
+      await tearDown();
+      rethrow;
     }
   }
 
@@ -290,7 +302,17 @@ class TestContext {
     await daemonClient?.close();
     await webRunner?.stop();
     await testServer?.stop();
+    client?.close();
     await _outputDir?.delete(recursive: true);
+
+    // clear the state for next setup
+    webDriver = null;
+    chromeDriver = null;
+    daemonClient = null;
+    webRunner = null;
+    testServer = null;
+    client = null;
+    _outputDir = null;
   }
 
   Future<void> changeInput() async {

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -23,6 +23,9 @@ class FakeAssetReader implements AssetReader {
   @override
   Future<String> sourceMapContents(String serverPath) =>
       throw UnimplementedError();
+
+  @override
+  Future<void> close() async {}
 }
 
 void main() {

--- a/frontend_server_common/lib/src/asset_server.dart
+++ b/frontend_server_common/lib/src/asset_server.dart
@@ -133,7 +133,8 @@ class TestAssetServer implements AssetReader {
   }
 
   /// Tear down the http server running.
-  Future<void> dispose() {
+  @override
+  Future<void> close() {
     return _httpServer.close();
   }
 

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -53,7 +53,7 @@ class WebDevFS {
 
   Future<void> dispose() {
     fileSystem.currentDirectory = _savedCurrentDirectory;
-    return assetServer.dispose();
+    return assetServer.close();
   }
 
   Future<UpdateFSReport> update({

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Expand `package:vm_service` to version `>=3.0.0 <6.0.0`.
 - Require at least `build_web_compilers` version `2.12.0`.
 - Depend on the latest `package:dwds`.
+- Fix issue where open http connections prevent the process for exiting.
 
 ## 2.6.2
 


### PR DESCRIPTION
proxyHandler is creating new http client if none is passed to it,
and this client is never closed, which causes the program to hang
in some scenarios - for example, in a coming expression evaluation
feature where the expression compiler worker is running in an
isolate, communicating with webdev isolate using send/receive
ports.

- pass an http client to all proxyHandlers
- close that client on exit
- cleanup running services on context.setup fail so to the
  subsequent setup retries do not fail due to services stil
  running.