### PR TITLE
Fixed incorrect location for libraries.json and added test

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Fix expression evaluation failure inside blocks.
 - Now log the encoded URI of the debug service to both the terminal
   and application console.
+- Fix an issue where running webdev with expression evaluation
+  enabled would fail to find `libraries.json` file and emit severe
+  error.
 
 ## 7.1.0
 

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -218,7 +218,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
     } else {
       var e = response['exception'];
       var s = response['stackTrace'];
-      _logger.info('Failed to update dependencies: $e:$s');
+      _logger.severe('Failed to update dependencies: $e:$s');
     }
     return result;
   }

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -190,7 +190,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
 
     var workerPath = p.join(binDir, 'snapshots', 'dartdevc.dart.snapshot');
     var sdkSummaryPath = p.join(sdkRoot, 'ddc_sdk.dill');
-    var librariesPath = p.join(sdkRoot, 'lib', 'libraries.json');
+    var librariesPath = p.join(sdkDir, 'lib', 'libraries.json');
 
     return ExpressionCompilerService.startWithPlatform(address, port,
         assetHandler, workerPath, sdkSummaryPath, librariesPath, verbose);
@@ -238,7 +238,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
       throw StateError('Expression compilation service has stopped');
     }
 
-    _logger.finest('compiling "$expression" at $libraryUri:$line');
+    _logger.finest('Compiling "$expression" at $libraryUri:$line');
 
     var response = await _send({
       'command': 'CompileExpression',
@@ -264,6 +264,11 @@ class ExpressionCompilerService implements ExpressionCompiler {
       var procedure = response['compiledProcedure'] as String;
       succeeded = response['succeeded'] as bool;
       result = succeeded ? procedure : error;
+    }
+    if (succeeded) {
+      _logger.finest('Compiled "$expression" to: $result');
+    } else {
+      _logger.finest('Failed to compile "$expression": $result');
     }
     return ExpressionCompilationResult(result, !succeeded);
   }

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dwds/dwds.dart';
+import 'package:dwds/src/utilities/shared.dart';
+import 'package:http_multi_server/http_multi_server.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:test/test.dart';
+import 'package:path/path.dart' as p;
+
+import 'fixtures/logging.dart';
+
+@TestOn('vm')
+void main() async {
+  group('expression compiler service with fake asset server', () {
+    ExpressionCompilerService service;
+    var output = StreamController<String>.broadcast();
+    HttpServer server;
+    var systemTempDir = Directory.systemTemp;
+    var outputDir = systemTempDir.createTempSync('foo bar');
+    var source = p.join(outputDir.path, 'try.dart');
+    var kernel = p.join(outputDir.path, 'try.full.dill');
+
+    FutureOr<Response> assetHandler(Request request) {
+      return Response(200, body: File(kernel).readAsBytesSync());
+    }
+
+    Future<void> stop() async {
+      await service?.stop();
+      await server?.close();
+      await output?.close();
+      service = null;
+      server = null;
+      output = null;
+    }
+
+    setUpAll(() async {
+      // redirect logs for testing
+      configureLogWriter(
+          customLogWriter: (level, message,
+                  {loggerName, error, stackTrace, verbose}) =>
+              output.add('[$level] $loggerName: $message'));
+
+      output.stream.listen(printOnFailure);
+
+      // start expression compilation service
+      var port = await findUnusedPort();
+      service = await ExpressionCompilerService.start(
+          'localhost', port, assetHandler, false);
+
+      // setup asset server
+      server = await HttpMultiServer.bind('localhost', port);
+      shelf_io.serveRequests(server, service.handler);
+
+      // generate full dill
+      File(source).writeAsStringSync('''void main() {
+        // breakpoint line
+      }''');
+
+      var process = await Process.start(
+              p.join(p.dirname(Platform.resolvedExecutable), 'dartdevc'),
+              [
+                'try.dart',
+                '-o',
+                'try.js',
+                '--experimental-output-compiled-kernel',
+                '--multi-root',
+                outputDir.path,
+                '--multi-root-scheme',
+                'org-dartlang-app',
+              ],
+              workingDirectory: outputDir.path)
+          .then((p) {
+        stdout.addStream(p.stdout);
+        stderr.addStream(p.stderr);
+        return p;
+      });
+      await process.exitCode;
+    });
+
+    tearDownAll(() async {
+      await stop();
+      outputDir.deleteSync(recursive: true);
+    });
+
+    test('works with no errors', () async {
+      expect(output.stream, neverEmits(contains('[SEVERE]')));
+      expect(
+          output.stream,
+          emitsThrough(contains(
+              '[INFO] ExpressionCompilerService: Updating dependencies...')));
+      expect(
+          output.stream,
+          emitsThrough(contains(
+              '[INFO] ExpressionCompilerService: Updated dependencies.')));
+      expect(
+          output.stream,
+          emitsThrough(contains(
+              '[FINEST] ExpressionCompilerService: Compiling "true" at org-dartlang-app:/try.dart:2')));
+      expect(
+          output.stream,
+          emitsThrough(contains(
+              '[FINEST] ExpressionCompilerService: Compiled "true" to:')));
+
+      var result = await service.updateDependencies({'try': 'try.full.dill'});
+      expect(result, true);
+
+      var compilationResult = await service.compileExpressionToJs(
+          '0', 'org-dartlang-app:/try.dart', 2, 1, {}, {}, 'try', 'true');
+      expect(compilationResult.result, contains('return true;'));
+      expect(compilationResult.isError, false);
+
+      await stop();
+    });
+  });
+}

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:io';
 


### PR DESCRIPTION
Fixed incorrect location for libraries.json causing severe failure when running webdev with 
`--enable-expression-evaluation`, added test to make sure expression compiler service can run its basic operations
with no errors.

Closes: https://github.com/dart-lang/webdev/issues/1195