### PR TITLE
Synchronize requests and responses to expression compilation service

### DIFF
--- a/dwds/dart_test.yaml
+++ b/dwds/dart_test.yaml
@@ -3,5 +3,5 @@ retry: 3
 
 tags:
   extension:  # Extension tests require configuration, so we may exclude.
-  frontend-server: #Frontend server test require dev version of SDK, so we may exclude for stable SDK
-  expression-compilation-service: #Expression compilation service test require dev version of SDK, so we may exclude for stable SDK
+  frontend-server: # Frontend server test require dev version of SDK, so we may exclude for stable SDK
+  expression-compilation-service: # Expression compilation service test require dev version of SDK, so we may exclude for stable SDK

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -39,14 +39,14 @@ class ExpressionCompilerService implements ExpressionCompiler {
     this._logWriter,
   ) : _responseQueue = StreamQueue<dynamic>(_responseStream);
 
-  Future<dynamic> _getResponse(dynamic request) {
+  Future<dynamic> _getResponse(dynamic request) async {
     _sendPort.send(request);
-    return _responseQueue.hasNext.then((value) => value
+    return (await _responseQueue.hasNext)
         ? _responseQueue.next
         : Future.value({
             'succeeded': false,
             'errors': ['compilation service response stream closed'],
-          }));
+          });
   }
 
   /// Handles resource requests from expression compiler worker.

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
+import 'package:async/async.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:path/path.dart' as p;
@@ -19,44 +20,29 @@ import 'expression_compiler.dart';
 /// mode in an isolate and communicates with the isolate via send/receive
 /// ports. It also handles full dill file read requests from the isolate
 /// and redirects them to the asset server.
-///
-/// Expression compiler serivice provides following API for the client:
-///
-/// [updateDependencies] - (re)load changed full dill files into the
-/// expression compilation worker.
-///
-/// [compileExpressionToJs] - compile expression to JavaScript to support
-/// expression evaluation fetures in the debugger.
-///
-/// [stop] - stop the service.
 class ExpressionCompilerService implements ExpressionCompiler {
   Isolate _worker;
-  final Stream _responseStream;
+  final StreamQueue<dynamic> _responseQueue;
   final ReceivePort _receivePort;
   final SendPort _sendPort;
   final Handler _assetHandler;
   final String _target;
   final Function(Level, String) _logWriter;
-  Completer<dynamic> _requestCompleter;
 
   ExpressionCompilerService._(
     this._worker,
-    this._responseStream,
+    Stream _responseStream,
     this._receivePort,
     this._sendPort,
     this._assetHandler,
     this._target,
     this._logWriter,
-  ) {
-    _responseStream.listen((response) {
-      if (_requestCompleter == null) {
-        _logWriter(Level.WARNING,
-            'ExpressionCompilerService: unexpected response from isolate $response');
-        return;
-      }
-      _requestCompleter.complete(response);
-      _requestCompleter = null;
-    });
+  ) : _responseQueue = StreamQueue<dynamic>(_responseStream);
+
+  Future<dynamic> _getResponse(dynamic request) {
+    _sendPort.send(request);
+    return _responseQueue.hasNext
+        .then((value) => value ? _responseQueue.next : Future.value(null));
   }
 
   /// Handles resource requests from expression compiler worker.
@@ -171,34 +157,29 @@ class ExpressionCompilerService implements ExpressionCompiler {
     return service;
   }
 
-  /// Update full dill files for changed modules.
+  /// (Re)loads full dill files for changed modules.
   ///
   /// [modules]: moduleName -> full dill path
   ///
-  /// [updateDependencies] needs to be called after every compilation
-  /// to update full dil files for changed modules that are loaded into
-  /// the expression compiler worker.
+  /// Needs to be called after every compilation to (re)load full dill files
+  /// for changed modules into the expression compiler worker.
   Future<bool> updateDependencies(Map<String, String> modules) async {
     if (_worker == null) {
       throw StateError('Expression compilation service has stopped');
     }
-    _requestCompleter = Completer<dynamic>();
 
     _logWriter(Level.INFO,
         'Updating dependencies for expression compilation service...');
     _logWriter(Level.FINEST, 'Dependencies: $modules');
 
-    _sendPort.send({
+    var event = await _getResponse({
       'command': 'UpdateDeps',
       'inputs': [
         for (var moduleName in modules.keys)
           {'path': modules[moduleName], 'moduleName': moduleName},
       ]
     });
-
-    var event = await _requestCompleter.future;
     var response = event as Map<String, dynamic>;
-
     var result = response['succeeded'] as bool;
     if (result) {
       _logWriter(
@@ -224,14 +205,13 @@ class ExpressionCompilerService implements ExpressionCompiler {
     if (_worker == null) {
       throw StateError('Expression compilation service has stopped');
     }
-    _requestCompleter = Completer<dynamic>();
 
     _logWriter(
         Level.FINEST,
         'ExpressionCompilerService: compiling '
         '"$expression" at $libraryUri:$line');
 
-    _sendPort.send({
+    var event = await _getResponse({
       'command': 'CompileExpression',
       'expression': expression,
       'line': line,
@@ -242,7 +222,6 @@ class ExpressionCompilerService implements ExpressionCompiler {
       'moduleName': moduleName,
     });
 
-    var event = await _requestCompleter.future;
     var response = event as Map<String, dynamic>;
     var errors = response['errors'] as List<String>;
     var error =
@@ -254,13 +233,12 @@ class ExpressionCompilerService implements ExpressionCompiler {
     return ExpressionCompilationResult(result, !succeeded);
   }
 
-  /// Stop the service
+  /// Stops the service.
   ///
   /// Terminates the isolate running expression compiler worker
   /// and marks the service as stopped.
   Future<void> stop() async {
     _sendPort.send({'command': 'Shutdown'});
-    _requestCompleter = null;
     _receivePort.close();
     _worker = null;
     _logWriter(Level.INFO, 'Stopped expression compilation service.');

--- a/webdev/lib/src/command/daemon_command.dart
+++ b/webdev/lib/src/command/daemon_command.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:async/async.dart';
+import 'package:logging/logging.dart';
 
 import '../daemon/app_domain.dart';
 import '../daemon/daemon.dart';
@@ -83,16 +84,18 @@ class DaemonCommand extends Command<int> {
       daemon = Daemon(_stdinCommandStream, _stdoutCommandResponse);
       var daemonDomain = DaemonDomain(daemon);
       setLogWriter((level, message, {loggerName, error, stackTrace, verbose}) {
-        daemonDomain.sendEvent('daemon.log', {
-          'log': formatLog(
-            level,
-            message,
-            loggerName: loggerName,
-            error: error,
-            stackTrace: stackTrace,
-            verbose: verbose,
-          )
-        });
+        if (verbose || level >= Level.INFO) {
+          daemonDomain.sendEvent('daemon.log', {
+            'log': formatLog(
+              level,
+              message,
+              loggerName: loggerName,
+              error: error,
+              stackTrace: stackTrace,
+              verbose: verbose,
+            )
+          });
+        }
       });
       daemon.registerDomain(daemonDomain);
       var buildOptions = buildRunnerArgs(pubspecLock, configuration);

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -272,6 +272,7 @@ void main() {
         '--no-enable-expression-evaluation',
       ];
       var process = await runWebDev(args, workingDirectory: exampleDirectory);
+      VmService vmService;
 
       try {
         // Wait for debug service Uri
@@ -282,7 +283,7 @@ void main() {
         }));
         expect(wsUri, isNotNull);
 
-        var vmService = await vmServiceConnectUri(wsUri);
+        vmService = await vmServiceConnectUri(wsUri);
         var vm = await vmService.getVM();
         var isolate = vm.isolates.first;
         var scripts = await vmService.getScripts(isolate.id);
@@ -307,9 +308,8 @@ void main() {
             () => vmService.evaluateInFrame(
                 isolate.id, event.topFrame.index, 'true'),
             throwsRPCError);
-
-        vmService.dispose();
       } finally {
+        vmService?.dispose();
         await exitWebdev(process);
         await process.shouldExit();
       }


### PR DESCRIPTION
Previously, some of the responses to requests from VSCode were arriving out of order.
In this change:

- make sure requests and responses in expression compilation service match
- address latests minor CR comments from the initial expression evaluation PR
- make daemon logger not emit low-level messages in non-verbose mode

Closes: https://github.com/dart-lang/webdev/issues/1134