### PR TITLE
Make disable-dds flag shared for all webdev commands

### DIFF
--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -355,8 +355,8 @@ class Configuration {
         release: release,
         reload: _parseReloadConfiguration(argResults),
         requireBuildWebCompilers: requireBuildWebCompilers,
-        verbose: verbose,
-        disableDds: disableDds);
+        disableDds: disableDds,
+        verbose: verbose);
   }
 }
 

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -44,11 +44,6 @@ refresh: Performs a full page refresh.
         help: 'Specify which port the Chrome debugger is listening on. '
             'If used with $launchInChromeFlag Chrome will be started with the'
             ' debugger listening on this port.')
-    ..addFlag(disableDdsFlag,
-        negatable: false,
-        help: 'Disable the Dart Development Service (DDS). Disabling DDS may '
-            'result in a degraded developer experience in some tools.',
-        hide: true)
     ..addOption(hostnameFlag,
         help: 'Specify the hostname to serve on.', defaultsTo: 'localhost')
     ..addFlag(hotRestartFlag,

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -37,6 +37,11 @@ void addSharedArgs(ArgParser argParser,
         defaultsTo: true,
         negatable: true,
         help: 'If a dependency on `build_web_compilers` is required to run.')
+    ..addFlag(disableDdsFlag,
+        negatable: false,
+        help: 'Disable the Dart Development Service (DDS). Disabling DDS may '
+            'result in a degraded developer experience in some tools.',
+        hide: true)
     ..addFlag(verboseFlag,
         abbr: 'v',
         defaultsTo: false,


### PR DESCRIPTION
Previously `disable-dds` flag was only available for `webdev serve` command only, but we run `dds` with other webdev commands as well. Move it to common flags instead.