### PR TITLE
Added temporary hack to allow google3 to find summaries

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -184,7 +184,7 @@ class ChromeProxyService implements VmServiceInterface {
           // is not a part of the name.
           // TODO: Save locations of summary kernel files in ddc metadata.
           // Issue: https://github.com/dart-lang/sdk/issues/44742
-          p.setExtension(serverPath.replaceAll('.ddk', '.ddc'), '.dill'));
+          p.setExtension(serverPath.replaceAll('.ddk.', '.ddc.'), '.dill'));
     }
     await _compiler?.updateDependencies(dependencies);
   }

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -176,8 +176,15 @@ class ChromeProxyService implements VmServiceInterface {
       var serverPath =
           await globalLoadStrategy.serverPathForModule(entrypoint, module);
       dependencies[module] = ModuleInfo(
+          // TODO: Save locations of full kernel files in ddc metadata.
+          // Issue: https://github.com/dart-lang/sdk/issues/43684
           p.setExtension(serverPath, '.full.dill'),
-          p.setExtension(serverPath, '.dill'));
+          // Replace .ddk to find the summary in google3.
+          // All other cases are coming from build_web_compilers where '.ddk'
+          // is not a part of the name.
+          // TODO: Save locations of summary kernel files in ddc metadata.
+          // Issue: https://github.com/dart-lang/sdk/issues/44742
+          p.setExtension(serverPath.replaceAll('.ddk', '.ddc'), '.dill'));
     }
     await _compiler?.updateDependencies(dependencies);
   }


### PR DESCRIPTION
Blaze uses `.ddc` in the name of the kernel summary, and `.ddk` in the full dill file.

This change help pass correct name for summaries in google3 case only. 
Note that the change is temporary and makes sure that evaluation works with summary files,  as supported by the following changes in google3:

https://critique-ng.corp.google.com/cl/353115269

The hack is going to be removed after the google3 changes is checked in and the following issues are resolved in the SDK:

https://github.com/dart-lang/sdk/issues/43684
https://github.com/dart-lang/sdk/issues/44742