### PR TITLE
Support DigestProvider in FrontendServerRequireStrategyProvider

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -27,6 +27,7 @@
   the `MetadataProvider`.
 - No longer require a `LogWriter` and corresponding `verbose` arguement
   but instead properly use `package:logger`.
+- `FrontendServerRequireStrategyProvider` now requires a `digestProvider`.
 
 ## 6.0.0
 

--- a/dwds/lib/src/loaders/frontend_server_require.dart
+++ b/dwds/lib/src/loaders/frontend_server_require.dart
@@ -10,27 +10,23 @@ import 'strategy.dart';
 class FrontendServerRequireStrategyProvider {
   final ReloadConfiguration _configuration;
   final AssetReader _assetReader;
+  final Future<Map<String, String>> Function() _digestsProvider;
 
   RequireStrategy _requireStrategy;
 
-  FrontendServerRequireStrategyProvider(this._configuration, this._assetReader);
+  FrontendServerRequireStrategyProvider(
+      this._configuration, this._assetReader, this._digestsProvider);
 
   RequireStrategy get strategy => _requireStrategy ??= RequireStrategy(
         _configuration,
         _moduleProvider,
-        _digestsProvider,
+        (_) => _digestsProvider(),
         _moduleForServerPath,
         _serverPathForModule,
         _sourceMapPathForModule,
         _serverPathForAppUri,
         _assetReader,
       );
-
-  Future<Map<String, String>> _digestsProvider(
-      MetadataProvider metadataProvider) async {
-    // TODO(grouma) - provide actual digests.
-    return {};
-  }
 
   Future<Map<String, String>> _moduleProvider(
           MetadataProvider metadataProvider) async =>

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -231,9 +231,7 @@ class TestContext {
             assetHandler = webRunner.devFS.assetServer.handleRequest;
 
             requireStrategy = FrontendServerRequireStrategyProvider(
-              reloadConfiguration,
-              assetReader,
-            ).strategy;
+                reloadConfiguration, assetReader, () async => {}).strategy;
 
             buildResults = const Stream<BuildResults>.empty();
           }


### PR DESCRIPTION
I don't think we can generically provide digests from `package:dwds`. However, with this callback support, Flutter Tools should be able to fully consume this abstraction and reduce the code duplication.

See https://github.com/flutter/flutter/pull/68235