### PR TITLE
Export AbsoluteImportUriException

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -8,6 +8,7 @@
   to enable running expression compiler worker from
   a given location.
 - Support Chrome `skipLists` to improve stepping performance.
+- Export `AbsoluteImportUriException`.
 
 ## 7.0.2
 

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -24,7 +24,8 @@ import 'src/services/expression_compiler.dart';
 
 export 'src/connections/app_connection.dart' show AppConnection;
 export 'src/connections/debug_connection.dart' show DebugConnection;
-export 'src/debugging/metadata/provider.dart' show MetadataProvider;
+export 'src/debugging/metadata/provider.dart'
+    show MetadataProvider, AbsoluteImportUriException;
 export 'src/handlers/dev_handler.dart' show AppConnectionException;
 export 'src/handlers/socket_connections.dart';
 export 'src/loaders/build_runner_require.dart'


### PR DESCRIPTION
This should have been exported when initially implemented.

Closes https://github.com/dart-lang/webdev/issues/1182