### PR TITLE
Support sound null safety flag

### DIFF
--- a/fixtures/_webdevSmoke/web/scopes_main.dart
+++ b/fixtures/_webdevSmoke/web/scopes_main.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// An example with more complicated scope
-
 import 'dart:async';
 import 'dart:collection';
 

--- a/fixtures/_webdevSoundSmoke/pubspec.yaml
+++ b/fixtures/_webdevSoundSmoke/pubspec.yaml
@@ -1,0 +1,9 @@
+name: _webdevSmoke 
+description: A test fixture for webdev testing with sound support.
+
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+
+dev_dependencies:
+  build_runner: '>=1.6.2 <2.0.0'
+  build_web_compilers: '>=2.12.0 <3.0.0'

--- a/fixtures/_webdevSoundSmoke/web/index.html
+++ b/fixtures/_webdevSoundSmoke/web/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>webdev example</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script defer src="main.dart.js"></script>
+</head>
+
+</html>

--- a/fixtures/_webdevSoundSmoke/web/main.dart
+++ b/fixtures/_webdevSoundSmoke/web/main.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart=2.12
+
+void main() {}

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.7.2 - Unreleased
 
 - Depend on the latest `package:dwds`.
+- Support new `sound-null-safety` flag. See README.
 
 ## 2.7.1
 

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -105,14 +105,15 @@ Common:
                                            (defaults to on)
 -e, --[no-]enable-expression-evaluation    Enable expression evaluation features
                                            in the debugger.
-    --[no-]sound-null-safety               If provided, `package:build_runner`
-                                           will be run with sound null safety
-                                           support. If negated,
-                                           `package:build_runner` will be run
-                                           without sound null safety support. If
-                                           not provided, the default
-                                           `package:build_runner` behavior is
-                                           used.
+    --[no-]sound-null-safety               If provided,
+                                           `package:build_web_compilers` will be
+                                           run with sound null safety support.
+                                           If negated,
+                                           `package:build_web_compilers` will be
+                                           run without sound null safety
+                                           support. If not provided, the default
+                                           `package:build_web_compilers`
+                                           behavior is used.
 -v, --verbose                              Enables verbose logging.
 
 Run "webdev help" to see global options.
@@ -144,14 +145,15 @@ Usage: webdev build [arguments]
                                            (defaults to on)
 -e, --[no-]enable-expression-evaluation    Enable expression evaluation features
                                            in the debugger.
-    --[no-]sound-null-safety               If provided, `package:build_runner`
-                                           will be run with sound null safety
-                                           support. If negated,
-                                           `package:build_runner` will be run
-                                           without sound null safety support. If
-                                           not provided, the default
-                                           `package:build_runner` behavior is
-                                           used.
+    --[no-]sound-null-safety               If provided,
+                                           `package:build_web_compilers` will be
+                                           run with sound null safety support.
+                                           If negated,
+                                           `package:build_web_compilers` will be
+                                           run without sound null safety
+                                           support. If not provided, the default
+                                           `package:build_web_compilers`
+                                           behavior is used.
 -v, --verbose                              Enables verbose logging.
 
 Run "webdev help" to see global options.

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -105,6 +105,14 @@ Common:
                                            (defaults to on)
 -e, --[no-]enable-expression-evaluation    Enable expression evaluation features
                                            in the debugger.
+    --[no-]sound-null-safety               If provided, `package:build_runner`
+                                           will be run with sound null safety
+                                           support. If negated,
+                                           `package:build_runner` will be run
+                                           without sound null safety support. If
+                                           not provided, the default
+                                           `package:build_runner` behavior is
+                                           used.
 -v, --verbose                              Enables verbose logging.
 
 Run "webdev help" to see global options.
@@ -136,6 +144,14 @@ Usage: webdev build [arguments]
                                            (defaults to on)
 -e, --[no-]enable-expression-evaluation    Enable expression evaluation features
                                            in the debugger.
+    --[no-]sound-null-safety               If provided, `package:build_runner`
+                                           will be run with sound null safety
+                                           support. If negated,
+                                           `package:build_runner` will be run
+                                           without sound null safety support. If
+                                           not provided, the default
+                                           `package:build_runner` behavior is
+                                           used.
 -v, --verbose                              Enables verbose logging.
 
 Run "webdev help" to see global options.

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -248,8 +248,8 @@ class Configuration {
 
   bool get verbose => _verbose ?? false;
 
-  // Null indicates that the default `package:build_runner` behavior should be
-  // used.
+  // Null indicates that the default `package:build_web_compilers`
+  // behavior should be used.
   bool get soundNullSafety => _soundNullSafety;
 
   /// Returns a new configuration with values updated from the parsed args.

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -29,6 +29,7 @@ const releaseFlag = 'release';
 const requireBuildWebCompilersFlag = 'build-web-compilers';
 const enableExpressionEvaluationFlag = 'enable-expression-evaluation';
 const verboseFlag = 'verbose';
+const soundNullSafetyFlag = 'sound-null-safety';
 const disableDdsFlag = 'disable-dds';
 
 ReloadConfiguration _parseReloadConfiguration(ArgResults argResults) {
@@ -96,6 +97,7 @@ class Configuration {
   final bool _enableExpressionEvaluation;
   final bool _verbose;
   final bool _disableDds;
+  final bool _soundNullSafety;
 
   Configuration({
     bool autoRun,
@@ -118,6 +120,7 @@ class Configuration {
     bool enableExpressionEvaluation,
     bool verbose,
     bool disableDds,
+    bool soundNullSafety,
   })  : _autoRun = autoRun,
         _chromeDebugPort = chromeDebugPort,
         _debugExtension = debugExtension,
@@ -135,7 +138,8 @@ class Configuration {
         _requireBuildWebCompilers = requireBuildWebCompilers,
         _disableDds = disableDds,
         _enableExpressionEvaluation = enableExpressionEvaluation,
-        _verbose = verbose {
+        _verbose = verbose,
+        _soundNullSafety = soundNullSafety {
     _validateConfiguration();
   }
 
@@ -201,7 +205,8 @@ class Configuration {
       disableDds: other._disableDds ?? _disableDds,
       enableExpressionEvaluation:
           other._enableExpressionEvaluation ?? _enableExpressionEvaluation,
-      verbose: other._verbose ?? _verbose);
+      verbose: other._verbose ?? _verbose,
+      soundNullSafety: other._soundNullSafety ?? _soundNullSafety);
 
   factory Configuration.noInjectedClientDefaults() =>
       Configuration(autoRun: false, debug: false, debugExtension: false);
@@ -242,6 +247,10 @@ class Configuration {
   bool get enableExpressionEvaluation => _enableExpressionEvaluation ?? false;
 
   bool get verbose => _verbose ?? false;
+
+  // Null indicates that the default `package:build_runner` behavior should be
+  // used.
+  bool get soundNullSafety => _soundNullSafety;
 
   /// Returns a new configuration with values updated from the parsed args.
   static Configuration fromArgs(ArgResults argResults,
@@ -346,31 +355,37 @@ class Configuration {
         ? argResults[verboseFlag] as bool
         : defaultConfiguration.verbose;
 
+    var soundNullSafety = argResults.options.contains(soundNullSafetyFlag)
+        ? argResults[soundNullSafetyFlag] as bool
+        : defaultConfiguration.soundNullSafety;
+
     var disableDds = argResults.options.contains(disableDdsFlag)
         ? argResults[disableDdsFlag] as bool
         : defaultConfiguration.disableDds;
 
     return Configuration(
-        autoRun: defaultConfiguration.autoRun,
-        chromeDebugPort: chromeDebugPort,
-        debugExtension: debugExtension,
-        debug: debug,
-        enableInjectedClient: enableInjectedClient,
-        hostname: hostname,
-        tlsCertChain: tlsCertChain,
-        tlsCertKey: tlsCertKey,
-        launchApps: launchApps,
-        launchInChrome: launchInChrome,
-        logRequests: logRequests,
-        output: output,
-        outputInput: outputInput,
-        outputPath: outputPath,
-        release: release,
-        reload: _parseReloadConfiguration(argResults),
-        requireBuildWebCompilers: requireBuildWebCompilers,
-        disableDds: disableDds,
-        enableExpressionEvaluation: enableExpressionEvaluation,
-        verbose: verbose);
+      autoRun: defaultConfiguration.autoRun,
+      chromeDebugPort: chromeDebugPort,
+      debugExtension: debugExtension,
+      debug: debug,
+      enableInjectedClient: enableInjectedClient,
+      hostname: hostname,
+      tlsCertChain: tlsCertChain,
+      tlsCertKey: tlsCertKey,
+      launchApps: launchApps,
+      launchInChrome: launchInChrome,
+      logRequests: logRequests,
+      output: output,
+      outputInput: outputInput,
+      outputPath: outputPath,
+      release: release,
+      reload: _parseReloadConfiguration(argResults),
+      requireBuildWebCompilers: requireBuildWebCompilers,
+      disableDds: disableDds,
+      enableExpressionEvaluation: enableExpressionEvaluation,
+      verbose: verbose,
+      soundNullSafety: soundNullSafety,
+    );
   }
 }
 

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -47,6 +47,14 @@ void addSharedArgs(ArgParser argParser,
         defaultsTo: false,
         negatable: true,
         help: 'Enable expression evaluation features in the debugger.')
+    ..addFlag(soundNullSafetyFlag,
+        negatable: true,
+        help: 'If provided, `package:build_runner` will be run with sound null '
+            'safety support. '
+            'If negated, `package:build_runner` will be run without sound null '
+            'safety support. '
+            'If not provided, the default `package:build_runner` behavior is '
+            'used.')
     ..addFlag(verboseFlag,
         abbr: 'v',
         defaultsTo: false,
@@ -72,6 +80,14 @@ List<String> buildRunnerArgs(
       ..add('--define')
       ..add('build_web_compilers|ddc=generate-full-dill=true');
   }
+
+  if (configuration.soundNullSafety != null) {
+    arguments
+      ..add('--define')
+      ..add('build_web_compilers:entrypoint=sound_null_safety='
+          '${configuration.soundNullSafety}');
+  }
+
   return arguments;
 }
 

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -49,12 +49,13 @@ void addSharedArgs(ArgParser argParser,
         help: 'Enable expression evaluation features in the debugger.')
     ..addFlag(soundNullSafetyFlag,
         negatable: true,
-        help: 'If provided, `package:build_runner` will be run with sound null '
-            'safety support. '
-            'If negated, `package:build_runner` will be run without sound null '
-            'safety support. '
-            'If not provided, the default `package:build_runner` behavior is '
-            'used.')
+        help:
+            'If provided, `package:build_web_compilers` will be run with sound '
+            'null safety support. '
+            'If negated, `package:build_web_compilers` will be run without '
+            'sound null safety support. '
+            'If not provided, the default `package:build_web_compilers` '
+            'behavior is used.')
     ..addFlag(verboseFlag,
         abbr: 'v',
         defaultsTo: false,

--- a/webdev/test/configuration_test.dart
+++ b/webdev/test/configuration_test.dart
@@ -37,6 +37,11 @@ void main() {
         throwsA(isA<InvalidConfiguration>()));
   });
 
+  test('soundNullSafety defaults to null', () {
+    var defaultConfiguration = Configuration.fromArgs(null);
+    expect(defaultConfiguration.soundNullSafety, isNull);
+  });
+
   test(
       'must not provide debug related configuartion when enableInjectedClient '
       'is false', () {

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:io/io.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
@@ -132,45 +133,59 @@ void main() {
         }
       });
     }
-    test('and --sound-null-safety', () async {
-      var args = [
-        'build',
-        '-o',
-        'web:${d.sandbox}',
-        '--no-release',
-        '--sound-null-safety'
-      ];
+    test(
+      'and --sound-null-safety',
+      () async {
+        var args = [
+          'build',
+          '-o',
+          'web:${d.sandbox}',
+          '--no-release',
+          '--sound-null-safety'
+        ];
 
-      var process =
-          await runWebDev(args, workingDirectory: soundExampleDirectory);
+        var process =
+            await runWebDev(args, workingDirectory: soundExampleDirectory);
 
-      var expectedItems = <Object>['Succeeded'];
+        var expectedItems = <Object>['Succeeded'];
 
-      await checkProcessStdout(process, expectedItems);
-      await process.shouldExit(0);
+        await checkProcessStdout(process, expectedItems);
+        await process.shouldExit(0);
 
-      await d.file('main.sound.ddc.js', isNotEmpty).validate();
-    });
+        await d.file('main.sound.ddc.js', isNotEmpty).validate();
+      },
+      skip: semver.Version.parse(Platform.version.split(' ').first) >
+              semver.Version.parse('2.11.0')
+          ? null
+          : 'SDK does not support sound null safety',
+    );
 
-    test('and --no-sound-null-safety', () async {
-      var args = [
-        'build',
-        '-o',
-        'web:${d.sandbox}',
-        '--no-release',
-        '--no-sound-null-safety'
-      ];
+    test(
+      'and --no-sound-null-safety',
+      () async {
+        var args = [
+          'build',
+          '-o',
+          'web:${d.sandbox}',
+          '--no-release',
+          '--no-sound-null-safety'
+        ];
 
-      var process =
-          await runWebDev(args, workingDirectory: soundExampleDirectory);
+        var process =
+            await runWebDev(args, workingDirectory: soundExampleDirectory);
 
-      var expectedItems = <Object>['Succeeded'];
+        var expectedItems = <Object>['Succeeded'];
 
-      await checkProcessStdout(process, expectedItems);
-      await process.shouldExit(0);
+        await checkProcessStdout(process, expectedItems);
+        await process.shouldExit(0);
 
-      await d.file('main.unsound.ddc.js', isNotEmpty).validate();
-    });
+        await d.file('main.unsound.ddc.js', isNotEmpty).validate();
+      },
+      skip: semver.Version.parse(Platform.version.split(' ').first) >
+              semver.Version.parse('2.11.0')
+          ? null
+          : 'SDK does not support sound null safety',
+    );
   });
 
   group('should build with --output=NONE', () {

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -32,12 +32,21 @@ const _testItems = <String, bool>{
 
 void main() {
   String exampleDirectory;
+  String soundExampleDirectory;
   setUpAll(() async {
     exampleDirectory =
         p.absolute(p.join(p.current, '..', 'fixtures', '_webdevSmoke'));
+    soundExampleDirectory =
+        p.absolute(p.join(p.current, '..', 'fixtures', '_webdevSoundSmoke'));
 
     var process = await TestProcess.start(pubPath, ['upgrade'],
         workingDirectory: exampleDirectory, environment: getPubEnvironment());
+
+    await process.shouldExit(0);
+
+    process = await TestProcess.start(pubPath, ['upgrade'],
+        workingDirectory: soundExampleDirectory,
+        environment: getPubEnvironment());
 
     await process.shouldExit(0);
 
@@ -123,6 +132,45 @@ void main() {
         }
       });
     }
+    test('and --sound-null-safety', () async {
+      var args = [
+        'build',
+        '-o',
+        'web:${d.sandbox}',
+        '--no-release',
+        '--sound-null-safety'
+      ];
+
+      var process =
+          await runWebDev(args, workingDirectory: soundExampleDirectory);
+
+      var expectedItems = <Object>['Succeeded'];
+
+      await checkProcessStdout(process, expectedItems);
+      await process.shouldExit(0);
+
+      await d.file('main.sound.ddc.js', isNotEmpty).validate();
+    });
+
+    test('and --no-sound-null-safety', () async {
+      var args = [
+        'build',
+        '-o',
+        'web:${d.sandbox}',
+        '--no-release',
+        '--no-sound-null-safety'
+      ];
+
+      var process =
+          await runWebDev(args, workingDirectory: soundExampleDirectory);
+
+      var expectedItems = <Object>['Succeeded'];
+
+      await checkProcessStdout(process, expectedItems);
+      await process.shouldExit(0);
+
+      await d.file('main.unsound.ddc.js', isNotEmpty).validate();
+    });
   });
 
   group('should build with --output=NONE', () {


### PR DESCRIPTION
Add support for `sound-null-safety` flag with the following behavior:

If provided, `package:build_runner` will be run with sound null safety support. If negated, `package:build_runner` will be run without sound null safety support. If  not provided, the default `package:build_runner` behavior is used.

Closes https://github.com/dart-lang/webdev/issues/1217