### PR TITLE
Remove Flutter Web references

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Depend on the latest `package:sse`.
 - Remove references to Flutter Web as webdev is no longer used with Flutter.
-  Users should be using Flutter Tools shipped with the Fluter SDK.
+  Users should be using Flutter Tools shipped with the Flutter SDK.
 
 
 ## 2.7.0

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.7.1 - Unreleased
 
 - Depend on the latest `package:sse`.
+- Remove references to Flutter Web as webdev is no longer used with Flutter.
+  Users should be using Flutter Tools shipped with the Fluter SDK.
 
 
 ## 2.7.0

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -6,7 +6,6 @@ A command-line tool for developing and deploying web applications with Dart.
 ## Requirements
 
 The latest release of `webdev` requires Dart SDK `2.3` or later.
-This corresponds to Flutter SDK `1.5` or later.
 
 To use `webdev` with a package, make sure you have entries in `pubspec.yaml`
 similar to:
@@ -29,8 +28,6 @@ functionality.*
 
 ```console
 $ pub global activate webdev
-# or
-$ flutter pub global activate webdev
 ```
 
 Learn more about activating and using packages [here][pub global].

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -5,7 +5,7 @@ A command-line tool for developing and deploying web applications with Dart.
 
 ## Requirements
 
-The latest release of `webdev` requires Dart SDK `2.3` or later.
+The latest release of `webdev` requires Dart SDK `2.10.0` or later.
 
 To use `webdev` with a package, make sure you have entries in `pubspec.yaml`
 similar to:

--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -154,7 +154,7 @@ class AppDomain extends Domain {
     if (!fullRestart) {
       return {
         'code': 1,
-        'message': 'hot reload not yet supported by package:flutter_web',
+        'message': 'hot reload not yet supported by webdev',
       };
     }
     // TODO(grouma) - Support pauseAfterRestart.

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -48,12 +48,6 @@ dev_dependencies:
   $pkgName: $constraint''',
           missingDependency: true);
 
-  static PackageExceptionDetails unsupportedFlutterWebDep(String pkgName) =>
-      PackageExceptionDetails._(
-          'You have a dependency on `$pkgName` which is not supported for '
-          'flutter_web tech preview. See https://flutter.dev/web for more '
-          'details.');
-
   @override
   String toString() => [error, description].join('\n');
 }
@@ -127,15 +121,6 @@ class PubspecLock {
     }
     return issues;
   }
-
-  List<PackageExceptionDetails> checkNoFlutterDependency(String pkgName) {
-    var issues = <PackageExceptionDetails>[];
-    var packageDetails = _packages[pkgName] as YamlMap;
-    if (packageDetails != null) {
-      issues.add(PackageExceptionDetails.unsupportedFlutterWebDep(pkgName));
-    }
-    return issues;
-  }
 }
 
 Future<List<PackageExceptionDetails>> _validateBuildDaemonVersion(
@@ -196,26 +181,6 @@ Future<void> checkPubspecLock(PubspecLock pubspecLock,
 
   if (buildRunnerIssues.isEmpty) {
     issues.addAll(await _validateBuildDaemonVersion(pubspecLock));
-  }
-
-  var unsupportedFlutterDeps = [
-    'cached_network_image',
-    'cloud_firestore',
-    'cupertino_icons',
-    'firebase_auth',
-    'firebase_core',
-    'flutter',
-    'flutter_test',
-    'google_sign_in',
-    'image_picker',
-    'path_provider',
-    'shared_preferences',
-    'sqflite',
-    'url_launcher',
-  ];
-
-  for (var dep in unsupportedFlutterDeps) {
-    issues.addAll(pubspecLock.checkNoFlutterDependency(dep));
   }
 
   if (issues.isNotEmpty) {

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -203,33 +203,6 @@ name: sample
         });
       }
 
-      group('unsupported dependency on', () {
-        var unsupportedPkgs = ['flutter', 'flutter_test'];
-        for (var unsupportedPkg in unsupportedPkgs) {
-          test('`$unsupportedPkg` should fail', () async {
-            await d.file('pubspec.yaml', 'name: sample').create();
-
-            await d
-                .file('pubspec.lock', _pubspecLock(extraPkgs: [unsupportedPkg]))
-                .create();
-
-            await d.file('.packages', '').create();
-            await d.dir(
-                '.dart_tool', [d.file('package_config.json', '')]).create();
-
-            var process =
-                await runWebDev([command], workingDirectory: d.sandbox);
-
-            await checkProcessStdout(process, [
-              'webdev could not run for this project.',
-              'You have a dependency on `$unsupportedPkg` which is not '
-                  'supported for flutter_web tech preview.'
-            ]);
-            await process.shouldExit(78);
-          });
-        }
-      });
-
       test('no pubspec.yaml', () async {
         var process = await runWebDev(['serve'], workingDirectory: d.sandbox);
 


### PR DESCRIPTION
We probably should add a readme test to ensure the referenced SDK is updated.