### PR TITLE
remove duplicate async frames

### DIFF
--- a/dwds/lib/src/debugging/frame_computer.dart
+++ b/dwds/lib/src/debugging/frame_computer.dart
@@ -72,6 +72,23 @@ class FrameComputer {
       await _collectAsyncFrames(dartFrames, frameIndex, asyncFrames);
     }
 
+    // The above method can return several kAsyncSuspensionMarkers together;
+    // remove duplicates.
+    if (dartFrames.length > 1) {
+      for (var i = dartFrames.length - 1; i >= 1; i--) {
+        if (dartFrames[i].kind == FrameKind.kAsyncSuspensionMarker &&
+            dartFrames[i - 1].kind == FrameKind.kAsyncSuspensionMarker) {
+          dartFrames.removeAt(i);
+        }
+      }
+    }
+
+    // Remove any trailing kAsyncSuspensionMarker frame.
+    if (dartFrames.isNotEmpty &&
+        dartFrames.last.kind == FrameKind.kAsyncSuspensionMarker) {
+      dartFrames.removeLast();
+    }
+
     return dartFrames;
   }
 

--- a/dwds/test/fixtures/debugger_data.dart
+++ b/dwds/test/fixtures/debugger_data.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Contains hard-coded test data usable for tests.
-
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 // ignore_for_file: prefer_single_quotes
@@ -84,7 +83,7 @@ List<Map<String, dynamic>> frames1Json = [
         }
       }
     ],
-    "this": {"type": "undefined"}
+    "this": {"type": "undefined"},
   }
 ];
 


### PR DESCRIPTION
- remove duplicate async frames
- remove any trailing async frame

This address issues seen in the debugger - due to how we calculate stack frames, we can create multiple adjacent async frame markers (and, can have a trailing async frame marker after all actual frames). In this image, they're the 'async gap' frames.

<img width="359" alt="Screen Shot 2020-10-06 at 4 17 03 PM" src="https://user-images.githubusercontent.com/1269969/95543873-80839a80-09ae-11eb-82d7-7166b8ec7dfa.png">
