### PR TITLE
New top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-webdev/README.md
+[![Dart](https://github.com/dart-lang/webdev/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/webdev/actions?query=workflow%3A%22Dart+CI%22)
+
+## dwds [![Pub Package](https://img.shields.io/pub/v/dwds.svg)](https://pub.dev/packages/dwds)
+
+* Package: https://pub.dev/packages/dwds
+* [Source code](dwds)
+
+A service that proxies between the Chrome debug protocol and the Dart VM service protocol.
+
+## webdev [![Pub Package](https://img.shields.io/pub/v/webdev.svg)](https://pub.dev/packages/webdev)
+
+* Package: https://pub.dev/packages/webdev
+* [Source code](webdev)
+
+A command-line tool for developing and deploying web applications with Dart.

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -1,17 +1,3 @@
-[![Dart](https://github.com/dart-lang/webdev/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/webdev/actions?query=workflow%3A%22Dart+CI%22)
-
-## dwds [![Pub Package](https://img.shields.io/pub/v/dwds.svg)](https://pub.dev/packages/dwds)
-
-* Package: https://pub.dev/packages/dwds
-* [Source code](dwds)
-
-A service that proxies between the Chrome debug protocol and the Dart VM service protocol.
-
-## webdev [![Pub Package](https://img.shields.io/pub/v/webdev.svg)](https://pub.dev/packages/webdev)
-
-* Package: https://pub.dev/packages/webdev
-* [Source code](webdev)
-
 A command-line tool for developing and deploying web applications with Dart.
 
 ## Requirements


### PR DESCRIPTION
- Create a new top level README (no longer a symlink to the webdev version)
- Update the webdev README to not contain top level information