### PR TITLE
Lazily Initialize ExpressionService

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,9 +1,13 @@
-## 7.2.0 - UNRELEASED
+## 8.0.0 - UNRELEASED
 
 - Improve logging around execution contexts.
 - Remove the expression compilation dependency update from the create
   isolate critical path.
 - Expose new event stream for future use with analytics.
+- Update `ExpressionCompiler` to include new `initialize` method which
+  has a parameter for the null safety mode.
+- Update `ExpressionCompilerService` to change how it is instantiated and
+  implement the new `initialize` method.
 
 ## 7.1.1
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -168,7 +168,7 @@ class ChromeProxyService implements VmServiceInterface {
   Future<void> updateCompilerDependencies(String entrypoint) async {
     // TODO(grouma) - use the entrypoint to determine the null safety mode
     // and initialize accordingly.
-    await _compiler?.initialize(withNullSafety: false);
+    await _compiler?.initialize(soundNullSafety: false);
     var metadataProvider = globalLoadStrategy.metadataProviderFor(entrypoint);
     var modules = await metadataProvider.moduleToModulePath;
     var dependencies = <String, String>{};

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -166,7 +166,9 @@ class ChromeProxyService implements VmServiceInterface {
   }
 
   Future<void> updateCompilerDependencies(String entrypoint) async {
-    await _compiler?.initialize(false);
+    // TODO(grouma) - use the entrypoint to determine the null safety mode
+    // and initialize accordingly.
+    await _compiler?.initialize(withNullSafety: false);
     var metadataProvider = globalLoadStrategy.metadataProviderFor(entrypoint);
     var modules = await metadataProvider.moduleToModulePath;
     var dependencies = <String, String>{};

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -166,6 +166,7 @@ class ChromeProxyService implements VmServiceInterface {
   }
 
   Future<void> updateCompilerDependencies(String entrypoint) async {
+    await _compiler?.initialize(false);
     var metadataProvider = globalLoadStrategy.metadataProviderFor(entrypoint);
     var modules = await metadataProvider.moduleToModulePath;
     var dependencies = <String, String>{};

--- a/dwds/lib/src/services/expression_compiler.dart
+++ b/dwds/lib/src/services/expression_compiler.dart
@@ -63,5 +63,5 @@ abstract class ExpressionCompiler {
   /// Initializes the compiler with the provided null safety mode.
   ///
   /// May be called multiple times and always before [updateDependencies].
-  Future<void> initialize(bool withNullSafety);
+  Future<void> initialize({bool withNullSafety});
 }

--- a/dwds/lib/src/services/expression_compiler.dart
+++ b/dwds/lib/src/services/expression_compiler.dart
@@ -63,5 +63,5 @@ abstract class ExpressionCompiler {
   /// Initializes the compiler with the provided null safety mode.
   ///
   /// May be called multiple times and always before [updateDependencies].
-  Future<void> initialize({bool withNullSafety});
+  Future<void> initialize({bool soundNullSafety});
 }

--- a/dwds/lib/src/services/expression_compiler.dart
+++ b/dwds/lib/src/services/expression_compiler.dart
@@ -59,4 +59,9 @@ abstract class ExpressionCompiler {
   ///
   /// [updateDependencies] is called during isolate creation.
   Future<bool> updateDependencies(Map<String, String> modules);
+
+  /// Initializes the compiler with the provided null safety mode.
+  ///
+  /// May be called multiple times and always before [updateDependencies].
+  Future<void> initialize(bool withNullSafety);
 }

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -14,24 +14,22 @@ import 'package:shelf/shelf.dart';
 import '../utilities/dart_uri.dart';
 import 'expression_compiler.dart';
 
-/// Service that handles expression compilation requests.
-///
-/// Expression compiler service spawns a dartdevc in expression compilation
-/// mode in an isolate and communicates with the isolate via send/receive
-/// ports. It also handles full dill file read requests from the isolate
-/// and redirects them to the asset server.
-class ExpressionCompilerService implements ExpressionCompiler {
-  static final _logger = Logger('ExpressionCompilerService');
-  Isolate _worker;
+final _logger = Logger('ExpressionCompilerService');
+
+class _Compiler {
+  final Isolate _worker;
   final StreamQueue<Object> _responseQueue;
   final ReceivePort _receivePort;
   final SendPort _sendPort;
-  final Handler _assetHandler;
 
   Future<void> _dependencyUpdate;
 
-  ExpressionCompilerService._(this._worker, this._responseQueue,
-      this._receivePort, this._sendPort, this._assetHandler);
+  _Compiler._(
+    this._worker,
+    this._responseQueue,
+    this._receivePort,
+    this._sendPort,
+  );
 
   /// Sends [request] on [_sendPort] and returns the next event from the
   /// response stream.
@@ -43,48 +41,6 @@ class ExpressionCompilerService implements ExpressionCompiler {
             'succeeded': false,
             'errors': ['compilation service response stream closed'],
           };
-  }
-
-  /// Handles resource requests from expression compiler worker.
-  ///
-  /// Handles REST get requests of the form:
-  /// http://host:port/getResource?uri=<resource uri>
-  ///
-  /// Where the resource uri can be a package Uri for a dart file
-  /// or a server path for a full dill file.
-  /// Translates given resource uri to a server path and redirects
-  /// the request to the asset handler.
-  FutureOr<Response> handler(Request request) {
-    var uri = request.requestedUri.queryParameters['uri'];
-    var query = request.requestedUri.path;
-
-    _logger.finest('request: ${request.requestedUri}');
-
-    if (query != '/getResource' || uri == null) {
-      return Response.notFound(uri);
-    }
-
-    if (!uri.endsWith('.dart') && !uri.endsWith('.dill')) {
-      return Response.notFound(uri);
-    }
-
-    var serverPath = uri;
-    if (uri.endsWith('.dart')) {
-      serverPath = DartUri(uri).serverPath;
-    }
-
-    _logger.finest('serverpath for $uri: $serverPath');
-
-    request = Request(
-        'GET',
-        Uri(
-          scheme: request.requestedUri.scheme,
-          host: request.requestedUri.host,
-          port: request.requestedUri.port,
-          path: serverPath,
-        ));
-
-    return _assetHandler(request);
   }
 
   /// Starts expression compilation service.
@@ -105,7 +61,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
   /// the service after the communication is established.
   ///
   /// Users need to stop the service by calling [stop].
-  static Future<ExpressionCompilerService> startWithPlatform(
+  static Future<_Compiler> startWithPlatform(
     String address,
     int port,
     Handler assetHandler,
@@ -161,44 +117,11 @@ class ExpressionCompilerService implements ExpressionCompiler {
     var responseQueue = StreamQueue(receivePort);
     var sendPort = await responseQueue.next as SendPort;
 
-    var service = ExpressionCompilerService._(
-        isolate, responseQueue, receivePort, sendPort, assetHandler);
+    var service = _Compiler._(isolate, responseQueue, receivePort, sendPort);
 
     return service;
   }
 
-  /// Starts expression compilation service.
-  ///
-  /// Starts expression compiler worker in an isolate and creates the
-  /// expression compilation service that communicates to the worker.
-  ///
-  /// Uses [address] and [port] to communicate and [assetHandler] to
-  /// redirect asset requests to the asset server.
-  ///
-  /// Uses current SDK to find platform, expression compiler worker,
-  /// and libraries definitions.
-  ///
-  /// Performs handshake with the isolate running expression compiler
-  /// worker to estabish communication via send/receive ports, returns
-  /// the service after the communication is established.
-  ///
-  /// Users need to stop the service by calling [stop].
-  static Future<ExpressionCompilerService> start(
-      String address, int port, Handler assetHandler, bool verbose) {
-    final executable = Platform.resolvedExecutable;
-    final binDir = p.dirname(executable);
-    final sdkDir = p.dirname(binDir);
-    final sdkRoot = p.join(sdkDir, 'lib', '_internal');
-
-    var workerPath = p.join(binDir, 'snapshots', 'dartdevc.dart.snapshot');
-    var sdkSummaryPath = p.join(sdkRoot, 'ddc_sdk.dill');
-    var librariesPath = p.join(sdkDir, 'lib', 'libraries.json');
-
-    return ExpressionCompilerService.startWithPlatform(address, port,
-        assetHandler, workerPath, sdkSummaryPath, librariesPath, verbose);
-  }
-
-  @override
   Future<bool> updateDependencies(Map<String, String> modules) async {
     if (_worker == null) {
       throw StateError('Expression compilation service has stopped');
@@ -228,7 +151,6 @@ class ExpressionCompilerService implements ExpressionCompiler {
     return result;
   }
 
-  @override
   Future<ExpressionCompilationResult> compileExpressionToJs(
     String isolateId,
     String libraryUri,
@@ -288,7 +210,116 @@ class ExpressionCompilerService implements ExpressionCompiler {
   Future<void> stop() async {
     _sendPort.send({'command': 'Shutdown'});
     _receivePort.close();
-    _worker = null;
     _logger.info('Stopped.');
+  }
+}
+
+/// Service that handles expression compilation requests.
+///
+/// Expression compiler service spawns a dartdevc in expression compilation
+/// mode in an isolate and communicates with the isolate via send/receive
+/// ports. It also handles full dill file read requests from the isolate
+/// and redirects them to the asset server.
+///
+/// Uses [_address] and [_port] to communicate and [_assetHandler] to
+/// redirect asset requests to the asset server.
+///
+/// Users need to stop the service by calling [stop].
+class ExpressionCompilerService implements ExpressionCompiler {
+  final _compiler = Completer<_Compiler>();
+  final String _address;
+  final int _port;
+  final Handler _assetHandler;
+  final bool _verbose;
+
+  ExpressionCompilerService(
+    this._address,
+    this._port,
+    this._assetHandler,
+    this._verbose,
+  );
+
+  @override
+  Future<ExpressionCompilationResult> compileExpressionToJs(
+          String isolateId,
+          String libraryUri,
+          int line,
+          int column,
+          Map<String, String> jsModules,
+          Map<String, String> jsFrameValues,
+          String moduleName,
+          String expression) async =>
+      (await _compiler.future).compileExpressionToJs(isolateId, libraryUri,
+          line, column, jsModules, jsFrameValues, moduleName, expression);
+
+  @override
+  Future<void> initialize(bool withNullSafety) async {
+    if (_compiler.isCompleted) return;
+
+    final executable = Platform.resolvedExecutable;
+    final binDir = p.dirname(executable);
+    final sdkDir = p.dirname(binDir);
+    final sdkRoot = p.join(sdkDir, 'lib', '_internal');
+
+    var workerPath = p.join(binDir, 'snapshots', 'dartdevc.dart.snapshot');
+    // TODO(grouma) - use entrypoint to conditionally determine which SDK to
+    // load based off the [withNullSafety] argument.
+    var sdkSummaryPath = p.join(sdkRoot, 'ddc_sdk.dill');
+    var librariesPath = p.join(sdkDir, 'lib', 'libraries.json');
+
+    var compiler = await _Compiler.startWithPlatform(_address, _port,
+        _assetHandler, workerPath, sdkSummaryPath, librariesPath, _verbose);
+
+    _compiler.complete(compiler);
+  }
+
+  @override
+  Future<bool> updateDependencies(Map<String, String> modules) async =>
+      (await _compiler.future).updateDependencies(modules);
+
+  Future<void> stop() async {
+    if (_compiler.isCompleted) return (await _compiler.future).stop();
+  }
+
+  /// Handles resource requests from expression compiler worker.
+  ///
+  /// Handles REST get requests of the form:
+  /// http://host:port/getResource?uri=<resource uri>
+  ///
+  /// Where the resource uri can be a package Uri for a dart file
+  /// or a server path for a full dill file.
+  /// Translates given resource uri to a server path and redirects
+  /// the request to the asset handler.
+  FutureOr<Response> handler(Request request) {
+    var uri = request.requestedUri.queryParameters['uri'];
+    var query = request.requestedUri.path;
+
+    _logger.finest('request: ${request.requestedUri}');
+
+    if (query != '/getResource' || uri == null) {
+      return Response.notFound(uri);
+    }
+
+    if (!uri.endsWith('.dart') && !uri.endsWith('.dill')) {
+      return Response.notFound(uri);
+    }
+
+    var serverPath = uri;
+    if (uri.endsWith('.dart')) {
+      serverPath = DartUri(uri).serverPath;
+    }
+
+    _logger.finest('serverpath for $uri: $serverPath');
+
+    request = Request(
+        'GET',
+        Uri(
+          scheme: request.requestedUri.scheme,
+          host: request.requestedUri.host,
+          port: request.requestedUri.port,
+          path: serverPath,
+        ));
+
+    return _assetHandler(request);
   }
 }

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -101,7 +101,7 @@ class _Compiler {
       '--asset-server-port',
       '$port',
       if (verbose) '--verbose',
-      if (soundNullSafety) '--sound-null-safety',
+      soundNullSafety ? '--sound-null-safety' : '--no-sound-null-safety',
     ];
 
     _logger.info('Starting...');

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -253,8 +253,9 @@ class ExpressionCompilerService implements ExpressionCompiler {
           line, column, jsModules, jsFrameValues, moduleName, expression);
 
   @override
-  Future<void> initialize(bool withNullSafety) async {
+  Future<void> initialize({bool withNullSafety}) async {
     if (_compiler.isCompleted) return;
+    withNullSafety ??= false;
 
     final executable = Platform.resolvedExecutable;
     final binDir = p.dirname(executable);
@@ -262,8 +263,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
     final sdkRoot = p.join(sdkDir, 'lib', '_internal');
 
     var workerPath = p.join(binDir, 'snapshots', 'dartdevc.dart.snapshot');
-    // TODO(grouma) - use entrypoint to conditionally determine which SDK to
-    // load based off the [withNullSafety] argument.
+    // TODO(grouma) - use withNullSafety to load the correct SDK.
     var sdkSummaryPath = p.join(sdkRoot, 'ddc_sdk.dill');
     var librariesPath = p.join(sdkDir, 'lib', 'libraries.json');
 

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '7.2.0-dev';
+const packageVersion = '8.0.0-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 7.2.0-dev
+version: 8.0.0-dev
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -59,7 +59,7 @@ void main() async {
       service =
           ExpressionCompilerService('localhost', port, assetHandler, false);
 
-      await service.initialize(false);
+      await service.initialize();
 
       // setup asset server
       server = await HttpMultiServer.bind('localhost', port);

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -9,10 +9,10 @@ import 'dart:io';
 import 'package:dwds/dwds.dart';
 import 'package:dwds/src/utilities/shared.dart';
 import 'package:http_multi_server/http_multi_server.dart';
+import 'package:path/path.dart' as p;
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:test/test.dart';
-import 'package:path/path.dart' as p;
 
 import 'fixtures/logging.dart';
 
@@ -56,8 +56,10 @@ void main() async {
       final port = await findUnusedPort();
       final assetHandler = (request) =>
           Response(200, body: File.fromUri(kernel).readAsBytesSync());
-      service = await ExpressionCompilerService.start(
-          'localhost', port, assetHandler, false);
+      service =
+          ExpressionCompilerService('localhost', port, assetHandler, false);
+
+      await service.initialize(false);
 
       // setup asset server
       server = await HttpMultiServer.bind('localhost', port);

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -182,7 +182,7 @@ class TestContext {
                 ProxyServerAssetReader(assetServerPort, root: pathToServe);
 
             if (enableExpressionEvaluation) {
-              ddcService = await ExpressionCompilerService.start(
+              ddcService = ExpressionCompilerService(
                 'localhost',
                 port,
                 assetHandler,

--- a/frontend_server_common/lib/src/frontend_server_client.dart
+++ b/frontend_server_common/lib/src/frontend_server_client.dart
@@ -778,5 +778,5 @@ class TestExpressionCompiler implements ExpressionCompiler {
   Future<bool> updateDependencies(Map<String, String> modules) async => true;
 
   @override
-  Future<void> initialize({bool withNullSafety}) async {}
+  Future<void> initialize({bool soundNullSafety}) async {}
 }

--- a/frontend_server_common/lib/src/frontend_server_client.dart
+++ b/frontend_server_common/lib/src/frontend_server_client.dart
@@ -778,5 +778,5 @@ class TestExpressionCompiler implements ExpressionCompiler {
   Future<bool> updateDependencies(Map<String, String> modules) async => true;
 
   @override
-  Future<void> initialize(bool withNullSafety) async {}
+  Future<void> initialize({bool withNullSafety}) async {}
 }

--- a/frontend_server_common/lib/src/frontend_server_client.dart
+++ b/frontend_server_common/lib/src/frontend_server_client.dart
@@ -776,4 +776,7 @@ class TestExpressionCompiler implements ExpressionCompiler {
 
   @override
   Future<bool> updateDependencies(Map<String, String> modules) async => true;
+
+  @override
+  Future<void> initialize(bool withNullSafety) async {}
 }

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -119,7 +119,7 @@ class WebDevServer {
           .strategy;
 
       if (options.configuration.enableExpressionEvaluation) {
-        ddcService = await ExpressionCompilerService.start(
+        ddcService = ExpressionCompilerService(
           options.configuration.hostname,
           options.port,
           assetHandler,


### PR DESCRIPTION
Before this change the `ExpressionCompilerService` would eagerly load the DDC SDK. However, we need to conditionally load the correct SDK based off null safety support. We will determine the null safety support from the DDC metadata files so we must lazily start the service after the entrypoint is determined.