### PR TITLE
Remove ddc-specific asset server

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -153,9 +153,14 @@ class ChromeProxyService implements VmServiceInterface {
     _locations.initialize(entrypoint);
     _modules.initialize(entrypoint);
     var metadataProvider = globalLoadStrategy.metadataProviderFor(entrypoint);
-    await _compiler?.updateDependencies(
-        (await metadataProvider.moduleToModulePath).map((key, value) =>
-            MapEntry(key, value.replaceAll('.js', '.full.dill'))));
+    var modules = await metadataProvider.moduleToModulePath;
+    var dependencies = <String, String>{};
+    for (var module in modules.keys) {
+      var serverPath =
+          await globalLoadStrategy.serverPathForModule(entrypoint, module);
+      dependencies[module] = serverPath.replaceAll('.js', '.full.dill');
+    }
+    await _compiler?.updateDependencies(dependencies);
   }
 
   /// Creates a new isolate.

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -27,16 +27,9 @@ class ExpressionCompilerService implements ExpressionCompiler {
   final ReceivePort _receivePort;
   final SendPort _sendPort;
   final Handler _assetHandler;
-  final String _target;
 
-  ExpressionCompilerService._(
-    this._worker,
-    this._responseQueue,
-    this._receivePort,
-    this._sendPort,
-    this._assetHandler,
-    this._target,
-  );
+  ExpressionCompilerService._(this._worker, this._responseQueue,
+      this._receivePort, this._sendPort, this._assetHandler);
 
   /// Sends [request] on [_sendPort] and returns the next event from the
   /// response stream.
@@ -63,8 +56,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
     var uri = request.requestedUri.queryParameters['uri'];
     var query = request.requestedUri.path;
 
-    _logger
-        .finest('ExpressionCompilerService: request: ${request.requestedUri}');
+    _logger.finest('request: ${request.requestedUri}');
 
     if (query != '/getResource' || uri == null) {
       return Response.notFound(uri);
@@ -77,11 +69,9 @@ class ExpressionCompilerService implements ExpressionCompiler {
     var serverPath = uri;
     if (uri.endsWith('.dart')) {
       serverPath = DartUri(uri).serverPath;
-      serverPath = '$_target/$serverPath';
     }
 
-    _logger
-        .finest('ExpressionCompilerService: serverpath for $uri: $serverPath');
+    _logger.finest('serverpath for $uri: $serverPath');
 
     request = Request(
         'GET',
@@ -108,7 +98,6 @@ class ExpressionCompilerService implements ExpressionCompiler {
   static Future<ExpressionCompilerService> start(
     String address,
     int port,
-    String target,
     Handler assetHandler,
     bool verbose,
   ) async {
@@ -135,7 +124,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
       if (verbose) '--verbose',
     ];
 
-    _logger.info('Starting expression compilation service...');
+    _logger.info('Starting...');
     _logger.finest('$workerUri ${args.join(' ')}');
 
     final receivePort = ReceivePort();
@@ -154,7 +143,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
     var sendPort = await responseQueue.next as SendPort;
 
     var service = ExpressionCompilerService._(
-        isolate, responseQueue, receivePort, sendPort, assetHandler, target);
+        isolate, responseQueue, receivePort, sendPort, assetHandler);
 
     return service;
   }
@@ -165,7 +154,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
       throw StateError('Expression compilation service has stopped');
     }
 
-    _logger.info('Updating dependencies for expression compilation service...');
+    _logger.info('Updating dependencies...');
     _logger.finest('Dependencies: $modules');
 
     var response = await _send({
@@ -177,9 +166,9 @@ class ExpressionCompilerService implements ExpressionCompiler {
     });
     var result = response == null ? false : response['succeeded'] as bool;
     if (result) {
-      _logger.info('Updated dependencies for expression compilation.');
+      _logger.info('Updated dependencies.');
     } else {
-      _logger.info('Failed to update dependencies for expression compilation.');
+      _logger.info('Failed to update dependencies.');
     }
     return result;
   }
@@ -199,8 +188,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
       throw StateError('Expression compilation service has stopped');
     }
 
-    _logger.finest('ExpressionCompilerService: compiling '
-        '"$expression" at $libraryUri:$line');
+    _logger.finest('compiling "$expression" at $libraryUri:$line');
 
     var response = await _send({
       'command': 'CompileExpression',
@@ -235,6 +223,6 @@ class ExpressionCompilerService implements ExpressionCompiler {
     _sendPort.send({'command': 'Shutdown'});
     _receivePort.close();
     _worker = null;
-    _logger.info('Stopped expression compilation service.');
+    _logger.info('Stopped.');
   }
 }

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -120,12 +120,13 @@ void main() async {
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '2'));
+              const TypeMatcher<ErrorRef>().having(
+                  (instance) => 
+                    instance.message, 
+                    'message', 
+                    contains("The getter '_field' isn't defined")));
         });
-      },
-          skip: 'Incorrect JavaScript for types from other libraries: '
-              'https://github.com/dart-lang/sdk/issues/43469');
+      });
 
       test('access instance fields after evaluation', () async {
         await onBreakPoint(isolate.id, mainScript, 'printField', () async {
@@ -154,7 +155,7 @@ void main() async {
               (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'valueFromTestLibrary');
+              isolate.id, event.topFrame.index, 'testLibraryValue');
 
           expect(
               result,
@@ -210,7 +211,7 @@ void main() async {
         });
       });
 
-      test('evaluate expression in another library', () async {
+      test('evaluate expression in _testPackage/test_library', () async {
         await onBreakPoint(isolate.id, testLibraryScript, 'testLibraryFunction', () async {
           var event = await stream.firstWhere(
               (Event event) => event.kind == EventKind.kPauseBreakpoint);
@@ -221,13 +222,13 @@ void main() async {
           expect(
               result,
               const TypeMatcher<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '13'));
+                  (instance) => instance.valueAsString, 'valueAsString', '23'));
         });
-      }, solo: true);
+      });
 
 
-      test('evaluate expression in a class constructor in another library', () async {
-        await onBreakPoint(isolate.id, testLibraryScript, 'testLibraryConstructor', () async {
+      test('evaluate expression in a class constructor in _testPackage/test_library', () async {
+        await onBreakPoint(isolate.id, testLibraryScript, 'testLibraryClassConstructor', () async {
           var event = await stream.firstWhere(
               (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
@@ -244,22 +245,22 @@ void main() async {
       'https://github.com/dart-lang/sdk/issues/43728');
 
       test('evaluate expression in caller frame', () async {
-        await onBreakPoint(isolate.id, testLibraryScript, 'printFromLibrary', () async {
+        await onBreakPoint(isolate.id, testLibraryScript, 'testLibraryFunction', () async {
           var event = await stream.firstWhere(
               (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index+  1, 'local');
+              isolate.id, event.topFrame.index + 1, 'local');
 
           expect(
               result,
               const TypeMatcher<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '1'));
+                  (instance) => instance.valueAsString, 'valueAsString', '23'));
         });
       });
 
-      test('evaluate expression in a library in another package', () async {
-        await onBreakPoint(isolate.id, libraryScript, 'printFromPackage', () async {
+      test('evaluate expression in  _test/library', () async {
+        await onBreakPoint(isolate.id, libraryScript, 'Concatenate', () async {
           var event = await stream.firstWhere(
               (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
@@ -269,7 +270,7 @@ void main() async {
           expect(
               result,
               const TypeMatcher<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', 'Program'));
+                  (instance) => instance.valueAsString, 'valueAsString', 'Hello'));
         });
       });
 

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/services/chrome_proxy_service.dart';
+import 'package:matcher/src/type_matcher.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
@@ -45,7 +46,7 @@ void main() async {
 
   group('shared context with evaluation', () {
     setUpAll(() async {
-      // Note: change printOnFailure to print for debug printing
+      // Note: change 'printOnFailure' to 'print' for debug printing
       configureLogWriter(
           customLogWriter: (level, message,
                   {loggerName, error, stackTrace, verbose}) =>
@@ -89,55 +90,53 @@ void main() async {
 
       test('local', () async {
         await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'local');
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
+              isA<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'valueAsString', '42'));
         });
       });
 
       test('field', () async {
         await onBreakPoint(isolate.id, mainScript, 'printField', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'instance.field');
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
+              isA<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'valueAsString', '1'));
         });
       });
 
       test('private field', () async {
         await onBreakPoint(isolate.id, mainScript, 'printField', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'instance._field');
 
           expect(
               result,
-              const TypeMatcher<ErrorRef>().having(
-                  (instance) => instance.message,
-                  'message',
+              isA<ErrorRef>().having((instance) => instance.message, 'message',
                   contains("The getter '_field' isn't defined")));
         });
       });
 
       test('access instance fields after evaluation', () async {
         await onBreakPoint(isolate.id, mainScript, 'printField', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var instanceRef = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'instance') as InstanceRef;
@@ -150,69 +149,67 @@ void main() async {
 
           expect(
               field.value,
-              const TypeMatcher<InstanceRef>().having(
+              isA<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'valueAsString', '1'));
         });
       });
 
       test('global', () async {
         await onBreakPoint(isolate.id, mainScript, 'printGlobal', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'testLibraryValue');
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
+              isA<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'valueAsString', '3'));
         });
       });
 
       test('call core function', () async {
         await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'print(local)');
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
-                  (instance) => instance.valueAsString,
-                  'valueAsString',
-                  'null'));
+              isA<InstanceRef>().having((instance) => instance.valueAsString,
+                  'valueAsString', 'null'));
         });
       });
 
       test('call library function with const param', () async {
         await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'testLibraryFunction(42)');
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
+              isA<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'valueAsString', '42'));
         });
       });
 
       test('call library function with local param', () async {
         await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'testLibraryFunction(local)');
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
+              isA<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'valueAsString', '42'));
         });
       });
@@ -220,15 +217,15 @@ void main() async {
       test('evaluate expression in _testPackage/test_library', () async {
         await onBreakPoint(isolate.id, testLibraryScript, 'testLibraryFunction',
             () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'formal');
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
+              isA<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'valueAsString', '23'));
         });
       });
@@ -239,15 +236,15 @@ void main() async {
         await onBreakPoint(
             isolate.id, testLibraryScript, 'testLibraryClassConstructor',
             () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'this.field');
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
+              isA<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'valueAsString', '1'));
         });
       },
@@ -257,57 +254,53 @@ void main() async {
       test('evaluate expression in caller frame', () async {
         await onBreakPoint(isolate.id, testLibraryScript, 'testLibraryFunction',
             () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index + 1, 'local');
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
+              isA<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'valueAsString', '23'));
         });
       });
 
       test('evaluate expression in  _test/library', () async {
         await onBreakPoint(isolate.id, libraryScript, 'Concatenate', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var result = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'a');
 
           expect(
               result,
-              const TypeMatcher<InstanceRef>().having(
-                  (instance) => instance.valueAsString,
-                  'valueAsString',
-                  'Hello'));
+              isA<InstanceRef>().having((instance) => instance.valueAsString,
+                  'valueAsString', 'Hello'));
         });
       });
 
       test('error', () async {
         await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           var error = await service.evaluateInFrame(
               isolate.id, event.topFrame.index, 'typo');
 
           expect(
               error,
-              const TypeMatcher<ErrorRef>().having(
-                  (instance) => instance.message,
-                  'message',
+              isA<ErrorRef>().having((instance) => instance.message, 'message',
                   matches('CompilationError: Getter not found:.*typo')));
         });
       });
 
       test('cannot evaluate in unsupported isolate', () async {
         await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           expect(
               () =>
@@ -352,8 +345,8 @@ void main() async {
 
       test('cannot evaluate expression', () async {
         await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream.firstWhere(
-              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
           expect(
               () => service.evaluateInFrame(

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -51,7 +51,7 @@ void main() async {
                   {loggerName, error, stackTrace, verbose}) =>
               printOnFailure(message));
 
-      await context.setUp(enableExpressionEvaluation: true, verbose: true);
+      await context.setUp(enableExpressionEvaluation: true, verbose: false);
     });
 
     tearDownAll(() async {

--- a/dwds/test/fixtures/logging.dart
+++ b/dwds/test/fixtures/logging.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+typedef LogWriter = void Function(Level level, String message,
+    {String error, String loggerName, String stackTrace});
+
+StreamSubscription<LogRecord> _loggerSub;
+
+void configureLogWriter({LogWriter customLogWriter}) {
+  _logWriter = customLogWriter ?? _logWriter;
+  Logger.root.level = Level.ALL;
+  _loggerSub ??= Logger.root.onRecord.listen((event) {
+    logWriter(event.level, event.message,
+        error: '${event.error}',
+        loggerName: event.loggerName,
+        stackTrace: '${event.stackTrace}');
+  });
+}
+
+void stopLogWriter() {
+  _loggerSub.cancel();
+  _loggerSub = null;
+}
+
+LogWriter _logWriter = (level, message,
+        {String error, String loggerName, String stackTrace}) =>
+    printOnFailure(message);
+
+LogWriter get logWriter => _logWriter;

--- a/dwds/test/fixtures/logging.dart
+++ b/dwds/test/fixtures/logging.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:logging/logging.dart';
@@ -8,6 +12,22 @@ typedef LogWriter = void Function(Level level, String message,
 
 StreamSubscription<LogRecord> _loggerSub;
 
+/// Configure test log writer.
+///
+/// Tests and groups of tests can use this to configure
+/// individual log writers on setup.
+///
+/// For example, to verbose printing during debugging:
+///
+/// group('shared context', () {
+///     setUpAll(() async {
+///       configureLogWriter(
+///           customLogWriter: (level, message,
+///                   {loggerName, error, stackTrace, verbose}) =>
+///               print(message));
+///
+///       await context.setUp();
+///     });
 void configureLogWriter({LogWriter customLogWriter}) {
   _logWriter = customLogWriter ?? _logWriter;
   Logger.root.level = Level.ALL;

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -92,7 +92,7 @@ void main() async {
             (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
         var result = await service.evaluateInFrame(
-            isolate.id, event.topFrame.index, 'valueFromTestPackage');
+            isolate.id, event.topFrame.index, 'valueFromTestLibrary');
 
         expect(
             result,

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -92,7 +92,7 @@ void main() async {
             (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
         var result = await service.evaluateInFrame(
-            isolate.id, event.topFrame.index, 'valueFromTestLibrary');
+            isolate.id, event.topFrame.index, 'testLibraryValue');
 
         expect(
             result,

--- a/fixtures/_test/lib/library.dart
+++ b/fixtures/_test/lib/library.dart
@@ -8,6 +8,5 @@ library test_library;
 int aVariable = 3;
 
 String concatenate(String a, String b) {
-  print('Concatenating $a and $b'); // breakPoint printFromPackage
-  return '$a$b';
+  return '$a$b'; // Breakpoint: Concatenate
 }

--- a/fixtures/_test/lib/library.dart
+++ b/fixtures/_test/lib/library.dart
@@ -8,6 +8,6 @@ library test_library;
 int aVariable = 3;
 
 String concatenate(String a, String b) {
-  print('Concatenating $a and $b');
+  print('Concatenating $a and $b'); // breakPoint printFromPackage
   return '$a$b';
 }

--- a/fixtures/_test/pubspec.yaml
+++ b/fixtures/_test/pubspec.yaml
@@ -14,6 +14,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.6.7
   build_web_compilers: ^2.12.0
-  webdev:
-    path: ../../webdev
 

--- a/fixtures/_test/pubspec.yaml
+++ b/fixtures/_test/pubspec.yaml
@@ -8,10 +8,12 @@ environment:
   sdk: ">=2.5.0 <3.0.0"
 
 dependencies:
-  intl: ^0.15.8
+  intl: ^0.16.0
   path: ^1.6.1
 
 dev_dependencies:
   build_runner: ^1.6.7
   build_web_compilers: ^2.12.0
+  webdev:
+    path: ../../webdev
 

--- a/fixtures/_testPackage/lib/test_library.dart
+++ b/fixtures/_testPackage/lib/test_library.dart
@@ -2,17 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-int valueFromTestLibrary= 3;
+int testLibraryValue = 3;
 
 int testLibraryFunction(int formal) {
   return formal; // Breakpoint: testLibraryFunction
 }
 
-class ClassFromPackage {
+class TestLibraryClass {
   final int field;
   final int _field;
-  ClassFromPackage(this.field, this._field) {
-    print('Contructor'); // Breakpoint: testLibraryConstructor
+  TestLibraryClass(this.field, this._field) {
+    print('Contructor'); // Breakpoint: testLibraryClassConstructor
   }
 
   @override

--- a/fixtures/_testPackage/lib/test_library.dart
+++ b/fixtures/_testPackage/lib/test_library.dart
@@ -2,16 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-int valueFromTestPackage = 3;
+int valueFromTestLibrary= 3;
 
 int testLibraryFunction(int formal) {
-  return formal;
+  return formal; // Breakpoint: testLibraryFunction
 }
 
 class ClassFromPackage {
   final int field;
   final int _field;
-  ClassFromPackage(this.field, this._field);
+  ClassFromPackage(this.field, this._field) {
+    print('Contructor'); // Breakpoint: testLibraryConstructor
+  }
 
   @override
   String toString() => 'field: $field, _field: $_field';

--- a/fixtures/_testPackage/pubspec.yaml
+++ b/fixtures/_testPackage/pubspec.yaml
@@ -14,5 +14,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.0.0
   build_web_compilers: ^2.12.0
-  webdev:
-    path: ../../webdev
+

--- a/fixtures/_testPackage/pubspec.yaml
+++ b/fixtures/_testPackage/pubspec.yaml
@@ -14,3 +14,5 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.0.0
   build_web_compilers: ^2.12.0
+  webdev:
+    path: ../../webdev

--- a/fixtures/_testPackage/web/main.dart
+++ b/fixtures/_testPackage/web/main.dart
@@ -7,6 +7,13 @@ import 'dart:html';
 import 'package:_test/library.dart';
 import 'package:_testPackage/test_library.dart';
 
+extension NumberParsing on String {
+  int parseInt() {
+    var ret = int.parse(this);
+    return ret; // Breakpoint: extension
+  }
+}
+
 void main() {
   var count = 0;
   // For setting breakpoints.
@@ -22,6 +29,7 @@ void main() {
     printGlobal();
     printFromTestLibrary();
     printFromTestPackage();
+    printCallExtension();
   });
 
   document.body.appendText(concatenate('Program', ' is running!'));
@@ -48,4 +56,9 @@ void printFromTestPackage() {
 void printFromTestLibrary() {
   var local = 23;
   print(testLibraryFunction(local));
+}
+
+void printCallExtension() {
+  var local = '23';
+  print(local.parseInt());
 }

--- a/fixtures/_testPackage/web/main.dart
+++ b/fixtures/_testPackage/web/main.dart
@@ -12,7 +12,7 @@ void main() {
   // For setting breakpoints.
   Timer.periodic(const Duration(seconds: 1), (_) {
     print('Count is: ${++count}');
-    print(valueFromTestPackage);
+    print(valueFromTestLibrary);
   });
 
   // for evaluation
@@ -20,6 +20,8 @@ void main() {
     printLocal();
     printField();
     printGlobal();
+    printFromTestLibrary();
+    printFromTestPackage();
   });
 
   document.body.appendText(concatenate('Program', ' is running!'));
@@ -31,10 +33,19 @@ void printLocal() {
 }
 
 void printField() {
-  var instance = ClassFromPackage(1, 2);
+  var local = 1;
+  var instance = ClassFromPackage(local, 2);
   print('$instance'); // Breakpoint: printField
 }
 
 void printGlobal() {
-  print(valueFromTestPackage); // Breakpoint: printGlobal
+  print(valueFromTestLibrary); // Breakpoint: printGlobal
+}
+
+void printFromTestPackage() {
+  print(concatenate('Hello', ' World'));
+}
+
+void printFromTestLibrary() {
+  print(testLibraryFunction(13));
 }

--- a/fixtures/_testPackage/web/main.dart
+++ b/fixtures/_testPackage/web/main.dart
@@ -12,7 +12,7 @@ void main() {
   // For setting breakpoints.
   Timer.periodic(const Duration(seconds: 1), (_) {
     print('Count is: ${++count}');
-    print(valueFromTestLibrary);
+    print(testLibraryValue);
   });
 
   // for evaluation
@@ -33,13 +33,12 @@ void printLocal() {
 }
 
 void printField() {
-  var local = 1;
-  var instance = ClassFromPackage(local, 2);
+  var instance = TestLibraryClass(1, 2);
   print('$instance'); // Breakpoint: printField
 }
 
 void printGlobal() {
-  print(valueFromTestLibrary); // Breakpoint: printGlobal
+  print(testLibraryValue); // Breakpoint: printGlobal
 }
 
 void printFromTestPackage() {
@@ -47,5 +46,6 @@ void printFromTestPackage() {
 }
 
 void printFromTestLibrary() {
-  print(testLibraryFunction(13));
+  var local = 23;
+  print(testLibraryFunction(local));
 }

--- a/webdev/lib/src/logging.dart
+++ b/webdev/lib/src/logging.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:io/ansi.dart';
@@ -11,15 +12,17 @@ typedef LogWriter = void Function(Level level, String message,
     {String error, String loggerName, String stackTrace});
 
 var _verbose = false;
+StreamSubscription<LogRecord> _subscription;
 
 void configureLogWriter(bool verbose, {LogWriter customLogWriter}) {
   _verbose = verbose;
   _logWriter = customLogWriter ?? _logWriter;
-  Logger.root.onRecord.listen((event) {
+  Logger.root.level = verbose ? Level.ALL : Level.INFO;
+  _subscription ??= Logger.root.onRecord.listen((event) {
     logWriter(event.level, event.message,
-        error: '${event.error}',
+        error: event.error?.toString(),
         loggerName: event.loggerName,
-        stackTrace: '${event.stackTrace}');
+        stackTrace: event.stackTrace?.toString());
   });
 }
 

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -105,8 +105,7 @@ class WebDevServer {
     var assetHandler = proxyHandler(
         'http://localhost:${options.daemonPort}/${options.target}/',
         client: client);
-    var ddcAssetHandler =
-        proxyHandler('http://localhost:${options.daemonPort}/', client: client);
+
     Dwds dwds;
     ExpressionCompilerService ddcService;
     if (options.configuration.enableInjectedClient) {
@@ -123,8 +122,7 @@ class WebDevServer {
         ddcService = await ExpressionCompilerService.start(
           options.configuration.hostname,
           options.port,
-          options.target,
-          ddcAssetHandler,
+          assetHandler,
           options.configuration.verbose,
         );
       }


### PR DESCRIPTION
Remove ddc asset handler, fixed logging issues
    
- Remove target from expression compiler service so it can work
  with already defined asset server
  - use already existing asset handler for ddc expression
     compilation service
  - remove "target" from ExpressionCompilerService.start
  - make BuildRunnerRequire use server paths for dill paths
- add tests covering evaluation in libraries
- fix logging problems
   - remove 'null's printed in logs
   - remove double logging by only having one log record subscription
   - emit all messages in verbose mode
    - add test logging setup so we can control logging from dwds tests