### PR TITLE
Allow eventStream to be listened to multiple times

### DIFF
--- a/dwds/lib/src/events.dart
+++ b/dwds/lib/src/events.dart
@@ -16,6 +16,8 @@ final _eventController = StreamController<DwdsEvent>();
 /// Adds an event to the global [eventStream];
 void emitEvent(DwdsEvent event) => _eventController.sink.add(event);
 
+Stream<DwdsEvent> _eventStream;
+
 /// A global stream of [DwdsEvent]s.
 Stream<DwdsEvent> get eventStream =>
-    _eventController.stream.asBroadcastStream();
+    _eventStream ??= _eventController.stream.asBroadcastStream();

--- a/dwds/lib/src/events.dart
+++ b/dwds/lib/src/events.dart
@@ -11,13 +11,10 @@ class DwdsEvent {
   DwdsEvent(this.type, this.payload);
 }
 
-final _eventController = StreamController<DwdsEvent>();
+final _eventController = StreamController<DwdsEvent>.broadcast();
 
 /// Adds an event to the global [eventStream];
 void emitEvent(DwdsEvent event) => _eventController.sink.add(event);
 
-Stream<DwdsEvent> _eventStream;
-
 /// A global stream of [DwdsEvent]s.
-Stream<DwdsEvent> get eventStream =>
-    _eventStream ??= _eventController.stream.asBroadcastStream();
+Stream<DwdsEvent> get eventStream => _eventController.stream;

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -16,9 +16,14 @@ void main() {
     );
   });
 
-  test('Emits DEVTOOLS_LAUNCH event', () async {
+  test('emits DEVTOOLS_LAUNCH event', () async {
     await context.webDriver.driver.keyboard.sendChord([Keyboard.alt, 'd']);
     expect(context.testServer.dwds.events,
         emits(predicate((DwdsEvent event) => event.type == 'DEVTOOLS_LAUNCH')));
+  });
+
+  test('events can be listened to multiple times', () async {
+    context.testServer.dwds.events.listen((_) {});
+    context.testServer.dwds.events.listen((_) {});
   });
 }

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -17,9 +17,11 @@ void main() {
   });
 
   test('emits DEVTOOLS_LAUNCH event', () async {
-    await context.webDriver.driver.keyboard.sendChord([Keyboard.alt, 'd']);
+    // The events stream is a broadcast stream so start listening before the
+    // action.
     expect(context.testServer.dwds.events,
         emits(predicate((DwdsEvent event) => event.type == 'DEVTOOLS_LAUNCH')));
+    await context.webDriver.driver.keyboard.sendChord([Keyboard.alt, 'd']);
   });
 
   test('events can be listened to multiple times', () async {


### PR DESCRIPTION
We weren't properly returning a broadcast stream and therefore it could not be listened to multiple times.