### PR TITLE
Read null safety option from metadata

### DIFF
--- a/dwds/lib/src/debugging/metadata/module_metadata.dart
+++ b/dwds/lib/src/debugging/metadata/module_metadata.dart
@@ -148,7 +148,7 @@ class ModuleMetadata {
         closureName = json['closureName'] as String,
         sourceMapUri = json['sourceMapUri'] as String,
         moduleUri = json['moduleUri'] as String,
-        soundNullSafety = json['soundNullSafety'] as bool {
+        soundNullSafety = (json['soundNullSafety'] as bool) ?? false {
     if (!ModuleMetadataVersion.current.isCompatibleWith(version) &&
         !ModuleMetadataVersion.previous.isCompatibleWith(version)) {
       throw Exception('Unsupported metadata version $version. '

--- a/dwds/lib/src/debugging/metadata/module_metadata.dart
+++ b/dwds/lib/src/debugging/metadata/module_metadata.dart
@@ -24,9 +24,6 @@ class ModuleMetadataVersion {
   ///
   /// Version follows simple semantic versioning format 'major.minor.patch'
   /// See https://semver.org
-  ///
-  /// TODO(annagrin): create metadata package, make version the same as the
-  /// metadata package version, automate updating with the package update
   static const ModuleMetadataVersion current = ModuleMetadataVersion(2, 0, 0);
 
   /// Previous version supported by the metadata reader
@@ -118,9 +115,14 @@ class ModuleMetadata {
   /// Module uri
   final String moduleUri;
 
+  /// True if the module corresponding to this metadata was compiled with sound
+  /// null safety enabled.
+  final bool soundNullSafety;
+
   final Map<String, LibraryMetadata> libraries = {};
 
   ModuleMetadata(this.name, this.closureName, this.sourceMapUri, this.moduleUri,
+      this.soundNullSafety,
       {this.version}) {
     version ??= ModuleMetadataVersion.current.version;
   }
@@ -145,7 +147,8 @@ class ModuleMetadata {
         name = json['name'] as String,
         closureName = json['closureName'] as String,
         sourceMapUri = json['sourceMapUri'] as String,
-        moduleUri = json['moduleUri'] as String {
+        moduleUri = json['moduleUri'] as String,
+        soundNullSafety = json['soundNullSafety'] as bool {
     if (!ModuleMetadataVersion.current.isCompatibleWith(version) &&
         !ModuleMetadataVersion.previous.isCompatibleWith(version)) {
       throw Exception('Unsupported metadata version $version. '
@@ -166,7 +169,8 @@ class ModuleMetadata {
       'closureName': closureName,
       'sourceMapUri': sourceMapUri,
       'moduleUri': moduleUri,
-      'libraries': [for (var lib in libraries.values) lib.toJson()]
+      'libraries': [for (var lib in libraries.values) lib.toJson()],
+      'soundNullSafety': soundNullSafety
     };
   }
 }

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -143,8 +143,8 @@ class MetadataProvider {
               var metadata =
                   ModuleMetadata.fromJson(moduleJson as Map<String, dynamic>);
               _addMetadata(metadata);
-              hasUnsoundNullSafety &= !(metadata.soundNullSafety ?? false);
-              hasSoundNullSafety &= metadata.soundNullSafety ?? false;
+              hasUnsoundNullSafety &= !metadata.soundNullSafety;
+              hasSoundNullSafety &= metadata.soundNullSafety;
               _logger
                   .fine('Loaded debug metadata for module: ${metadata.name}');
             } catch (e) {

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -143,8 +143,8 @@ class MetadataProvider {
               var metadata =
                   ModuleMetadata.fromJson(moduleJson as Map<String, dynamic>);
               _addMetadata(metadata);
-              hasUnsoundNullSafety &= !metadata.soundNullSafety;
-              hasSoundNullSafety &= metadata.soundNullSafety;
+              hasUnsoundNullSafety &= !(metadata.soundNullSafety ?? false);
+              hasSoundNullSafety &= metadata.soundNullSafety ?? false;
               _logger
                   .fine('Loaded debug metadata for module: ${metadata.name}');
             } catch (e) {

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -166,10 +166,13 @@ class ChromeProxyService implements VmServiceInterface {
   }
 
   Future<void> updateCompilerDependencies(String entrypoint) async {
-    // TODO(grouma) - use the entrypoint to determine the null safety mode
-    // and initialize accordingly.
-    await _compiler?.initialize(soundNullSafety: false);
     var metadataProvider = globalLoadStrategy.metadataProviderFor(entrypoint);
+    _logger.info('Updating dependencies for $entrypoint '
+        'with sound null safety: ${metadataProvider.soundNullSafety}');
+
+    var soundNullSafety = await metadataProvider.soundNullSafety;
+    await _compiler?.initialize(soundNullSafety: soundNullSafety);
+
     var modules = await metadataProvider.moduleToModulePath;
     var dependencies = <String, ModuleInfo>{};
     for (var module in modules.keys) {

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -167,10 +167,11 @@ class ChromeProxyService implements VmServiceInterface {
 
   Future<void> updateCompilerDependencies(String entrypoint) async {
     var metadataProvider = globalLoadStrategy.metadataProviderFor(entrypoint);
-    _logger.info('Updating dependencies for $entrypoint '
-        'with sound null safety: ${metadataProvider.soundNullSafety}');
-
     var soundNullSafety = await metadataProvider.soundNullSafety;
+
+    _logger.info('Initializing expression compiler for $entrypoint '
+        'with sound null safety: $soundNullSafety');
+
     await _compiler?.initialize(soundNullSafety: soundNullSafety);
 
     var modules = await metadataProvider.moduleToModulePath;

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -16,371 +16,425 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
 
-final context = TestContext(
-    directory: p.join('..', 'fixtures', '_testPackage'),
-    entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
-    path: 'index.html',
-    pathToServe: 'web');
+class TestSetup {
+  static final contextUnsound = TestContext(
+      directory: p.join('..', 'fixtures', '_testPackage'),
+      entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
+      path: 'index.html',
+      pathToServe: 'web');
 
-ChromeProxyService get service =>
-    fetchChromeProxyService(context.debugConnection);
-WipConnection get tabConnection => context.tabConnection;
+  static final contextSound = TestContext(
+      directory: p.join('..', 'fixtures', '_testPackageSound'),
+      entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
+      path: 'index.html',
+      pathToServe: 'web');
+
+  TestContext context;
+
+  TestSetup.sound() : context = contextSound;
+
+  TestSetup.unsound() : context = contextUnsound;
+
+  ChromeProxyService get service =>
+      fetchChromeProxyService(context.debugConnection);
+  WipConnection get tabConnection => context.tabConnection;
+}
 
 void main() async {
-  Future<void> onBreakPoint(String isolate, ScriptRef script,
-      String breakPointId, Future<void> Function() body) async {
-    Breakpoint bp;
-    try {
-      var line =
-          await context.findBreakpointLine(breakPointId, isolate, script);
-      bp = await service.addBreakpointWithScriptUri(isolate, script.uri, line);
-      await body();
-    } finally {
-      // Remove breakpoint so it doesn't impact other tests or retries.
-      if (bp != null) {
-        await service.removeBreakpoint(isolate, bp.id);
+  for (var soundNullSafety in [true, false]) {
+    var setup = soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
+    var context = setup.context;
+    group('${soundNullSafety ? "" : "no "}sound null safety', () {
+      Future<void> onBreakPoint(String isolate, ScriptRef script,
+          String breakPointId, Future<void> Function() body) async {
+        Breakpoint bp;
+        try {
+          var line =
+              await context.findBreakpointLine(breakPointId, isolate, script);
+          bp = await setup.service
+              .addBreakpointWithScriptUri(isolate, script.uri, line);
+          await body();
+        } finally {
+          // Remove breakpoint so it doesn't impact other tests or retries.
+          if (bp != null) {
+            await setup.service.removeBreakpoint(isolate, bp.id);
+          }
+        }
       }
-    }
+
+      group('shared context with evaluation', () {
+        setUpAll(() async {
+          // Note: change 'printOnFailure' to 'print' for debug printing
+          configureLogWriter(
+              customLogWriter: (level, message,
+                      {loggerName, error, stackTrace, verbose}) =>
+                  print('[$level] $loggerName: $message'));
+
+          await context.setUp(enableExpressionEvaluation: true, verbose: false);
+        });
+
+        tearDownAll(() async {
+          await context.tearDown();
+        });
+
+        group('evaluateInFrame', () {
+          VM vm;
+          Isolate isolate;
+          ScriptList scripts;
+          ScriptRef mainScript;
+          ScriptRef libraryScript;
+          ScriptRef testLibraryScript;
+          Stream<Event> stream;
+
+          setUp(() async {
+            vm = await setup.service.getVM();
+            isolate = await setup.service.getIsolate(vm.isolates.first.id);
+            scripts = await setup.service.getScripts(isolate.id);
+
+            await setup.service.streamListen('Debug');
+            stream = setup.service.onEvent('Debug');
+
+            mainScript = scripts.scripts
+                .firstWhere((each) => each.uri.contains('main.dart'));
+            testLibraryScript = scripts.scripts.firstWhere((each) =>
+                each.uri.contains('package:_testPackage/test_library.dart'));
+            libraryScript = scripts.scripts.firstWhere(
+                (each) => each.uri.contains('package:_test/library.dart'));
+          });
+
+          tearDown(() async {
+            await setup.service.resume(isolate.id);
+          });
+
+          test('local', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service
+                  .evaluateInFrame(isolate.id, event.topFrame.index, 'local');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '42'));
+            });
+          });
+
+          test('field', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printField', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service.evaluateInFrame(
+                  isolate.id, event.topFrame.index, 'instance.field');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '1'));
+            });
+          }, tags: ['dev-sdk']);
+
+          test('private field from another library', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printField', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service.evaluateInFrame(
+                  isolate.id, event.topFrame.index, 'instance._field');
+
+              expect(
+                  result,
+                  isA<ErrorRef>().having(
+                      (instance) => instance.message,
+                      'message',
+                      contains("The getter '_field' isn't defined")));
+            });
+          }, tags: ['dev-sdk']);
+
+          test('private field from current library', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printFieldMain',
+                () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service.evaluateInFrame(
+                  isolate.id, event.topFrame.index, 'instance._field');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '1'));
+            });
+          }, tags: ['dev-sdk']);
+
+          test('access instance fields after evaluation', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printField', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var instanceRef = await setup.service.evaluateInFrame(
+                  isolate.id, event.topFrame.index, 'instance') as InstanceRef;
+
+              var instance = await setup.service
+                  .getObject(isolate.id, instanceRef.id) as Instance;
+
+              var field = instance.fields.firstWhere(
+                  (BoundField element) => element.decl.name == 'field');
+
+              expect(
+                  field.value,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '1'));
+            });
+          });
+
+          test('global', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printGlobal', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service.evaluateInFrame(
+                  isolate.id, event.topFrame.index, 'testLibraryValue');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '3'));
+            });
+          });
+
+          test('call core function', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service.evaluateInFrame(
+                  isolate.id, event.topFrame.index, 'print(local)');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      'null'));
+            });
+          });
+
+          test('call library function with const param', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service.evaluateInFrame(
+                  isolate.id, event.topFrame.index, 'testLibraryFunction(42)');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '42'));
+            });
+          });
+
+          test('call library function with local param', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service.evaluateInFrame(isolate.id,
+                  event.topFrame.index, 'testLibraryFunction(local)');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '42'));
+            });
+          }, tags: ['dev-sdk']);
+
+          test('loop variable', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printLoopVariable',
+                () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service
+                  .evaluateInFrame(isolate.id, event.topFrame.index, 'item');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '1'));
+            });
+          }, tags: ['dev-sdk']);
+
+          test('evaluate expression in _testPackage/test_library', () async {
+            await onBreakPoint(
+                isolate.id, testLibraryScript, 'testLibraryFunction', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service
+                  .evaluateInFrame(isolate.id, event.topFrame.index, 'formal');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '23'));
+            });
+          });
+
+          test('evaluate expression in a class constructor in another library',
+              () async {
+            await onBreakPoint(
+                isolate.id, testLibraryScript, 'testLibraryClassConstructor',
+                () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service.evaluateInFrame(
+                  isolate.id, event.topFrame.index, 'this.field');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '1'));
+            });
+          }, tags: 'dev-sdk');
+
+          test('evaluate expression in caller frame', () async {
+            await onBreakPoint(
+                isolate.id, testLibraryScript, 'testLibraryFunction', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service.evaluateInFrame(
+                  isolate.id, event.topFrame.index + 1, 'local');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      '23'));
+            });
+          });
+
+          test('evaluate expression in  another library', () async {
+            await onBreakPoint(isolate.id, libraryScript, 'Concatenate',
+                () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var result = await setup.service
+                  .evaluateInFrame(isolate.id, event.topFrame.index, 'a');
+
+              expect(
+                  result,
+                  isA<InstanceRef>().having(
+                      (instance) => instance.valueAsString,
+                      'valueAsString',
+                      'Hello'));
+            });
+          });
+
+          test('error', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var error = await setup.service
+                  .evaluateInFrame(isolate.id, event.topFrame.index, 'typo');
+
+              expect(
+                  error,
+                  isA<ErrorRef>().having(
+                      (instance) => instance.message,
+                      'message',
+                      matches('CompilationError: Getter not found:.*typo')));
+            });
+          });
+
+          test('cannot evaluate in unsupported isolate', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              expect(
+                  () => setup.service
+                      .evaluateInFrame('bad', event.topFrame.index, 'local'),
+                  throwsRPCError);
+            });
+          });
+        });
+      }, timeout: const Timeout.factor(2));
+
+      group('shared context with no evaluation', () {
+        setUpAll(() async {
+          await context.setUp(
+              enableExpressionEvaluation: false, verbose: false);
+        });
+
+        tearDownAll(() async {
+          await context.tearDown();
+        });
+
+        group('evaluateInFrame', () {
+          VM vm;
+          Isolate isolate;
+          ScriptList scripts;
+          ScriptRef mainScript;
+          Stream<Event> stream;
+
+          setUp(() async {
+            vm = await setup.service.getVM();
+            isolate = await setup.service.getIsolate(vm.isolates.first.id);
+            scripts = await setup.service.getScripts(isolate.id);
+
+            await setup.service.streamListen('Debug');
+            stream = setup.service.onEvent('Debug');
+
+            mainScript = scripts.scripts
+                .firstWhere((each) => each.uri.contains('main.dart'));
+          });
+
+          tearDown(() async {
+            await setup.service.resume(isolate.id);
+          });
+
+          test('cannot evaluate expression', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              expect(
+                  () => setup.service.evaluateInFrame(
+                      isolate.id, event.topFrame.index, 'local'),
+                  throwsRPCError);
+            });
+          });
+        });
+      });
+    });
   }
-
-  group('shared context with evaluation', () {
-    setUpAll(() async {
-      // Note: change 'printOnFailure' to 'print' for debug printing
-      configureLogWriter(
-          customLogWriter: (level, message,
-                  {loggerName, error, stackTrace, verbose}) =>
-              printOnFailure('[$level] $loggerName: $message'));
-
-      await context.setUp(enableExpressionEvaluation: true, verbose: false);
-    });
-
-    tearDownAll(() async {
-      await context.tearDown();
-    });
-
-    group('evaluateInFrame', () {
-      VM vm;
-      Isolate isolate;
-      ScriptList scripts;
-      ScriptRef mainScript;
-      ScriptRef libraryScript;
-      ScriptRef testLibraryScript;
-      Stream<Event> stream;
-
-      setUp(() async {
-        vm = await service.getVM();
-        isolate = await service.getIsolate(vm.isolates.first.id);
-        scripts = await service.getScripts(isolate.id);
-
-        await service.streamListen('Debug');
-        stream = service.onEvent('Debug');
-
-        mainScript = scripts.scripts
-            .firstWhere((each) => each.uri.contains('main.dart'));
-        testLibraryScript = scripts.scripts.firstWhere((each) =>
-            each.uri.contains('package:_testPackage/test_library.dart'));
-        libraryScript = scripts.scripts.firstWhere(
-            (each) => each.uri.contains('package:_test/library.dart'));
-      });
-
-      tearDown(() async {
-        await service.resume(isolate.id);
-      });
-
-      test('local', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'local');
-
-          expect(
-              result,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '42'));
-        });
-      });
-
-      test('field', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printField', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'instance.field');
-
-          expect(
-              result,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '1'));
-        });
-      }, tags: ['dev-sdk']);
-
-      test('private field from another library', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printField', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'instance._field');
-
-          expect(
-              result,
-              isA<ErrorRef>().having((instance) => instance.message, 'message',
-                  contains("The getter '_field' isn't defined")));
-        });
-      }, tags: ['dev-sdk']);
-
-      test('private field from current library', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printFieldMain', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'instance._field');
-
-          expect(
-              result,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '1'));
-        });
-      }, tags: ['dev-sdk']);
-
-      test('access instance fields after evaluation', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printField', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var instanceRef = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'instance') as InstanceRef;
-
-          var instance =
-              await service.getObject(isolate.id, instanceRef.id) as Instance;
-
-          var field = instance.fields
-              .firstWhere((BoundField element) => element.decl.name == 'field');
-
-          expect(
-              field.value,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '1'));
-        });
-      });
-
-      test('global', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printGlobal', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'testLibraryValue');
-
-          expect(
-              result,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '3'));
-        });
-      });
-
-      test('call core function', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'print(local)');
-
-          expect(
-              result,
-              isA<InstanceRef>().having((instance) => instance.valueAsString,
-                  'valueAsString', 'null'));
-        });
-      });
-
-      test('call library function with const param', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'testLibraryFunction(42)');
-
-          expect(
-              result,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '42'));
-        });
-      });
-
-      test('call library function with local param', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'testLibraryFunction(local)');
-
-          expect(
-              result,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '42'));
-        });
-      }, tags: ['dev-sdk']);
-
-      test('loop variable', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printLoopVariable',
-            () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'item');
-
-          expect(
-              result,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '1'));
-        });
-      }, tags: ['dev-sdk']);
-
-      test('evaluate expression in _testPackage/test_library', () async {
-        await onBreakPoint(isolate.id, testLibraryScript, 'testLibraryFunction',
-            () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'formal');
-
-          expect(
-              result,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '23'));
-        });
-      });
-
-      test('evaluate expression in a class constructor in another library',
-          () async {
-        await onBreakPoint(
-            isolate.id, testLibraryScript, 'testLibraryClassConstructor',
-            () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'this.field');
-
-          expect(
-              result,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '1'));
-        });
-      }, tags: 'dev-sdk');
-
-      test('evaluate expression in caller frame', () async {
-        await onBreakPoint(isolate.id, testLibraryScript, 'testLibraryFunction',
-            () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index + 1, 'local');
-
-          expect(
-              result,
-              isA<InstanceRef>().having(
-                  (instance) => instance.valueAsString, 'valueAsString', '23'));
-        });
-      });
-
-      test('evaluate expression in  another library', () async {
-        await onBreakPoint(isolate.id, libraryScript, 'Concatenate', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var result = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'a');
-
-          expect(
-              result,
-              isA<InstanceRef>().having((instance) => instance.valueAsString,
-                  'valueAsString', 'Hello'));
-        });
-      });
-
-      test('error', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          var error = await service.evaluateInFrame(
-              isolate.id, event.topFrame.index, 'typo');
-
-          expect(
-              error,
-              isA<ErrorRef>().having((instance) => instance.message, 'message',
-                  matches('CompilationError: Getter not found:.*typo')));
-        });
-      });
-
-      test('cannot evaluate in unsupported isolate', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          expect(
-              () =>
-                  service.evaluateInFrame('bad', event.topFrame.index, 'local'),
-              throwsRPCError);
-        });
-      });
-    });
-  }, timeout: const Timeout.factor(2));
-
-  group('shared context with no evaluation', () {
-    setUpAll(() async {
-      await context.setUp(enableExpressionEvaluation: false, verbose: false);
-    });
-
-    tearDownAll(() async {
-      await context.tearDown();
-    });
-
-    group('evaluateInFrame', () {
-      VM vm;
-      Isolate isolate;
-      ScriptList scripts;
-      ScriptRef mainScript;
-      Stream<Event> stream;
-
-      setUp(() async {
-        vm = await service.getVM();
-        isolate = await service.getIsolate(vm.isolates.first.id);
-        scripts = await service.getScripts(isolate.id);
-
-        await service.streamListen('Debug');
-        stream = service.onEvent('Debug');
-
-        mainScript = scripts.scripts
-            .firstWhere((each) => each.uri.contains('main.dart'));
-      });
-
-      tearDown(() async {
-        await service.resume(isolate.id);
-      });
-
-      test('cannot evaluate expression', () async {
-        await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
-          var event = await stream
-              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-
-          expect(
-              () => service.evaluateInFrame(
-                  isolate.id, event.topFrame.index, 'local'),
-              throwsRPCError);
-        });
-      });
-    });
-  });
 }

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -68,7 +68,7 @@ void main() async {
           configureLogWriter(
               customLogWriter: (level, message,
                       {loggerName, error, stackTrace, verbose}) =>
-                  print('[$level] $loggerName: $message'));
+                  printOnFailure('[$level] $loggerName: $message'));
 
           await context.setUp(enableExpressionEvaluation: true, verbose: false);
         });

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -71,7 +71,7 @@ void main() {
     );
     expect(await provider.libraries,
         contains('org-dartlang-app:///web/main.dart'));
-    expect(await provider.soundNullSafety, isNull);
+    expect(await provider.soundNullSafety, false);
   });
 
   test('throws on metadata with absolute import uris', () async {

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dwds/dwds.dart';
+import 'package:dwds/src/debugging/metadata/module_metadata.dart';
 import 'package:dwds/src/debugging/metadata/provider.dart';
 import 'package:test/test.dart';
 
@@ -81,5 +82,39 @@ void main() {
     );
     await expectLater(provider.libraries,
         throwsA(const TypeMatcher<AbsoluteImportUriException>()));
+  });
+
+  test('creates metadata from json', () async {
+    const json = {
+      'version': '1.0.0',
+      'name': 'web/main',
+      'closureName': 'load__web__main',
+      'sourceMapUri': 'foo/web/main.ddc.js.map',
+      'moduleUri': 'foo/web/main.ddc.js',
+      'libraries': [
+        {
+          'name': 'main',
+          'importUri': 'org-dartlang-app:///web/main.dart',
+          'partUris': ['org-dartlang-app:///web/main.dart']
+        }
+      ]
+    };
+
+    var metadata = ModuleMetadata.fromJson(json);
+    expect(metadata.version, '1.0.0');
+    expect(metadata.name, 'web/main');
+    expect(metadata.closureName, 'load__web__main');
+    expect(metadata.sourceMapUri, 'foo/web/main.ddc.js.map');
+    expect(metadata.moduleUri, 'foo/web/main.ddc.js');
+    var libraries = metadata.libraries;
+    expect(libraries.length, 1);
+    for (var lib in libraries.values) {
+      expect(lib.name, 'main');
+      expect(lib.importUri, 'org-dartlang-app:///web/main.dart');
+      var parts = lib.partUris;
+      expect(parts.length, 1);
+      expect(parts[0], 'org-dartlang-app:///web/main.dart');
+    }
+    expect(metadata.soundNullSafety, false);
   });
 }

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -10,6 +10,16 @@ const _emptySourceMetadata =
     '{"version":"1.0.0","name":"web/main","closureName":"load__web__main",'
     '"sourceMapUri":"foo/web/main.ddc.js.map",'
     '"moduleUri":"foo/web/main.ddc.js",'
+    '"soundNullSafety":true,'
+    '"libraries":[{"name":"main",'
+    '"importUri":"org-dartlang-app:///web/main.dart",'
+    '"fileUri":"org-dartlang-app:///web/main.dart","partUris":[]}]}\n'
+    '// intentionally empty: package blah has no dart sources';
+
+const _noNullSafetyMetadata =
+    '{"version":"1.0.0","name":"web/main","closureName":"load__web__main",'
+    '"sourceMapUri":"foo/web/main.ddc.js.map",'
+    '"moduleUri":"foo/web/main.ddc.js",'
     '"libraries":[{"name":"main",'
     '"importUri":"org-dartlang-app:///web/main.dart",'
     '"fileUri":"org-dartlang-app:///web/main.dart","partUris":[]}]}\n'
@@ -19,6 +29,7 @@ const _fileUriMetadata =
     '{"version":"1.0.0","name":"web/main","closureName":"load__web__main",'
     '"sourceMapUri":"foo/web/main.ddc.js.map",'
     '"moduleUri":"foo/web/main.ddc.js",'
+    '"soundNullSafety":true,'
     '"libraries":[{"name":"main",'
     '"importUri":"file:/Users/foo/blah/sample/lib/bar.dart",'
     '"fileUri":"org-dartlang-app:///web/main.dart","partUris":[]}]}\n'
@@ -50,6 +61,17 @@ void main() {
     );
     expect(await provider.libraries,
         contains('org-dartlang-app:///web/main.dart'));
+    expect(await provider.soundNullSafety, isNotNull);
+  });
+
+  test('can parse metadata with no null safety information', () async {
+    var provider = MetadataProvider(
+      'foo.bootstrap.js',
+      FakeAssetReader(_noNullSafetyMetadata),
+    );
+    expect(await provider.libraries,
+        contains('org-dartlang-app:///web/main.dart'));
+    expect(await provider.soundNullSafety, isNull);
   });
 
   test('throws on metadata with absolute import uris', () async {

--- a/fixtures/_testPackageSound/lib/src/version.dart
+++ b/fixtures/_testPackageSound/lib/src/version.dart
@@ -1,0 +1,2 @@
+// Generated code. Do not modify.
+const packageVersion = '1.0.0';

--- a/fixtures/_testPackageSound/lib/test_library.dart
+++ b/fixtures/_testPackageSound/lib/test_library.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+int testLibraryValue = 3;
+
+int testLibraryFunction(int formal) {
+  return formal; // Breakpoint: testLibraryFunction
+}
+
+class TestLibraryClass {
+  final int field;
+  final int _field;
+  TestLibraryClass(this.field, this._field) {
+    print('Contructor'); // Breakpoint: testLibraryClassConstructor
+  }
+
+  @override
+  String toString() => 'field: $field, _field: $_field';
+}

--- a/fixtures/_testPackageSound/lib/test_library.dart
+++ b/fixtures/_testPackageSound/lib/test_library.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/fixtures/_testPackageSound/pubspec.yaml
+++ b/fixtures/_testPackageSound/pubspec.yaml
@@ -1,0 +1,16 @@
+name: _testPackage
+version: 1.0.0
+description: >-
+  A fake package used for testing imports. Imports _test.
+publish_to: none
+
+environment:
+  sdk: '>=2.12.0-259.0.dev <3.0.0'
+
+dependencies:
+  _test:
+    path: ../_testSound
+
+dev_dependencies:
+  build_runner: ^1.0.0
+  build_web_compilers: ^2.12.0

--- a/fixtures/_testPackageSound/web/index.html
+++ b/fixtures/_testPackageSound/web/index.html
@@ -1,0 +1,7 @@
+<html>
+
+<head>
+  <script defer src="main.dart.js"></script>
+</head>
+
+</html>

--- a/fixtures/_testPackageSound/web/main.dart
+++ b/fixtures/_testPackageSound/web/main.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/fixtures/_testPackageSound/web/main.dart
+++ b/fixtures/_testPackageSound/web/main.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:core';
+import 'dart:html';
+
+import 'package:_test/library.dart';
+import 'package:_testPackage/test_library.dart';
+
+extension NumberParsing on String {
+  int parseInt() {
+    var ret = int.parse(this);
+    return ret; // Breakpoint: extension
+  }
+}
+
+void main() async {
+  var count = 0;
+  // For setting breakpoints.
+  Timer.periodic(const Duration(seconds: 1), (_) {
+    print('Count is: ${++count}');
+    print(testLibraryValue);
+  });
+
+  // for evaluation
+  Timer.periodic(const Duration(seconds: 1), (_) async {
+    await asyncMethod();
+    //printLocal();
+    printField();
+    printFieldMain();
+    printGlobal();
+    printFromTestLibrary();
+    printFromTestPackage();
+    printCallExtension();
+    printLoopVariable();
+    printGeneric<int>(0);
+  });
+
+  document.body?.appendText(concatenate('Program', ' is running!'));
+}
+
+Future<int> asyncMethod() async {
+  printLocal();
+  return 0;
+}
+void printGeneric<T>(T formal) {
+  print(formal);
+}
+
+void printLocal() {
+  var local = 42;
+  print('Local is: $local'); // Breakpoint: printLocal
+}
+
+void printField() {
+  var instance = TestLibraryClass(1, 2);
+  print('$instance'); // Breakpoint: printField
+}
+
+void printFieldMain() {
+  var instance = MainClass(1);
+  print('$instance'); // Breakpoint: printFieldMain
+}
+
+void printGlobal() {
+  print(testLibraryValue); // Breakpoint: printGlobal
+}
+
+void printFromTestPackage() {
+  print(concatenate('Hello', ' World'));
+}
+
+void printFromTestLibrary() {
+  var local = 23;
+  print(testLibraryFunction(local));
+}
+
+void printCallExtension() {
+  var local = '23';
+  print(local.parseInt());
+}
+
+void printLoopVariable() {
+  var list  = <String>['1'];
+  for(var item in list) {
+    print(item); // Breakpoint: printLoopVariable
+  }
+}
+
+class MainClass {
+  int _field;
+  MainClass(this._field);
+}

--- a/fixtures/_testSound/example/append_body/index.html
+++ b/fixtures/_testSound/example/append_body/index.html
@@ -1,0 +1,7 @@
+<html>
+
+<head>
+  <script defer src="main.dart.js"></script>
+</head>
+
+</html>

--- a/fixtures/_testSound/example/append_body/main.dart
+++ b/fixtures/_testSound/example/append_body/main.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:developer';
+import 'dart:html';
+
+void main() {
+  var count = 0;
+  // For setting breakpoints.
+  Timer.periodic(const Duration(seconds: 1), (_) {
+    print('Count is: ${++count}'); // Breakpoint: printCount
+  });
+
+  document.body?.appendText('Hello World!');
+
+  registerExtension('ext.flutter.disassemble', (_, __) async {
+    document.body?.appendText('start disassemble ');
+    await Future.delayed(const Duration(seconds: 1));
+    document.body?.appendText('end disassemble ');
+    return ServiceExtensionResponse.result('{}');
+  });
+}

--- a/fixtures/_testSound/example/append_body/main.dart
+++ b/fixtures/_testSound/example/append_body/main.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/fixtures/_testSound/example/hello_world/index.html
+++ b/fixtures/_testSound/example/hello_world/index.html
@@ -1,0 +1,7 @@
+<html>
+
+<head>
+  <script defer src="main.dart.js"></script>
+</head>
+
+</html>

--- a/fixtures/_testSound/example/hello_world/main.dart
+++ b/fixtures/_testSound/example/hello_world/main.dart
@@ -1,0 +1,124 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:developer';
+import 'dart:html';
+import 'dart:js';
+
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+
+part 'part.dart';
+
+final myInstance = MyTestClass();
+
+void main() async {
+  print(DateFormat());
+  // Long running so that we can test the pause / resume behavior.
+  Timer.periodic(const Duration(seconds: 1), (_) {});
+
+  print(p.join('Hello', 'World')); // Breakpoint: printHelloWorld
+
+  // long running to test evaluateInFrame
+  Timer.periodic(const Duration(seconds: 1), (_) {
+    var local = 42;
+    print(local); // Breakpoint: printLocal
+  });
+
+  context['inspectInstance'] = () {
+    inspect(myInstance);
+  };
+
+  context['postEvent'] = (String kind) {
+    postEvent(kind, {'example': 'data'});
+  };
+
+  context['registerExtension'] = (String method) {
+    registerExtension(method,
+        (String method, Map<String, String> parameters) async {
+      return ServiceExtensionResponse.result(jsonEncode(parameters ?? {}));
+    });
+  };
+
+  context['registerExtensionWithError'] = (String method) {
+    registerExtension(method,
+        (String method, Map<String, String> parameters) async {
+      return ServiceExtensionResponse.error(
+          int.parse(parameters['code']!), parameters['details']!);
+    });
+  };
+
+  context['sendLog'] = (String message) {
+    log(message, name: 'testLogCategory');
+  };
+
+  Timer.periodic(const Duration(seconds: 1), (_) {
+    printCount(); // Breakpoint: callPrintCount
+  });
+
+  Timer.periodic(const Duration(seconds: 1), (_) {
+    asyncCall();
+  });
+
+  Timer.periodic(const Duration(seconds: 1), (_) {
+    throwsException();
+  });
+
+  // Register one up front before the proxy connects, the isolate should still
+  // recognize this as an available extension.
+  registerExtension('ext.hello_world.existing', (_, __) => Future.value(ServiceExtensionResponse.error(0, '')));
+
+  window.console.debug('Page Ready');
+}
+
+var count = 0;
+
+// An easy location to add a breakpoint.
+void printCount() {
+  print('The count is ${++count}'); // Breakpoint: inPrintCount
+  doSomething();
+}
+
+void asyncCall() async {
+  var now = DateTime.now();
+
+  await Future.delayed(Duration.zero);
+
+  var then = DateTime.now(); // Breakpoint: asyncCall
+  // ignore: unused_local_variable
+  var diff = then.difference(now);
+}
+
+void throwsException() {
+  try {
+    throw Exception('new exception');
+  } catch (e) {
+    // ignore
+  }
+}
+
+String helloString(String response) => response;
+
+bool helloBool(bool response) => response;
+
+num helloNum(num response) => response;
+
+MyTestClass createObject(String message) => MyTestClass(message: message);
+
+String messageFor(MyTestClass instance) => instance.message;
+
+String messagesCombined(MyTestClass a, MyTestClass b) => a.message + b.message;
+
+class MyTestClass {
+  final String message;
+
+  String notFinal;
+
+  MyTestClass({this.message = 'world'}):
+    notFinal = 'wonderful';
+
+  String hello() => message;
+}

--- a/fixtures/_testSound/example/hello_world/main.dart
+++ b/fixtures/_testSound/example/hello_world/main.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/fixtures/_testSound/example/hello_world/part.dart
+++ b/fixtures/_testSound/example/hello_world/part.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/fixtures/_testSound/example/hello_world/part.dart
+++ b/fixtures/_testSound/example/hello_world/part.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of 'main.dart';
+
+var blah = 'blah';
+
+void doSomething() {
+  print(blah);
+}

--- a/fixtures/_testSound/lib/library.dart
+++ b/fixtures/_testSound/lib/library.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A library that we can import.
+library test_library;
+
+int aVariable = 3;
+
+String concatenate(String a, String b) {
+  return '$a$b'; // Breakpoint: Concatenate
+}

--- a/fixtures/_testSound/lib/library.dart
+++ b/fixtures/_testSound/lib/library.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/fixtures/_testSound/pubspec.yaml
+++ b/fixtures/_testSound/pubspec.yaml
@@ -1,0 +1,16 @@
+name: _test
+version: 1.0.0
+description: >-
+  A fake package used for testing
+publish_to: none
+
+environment:
+  sdk: '>=2.12.0-259.0.dev <3.0.0'
+
+dependencies:
+  intl: ^0.17.0-nullsafety.2
+  path: ^1.6.1
+
+dev_dependencies:
+  build_runner: ^1.6.7
+  build_web_compilers: ^2.12.0

--- a/fixtures/_webdevSoundSmoke/pubspec.yaml
+++ b/fixtures/_webdevSoundSmoke/pubspec.yaml
@@ -4,16 +4,6 @@ description: A test fixture for webdev testing with sound support.
 environment:
   sdk: '>=2.12.0-259.0.dev <3.0.0'
 
-# dependencies:
-#   html: ^0.15.0
-#   csslib: ^0.17.0
-
-# dependency_overrides:
-#   html:
-#     path: ../../../html
-#   csslib: 
-#     path: ../../../csslib
-
 dev_dependencies:
   build_runner: '>=1.6.2 <2.0.0'
   build_web_compilers: '>=2.12.0 <3.0.0'

--- a/fixtures/_webdevSoundSmoke/pubspec.yaml
+++ b/fixtures/_webdevSoundSmoke/pubspec.yaml
@@ -2,8 +2,19 @@ name: _webdevSmoke
 description: A test fixture for webdev testing with sound support.
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0-259.0.dev <3.0.0'
+
+# dependencies:
+#   html: ^0.15.0
+#   csslib: ^0.17.0
+
+# dependency_overrides:
+#   html:
+#     path: ../../../html
+#   csslib: 
+#     path: ../../../csslib
 
 dev_dependencies:
   build_runner: '>=1.6.2 <2.0.0'
   build_web_compilers: '>=2.12.0 <3.0.0'
+

--- a/fixtures/_webdevSoundSmoke/web/main.dart
+++ b/fixtures/_webdevSoundSmoke/web/main.dart
@@ -3,5 +3,23 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.12
+import 'dart:async';
+import 'dart:convert';
+import 'dart:developer';
+import 'dart:html';
 
-void main() {}
+void main() {
+  print('Initial Print');
+
+  registerExtension('ext.print', (_, __) async {
+    print('Hello World');
+    return ServiceExtensionResponse.result(json.encode({'success': true}));
+  });
+  document.body?.append(SpanElement()..text = 'Hello World!!');
+
+  var count = 0;
+  Timer.periodic(const Duration(seconds: 1), (_) {
+    print('Counter is: ${++count}'); // Breakpoint: printCounter
+  });
+}
+  

--- a/fixtures/_webdevSoundSmoke/web/main.dart
+++ b/fixtures/_webdevSoundSmoke/web/main.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.12
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.7.2 - Unreleased
 
 - Depend on the latest `package:dwds`.
-- Support new `sound-null-safety` flag. See README.
+- Support new `null-safety` flag. See README.
 - Support latest `package:vm_service` version `6.x.x`.
 
 ## 2.7.1

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -42,7 +42,7 @@ changes.
 Usage: webdev serve [arguments] [<directory>[:<port>]]...
     --auto                                 Automatically performs an action
                                            after each build:
-
+                                           
                                            restart: Reload modules and re-invoke
                                            main (loses current state)
                                            refresh: Performs a full page
@@ -97,6 +97,16 @@ Common:
                                            "--output" value should be passed to
                                            `build_runner`.
                                            (defaults to "NONE")
+-n, --null-safety                          If "sound",
+                                           `package:build_web_compilers` will be
+                                           run with sound null safety support.
+                                           If "unsound",
+                                           `package:build_web_compilers` will be
+                                           run without sound null safety
+                                           support. If "auto", the default
+                                           `package:build_web_compilers`
+                                           behavior is used.
+                                           (defaults to "auto")
 -r, --[no-]release                         Build with release mode defaults for
                                            builders.
     --[no-]build-web-compilers             If a dependency on
@@ -105,18 +115,10 @@ Common:
                                            (defaults to on)
 -e, --[no-]enable-expression-evaluation    Enable expression evaluation features
                                            in the debugger.
-    --[no-]sound-null-safety               If provided,
-                                           `package:build_web_compilers` will be
-                                           run with sound null safety support.
-                                           If negated,
-                                           `package:build_web_compilers` will be
-                                           run without sound null safety
-                                           support. If not provided, the default
-                                           `package:build_web_compilers`
-                                           behavior is used.
 -v, --verbose                              Enables verbose logging.
 
 Run "webdev help" to see global options.
+
 ```
 
 ### `webdev build`
@@ -136,6 +138,16 @@ Usage: webdev build [arguments]
                                            "--output" value should be passed to
                                            `build_runner`.
                                            (defaults to "web:build")
+-n, --null-safety                          If "sound",
+                                           `package:build_web_compilers` will be
+                                           run with sound null safety support.
+                                           If "unsound",
+                                           `package:build_web_compilers` will be
+                                           run without sound null safety
+                                           support. If "auto", the default
+                                           `package:build_web_compilers`
+                                           behavior is used.
+                                           (defaults to "auto")
 -r, --[no-]release                         Build with release mode defaults for
                                            builders.
                                            (defaults to on)
@@ -145,15 +157,6 @@ Usage: webdev build [arguments]
                                            (defaults to on)
 -e, --[no-]enable-expression-evaluation    Enable expression evaluation features
                                            in the debugger.
-    --[no-]sound-null-safety               If provided,
-                                           `package:build_web_compilers` will be
-                                           run with sound null safety support.
-                                           If negated,
-                                           `package:build_web_compilers` will be
-                                           run without sound null safety
-                                           support. If not provided, the default
-                                           `package:build_web_compilers`
-                                           behavior is used.
 -v, --verbose                              Enables verbose logging.
 
 Run "webdev help" to see global options.

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -42,7 +42,7 @@ changes.
 Usage: webdev serve [arguments] [<directory>[:<port>]]...
     --auto                                 Automatically performs an action
                                            after each build:
-                                           
+
                                            restart: Reload modules and re-invoke
                                            main (loses current state)
                                            refresh: Performs a full page
@@ -160,6 +160,7 @@ Usage: webdev build [arguments]
 -v, --verbose                              Enables verbose logging.
 
 Run "webdev help" to see global options.
+
 ```
 
 [activating]: https://www.dartlang.org/tools/pub/cmd/pub-global#activating-a-package

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -106,7 +106,7 @@ Common:
                                            support. If "auto", the default
                                            `package:build_web_compilers`
                                            behavior is used.
-                                           (defaults to "auto")
+                                           [sound, unsound, auto (default)]
 -r, --[no-]release                         Build with release mode defaults for
                                            builders.
     --[no-]build-web-compilers             If a dependency on
@@ -147,7 +147,7 @@ Usage: webdev build [arguments]
                                            support. If "auto", the default
                                            `package:build_web_compilers`
                                            behavior is used.
-                                           (defaults to "auto")
+                                           [sound, unsound, auto (default)]
 -r, --[no-]release                         Build with release mode defaults for
                                            builders.
                                            (defaults to on)

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -30,6 +30,9 @@ const requireBuildWebCompilersFlag = 'build-web-compilers';
 const enableExpressionEvaluationFlag = 'enable-expression-evaluation';
 const verboseFlag = 'verbose';
 const nullSafetyFlag = 'null-safety';
+const nullSafetySound = 'sound';
+const nullSafetyUnsound = 'unsound';
+const nullSafetyAuto = 'auto';
 const disableDdsFlag = 'disable-dds';
 
 ReloadConfiguration _parseReloadConfiguration(ArgResults argResults) {

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -29,7 +29,7 @@ const releaseFlag = 'release';
 const requireBuildWebCompilersFlag = 'build-web-compilers';
 const enableExpressionEvaluationFlag = 'enable-expression-evaluation';
 const verboseFlag = 'verbose';
-const soundNullSafetyFlag = 'sound-null-safety';
+const nullSafetyFlag = 'null-safety';
 const disableDdsFlag = 'disable-dds';
 
 ReloadConfiguration _parseReloadConfiguration(ArgResults argResults) {
@@ -97,7 +97,7 @@ class Configuration {
   final bool _enableExpressionEvaluation;
   final bool _verbose;
   final bool _disableDds;
-  final bool _soundNullSafety;
+  final String _nullSafety;
 
   Configuration({
     bool autoRun,
@@ -120,7 +120,7 @@ class Configuration {
     bool enableExpressionEvaluation,
     bool verbose,
     bool disableDds,
-    bool soundNullSafety,
+    String nullSafety,
   })  : _autoRun = autoRun,
         _chromeDebugPort = chromeDebugPort,
         _debugExtension = debugExtension,
@@ -139,7 +139,7 @@ class Configuration {
         _disableDds = disableDds,
         _enableExpressionEvaluation = enableExpressionEvaluation,
         _verbose = verbose,
-        _soundNullSafety = soundNullSafety {
+        _nullSafety = nullSafety {
     _validateConfiguration();
   }
 
@@ -206,7 +206,7 @@ class Configuration {
       enableExpressionEvaluation:
           other._enableExpressionEvaluation ?? _enableExpressionEvaluation,
       verbose: other._verbose ?? _verbose,
-      soundNullSafety: other._soundNullSafety ?? _soundNullSafety);
+      nullSafety: other._nullSafety ?? _nullSafety);
 
   factory Configuration.noInjectedClientDefaults() =>
       Configuration(autoRun: false, debug: false, debugExtension: false);
@@ -248,9 +248,12 @@ class Configuration {
 
   bool get verbose => _verbose ?? false;
 
-  // Null indicates that the default `package:build_web_compilers`
+  /// Null safety mode:
+  ///
+  /// 'sound', 'unsound', or 'auto'.
+  /// 'auto' indicates that the default `package:build_web_compilers`
   // behavior should be used.
-  bool get soundNullSafety => _soundNullSafety;
+  String get nullSafety => _nullSafety;
 
   /// Returns a new configuration with values updated from the parsed args.
   static Configuration fromArgs(ArgResults argResults,
@@ -355,9 +358,9 @@ class Configuration {
         ? argResults[verboseFlag] as bool
         : defaultConfiguration.verbose;
 
-    var soundNullSafety = argResults.options.contains(soundNullSafetyFlag)
-        ? argResults[soundNullSafetyFlag] as bool
-        : defaultConfiguration.soundNullSafety;
+    var nullSafety = argResults.options.contains(nullSafetyFlag)
+        ? argResults[nullSafetyFlag] as String
+        : defaultConfiguration.nullSafety;
 
     var disableDds = argResults.options.contains(disableDdsFlag)
         ? argResults[disableDdsFlag] as bool
@@ -384,7 +387,7 @@ class Configuration {
       disableDds: disableDds,
       enableExpressionEvaluation: enableExpressionEvaluation,
       verbose: verbose,
-      soundNullSafety: soundNullSafety,
+      nullSafety: nullSafety,
     );
   }
 }

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -255,7 +255,7 @@ class Configuration {
   ///
   /// 'sound', 'unsound', or 'auto'.
   /// 'auto' indicates that the default `package:build_web_compilers`
-  // behavior should be used.
+  /// behavior should be used.
   String get nullSafety => _nullSafety;
 
   /// Returns a new configuration with values updated from the parsed args.

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -30,7 +30,8 @@ void addSharedArgs(ArgParser argParser,
     )
     ..addOption(nullSafetyFlag,
         abbr: 'n',
-        defaultsTo: autoOption,
+        defaultsTo: nullSafetyAuto,
+        allowed: [nullSafetySound, nullSafetyUnsound, nullSafetyAuto],
         help:
             'If "sound", `package:build_web_compilers` will be run with sound '
             'null safety support. '
@@ -83,11 +84,11 @@ List<String> buildRunnerArgs(
       ..add('build_web_compilers|ddc=generate-full-dill=true');
   }
 
-  if (configuration.nullSafety != autoOption) {
+  if (configuration.nullSafety != nullSafetyAuto) {
     arguments
       ..add('--define')
       ..add('build_web_compilers:entrypoint=sound_null_safety='
-          '${configuration.nullSafety == "sound"}');
+          '${configuration.nullSafety == nullSafetySound}');
   }
 
   return arguments;

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -28,6 +28,16 @@ void addSharedArgs(ArgParser argParser,
           'A value of "NONE" indicates that no "--output" value should be '
           'passed to `build_runner`.',
     )
+    ..addOption(nullSafetyFlag,
+        abbr: 'n',
+        defaultsTo: autoOption,
+        help:
+            'If "sound", `package:build_web_compilers` will be run with sound '
+            'null safety support. '
+            'If "unsound", `package:build_web_compilers` will be run without '
+            'sound null safety support. '
+            'If "auto", the default `package:build_web_compilers` '
+            'behavior is used.')
     ..addFlag(releaseFlag,
         abbr: 'r',
         defaultsTo: releaseDefault,
@@ -47,15 +57,6 @@ void addSharedArgs(ArgParser argParser,
         defaultsTo: false,
         negatable: true,
         help: 'Enable expression evaluation features in the debugger.')
-    ..addFlag(soundNullSafetyFlag,
-        negatable: true,
-        help:
-            'If provided, `package:build_web_compilers` will be run with sound '
-            'null safety support. '
-            'If negated, `package:build_web_compilers` will be run without '
-            'sound null safety support. '
-            'If not provided, the default `package:build_web_compilers` '
-            'behavior is used.')
     ..addFlag(verboseFlag,
         abbr: 'v',
         defaultsTo: false,
@@ -82,11 +83,11 @@ List<String> buildRunnerArgs(
       ..add('build_web_compilers|ddc=generate-full-dill=true');
   }
 
-  if (configuration.soundNullSafety != null) {
+  if (configuration.nullSafety != autoOption) {
     arguments
       ..add('--define')
       ..add('build_web_compilers:entrypoint=sound_null_safety='
-          '${configuration.soundNullSafety}');
+          '${configuration.nullSafety == "sound"}');
   }
 
   return arguments;

--- a/webdev/test/configuration_test.dart
+++ b/webdev/test/configuration_test.dart
@@ -37,9 +37,10 @@ void main() {
         throwsA(isA<InvalidConfiguration>()));
   });
 
-  test('soundNullSafety defaults to null', () {
-    var defaultConfiguration = Configuration.fromArgs(null);
-    expect(defaultConfiguration.soundNullSafety, isNull);
+  test('nullSafety defaults to auto', () {
+    var argResults = argParser.parse(['']);
+    var defaultConfiguration = Configuration.fromArgs(argResults);
+    expect(defaultConfiguration.nullSafety, equals(autoOption));
   });
 
   test(

--- a/webdev/test/configuration_test.dart
+++ b/webdev/test/configuration_test.dart
@@ -9,7 +9,9 @@ import 'package:webdev/src/command/configuration.dart';
 void main() {
   ArgParser argParser;
   setUp(() {
-    argParser = ArgParser()..addFlag('release');
+    argParser = ArgParser()
+      ..addFlag('release')
+      ..addOption(nullSafetyFlag, defaultsTo: nullSafetyAuto);
   });
 
   test('default configuration is correctly applied', () {
@@ -40,7 +42,7 @@ void main() {
   test('nullSafety defaults to auto', () {
     var argResults = argParser.parse(['']);
     var defaultConfiguration = Configuration.fromArgs(argResults);
-    expect(defaultConfiguration.nullSafety, equals(autoOption));
+    expect(defaultConfiguration.nullSafety, equals(nullSafetyAuto));
   });
 
   test(

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -283,7 +283,6 @@ void main() {
             'daemon',
             'web:$openPort',
             '--enable-expression-evaluation',
-            //'--null-safety=$nullSafetyOption',
             '--verbose',
           ];
           var process = await runWebDev(args,
@@ -341,7 +340,6 @@ void main() {
             'daemon',
             'web:$openPort',
             '--no-enable-expression-evaluation',
-            //'--null-safety=$nullSafetyOption',
           ];
           var process = await runWebDev(args,
               workingDirectory:

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -168,7 +168,7 @@ void main() {
           '-o',
           'web:${d.sandbox}',
           '--no-release',
-          'null-safety=unsound'
+          '--null-safety=unsound'
         ];
 
         var process =

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -134,14 +134,14 @@ void main() {
       });
     }
     test(
-      'and --sound-null-safety',
+      'and --null-safety=sound',
       () async {
         var args = [
           'build',
           '-o',
           'web:${d.sandbox}',
           '--no-release',
-          '--sound-null-safety'
+          '--null-safety=sound'
         ];
 
         var process =
@@ -161,14 +161,14 @@ void main() {
     );
 
     test(
-      'and --no-sound-null-safety',
+      'and --null-safety=unsound',
       () async {
         var args = [
           'build',
           '-o',
           'web:${d.sandbox}',
           '--no-release',
-          '--no-sound-null-safety'
+          'null-safety=unsound'
         ];
 
         var process =
@@ -272,110 +272,123 @@ void main() {
     }
   });
 
-  group('should work with expression evaluation', () {
-    test('enabled', () async {
-      var openPort = await findUnusedPort();
-      // running daemon command that starts dwds without keyboard input
-      var args = [
-        'daemon',
-        'web:$openPort',
-        '--enable-expression-evaluation',
-        '--verbose',
-      ];
-      var process = await runWebDev(args, workingDirectory: exampleDirectory);
-      VmService vmService;
+  group('should work with ', () {
+    for (var soundNullSafety in [false, true]) {
+      var nullSafetyOption = soundNullSafety ? 'sound' : 'unsound';
+      group('--null-safety=$nullSafetyOption', () {
+        test('and --enable-expression-evaluation', () async {
+          var openPort = await findUnusedPort();
+          // running daemon command that starts dwds without keyboard input
+          var args = [
+            'daemon',
+            'web:$openPort',
+            '--enable-expression-evaluation',
+            //'--null-safety=$nullSafetyOption',
+            '--verbose',
+          ];
+          var process = await runWebDev(args,
+              workingDirectory:
+                  soundNullSafety ? soundExampleDirectory : exampleDirectory);
+          VmService vmService;
 
-      try {
-        // Wait for debug service Uri
-        String wsUri;
-        await expectLater(process.stdout, emitsThrough((message) {
-          wsUri = getDebugServiceUri(message as String);
-          return wsUri != null;
-        }));
-        expect(wsUri, isNotNull);
+          try {
+            // Wait for debug service Uri
+            String wsUri;
+            await expectLater(process.stdout, emitsThrough((message) {
+              wsUri = getDebugServiceUri(message as String);
+              return wsUri != null;
+            }));
+            expect(wsUri, isNotNull);
 
-        vmService = await vmServiceConnectUri(wsUri);
-        var vm = await vmService.getVM();
-        var isolate = vm.isolates.first;
-        var scripts = await vmService.getScripts(isolate.id);
+            vmService = await vmServiceConnectUri(wsUri);
+            var vm = await vmService.getVM();
+            var isolate = vm.isolates.first;
+            var scripts = await vmService.getScripts(isolate.id);
 
-        await vmService.streamListen('Debug');
-        var stream = vmService.onEvent('Debug');
+            await vmService.streamListen('Debug');
+            var stream = vmService.onEvent('Debug');
 
-        var mainScript = scripts.scripts
-            .firstWhere((each) => each.uri.contains('main.dart'));
+            var mainScript = scripts.scripts
+                .firstWhere((each) => each.uri.contains('main.dart'));
 
-        var bpLine = await findBreakpointLine(
-            vmService, 'printCounter', isolate.id, mainScript);
+            var bpLine = await findBreakpointLine(
+                vmService, 'printCounter', isolate.id, mainScript);
 
-        var bp = await vmService.addBreakpointWithScriptUri(
-            isolate.id, mainScript.uri, bpLine);
-        expect(bp, isNotNull);
+            var bp = await vmService.addBreakpointWithScriptUri(
+                isolate.id, mainScript.uri, bpLine);
+            expect(bp, isNotNull);
 
-        await stream.firstWhere(
-            (Event event) => event.kind == EventKind.kPauseBreakpoint);
+            await stream.firstWhere(
+                (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
-        var result = await vmService.evaluateInFrame(isolate.id, 0, 'true');
-        expect(
-            result,
-            const TypeMatcher<InstanceRef>().having(
-                (instance) => instance.valueAsString, 'valueAsString', 'true'));
-      } finally {
-        await vmService?.dispose();
-        await exitWebdev(process);
-        await process.shouldExit();
-      }
-    }, timeout: const Timeout.factor(2));
+            var result = await vmService.evaluateInFrame(isolate.id, 0, 'true');
+            expect(
+                result,
+                const TypeMatcher<InstanceRef>().having(
+                    (instance) => instance.valueAsString,
+                    'valueAsString',
+                    'true'));
+          } finally {
+            await vmService?.dispose();
+            await exitWebdev(process);
+            await process.shouldExit();
+          }
+        }, timeout: const Timeout.factor(2));
 
-    test('disabled', () async {
-      var openPort = await findUnusedPort();
-      var args = [
-        'daemon',
-        'web:$openPort',
-        '--no-enable-expression-evaluation',
-      ];
-      var process = await runWebDev(args, workingDirectory: exampleDirectory);
-      VmService vmService;
+        test('and --no-enable-expression-evaluation', () async {
+          var openPort = await findUnusedPort();
+          var args = [
+            'daemon',
+            'web:$openPort',
+            '--no-enable-expression-evaluation',
+            //'--null-safety=$nullSafetyOption',
+          ];
+          var process = await runWebDev(args,
+              workingDirectory:
+                  soundNullSafety ? soundExampleDirectory : exampleDirectory);
+          VmService vmService;
 
-      try {
-        // Wait for debug service Uri
-        String wsUri;
-        await expectLater(process.stdout, emitsThrough((message) {
-          wsUri = getDebugServiceUri(message as String);
-          return wsUri != null;
-        }));
-        expect(wsUri, isNotNull);
+          try {
+            // Wait for debug service Uri
+            String wsUri;
+            await expectLater(process.stdout, emitsThrough((message) {
+              wsUri = getDebugServiceUri(message as String);
+              return wsUri != null;
+            }));
+            expect(wsUri, isNotNull);
 
-        vmService = await vmServiceConnectUri(wsUri);
-        var vm = await vmService.getVM();
-        var isolate = vm.isolates.first;
-        var scripts = await vmService.getScripts(isolate.id);
+            vmService = await vmServiceConnectUri(wsUri);
+            var vm = await vmService.getVM();
+            var isolate = vm.isolates.first;
+            var scripts = await vmService.getScripts(isolate.id);
 
-        await vmService.streamListen('Debug');
-        var stream = vmService.onEvent('Debug');
+            await vmService.streamListen('Debug');
+            var stream = vmService.onEvent('Debug');
 
-        var mainScript = scripts.scripts
-            .firstWhere((each) => each.uri.contains('main.dart'));
+            var mainScript = scripts.scripts
+                .firstWhere((each) => each.uri.contains('main.dart'));
 
-        var bpLine = await findBreakpointLine(
-            vmService, 'printCounter', isolate.id, mainScript);
+            var bpLine = await findBreakpointLine(
+                vmService, 'printCounter', isolate.id, mainScript);
 
-        var bp = await vmService.addBreakpointWithScriptUri(
-            isolate.id, mainScript.uri, bpLine);
-        expect(bp, isNotNull);
+            var bp = await vmService.addBreakpointWithScriptUri(
+                isolate.id, mainScript.uri, bpLine);
+            expect(bp, isNotNull);
 
-        var event = await stream.firstWhere(
-            (Event event) => event.kind == EventKind.kPauseBreakpoint);
+            var event = await stream.firstWhere(
+                (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
-        expect(
-            () => vmService.evaluateInFrame(
-                isolate.id, event.topFrame.index, 'true'),
-            throwsRPCError);
-      } finally {
-        await vmService?.dispose();
-        await exitWebdev(process);
-        await process.shouldExit();
-      }
-    });
+            expect(
+                () => vmService.evaluateInFrame(
+                    isolate.id, event.topFrame.index, 'true'),
+                throwsRPCError);
+          } finally {
+            await vmService?.dispose();
+            await exitWebdev(process);
+            await process.shouldExit();
+          }
+        });
+      });
+    }
   }, tags: 'expression-compilation-service');
 }


### PR DESCRIPTION
- Update metadata to include null safety option for a module
- Read null safety information from the module metadata and pass
  it to ExpressionCompiler.initialize()
- Add contents to _webdevSoundSmoke to text evaluation in sound mode
- Added sound null safety tests for expression evaluation in dwds when using
  build_web_compilers to compile.
- Changed `--sound-null-safety` flag to a `--null-safety=<sound, unsound, auto>`
  to make its tri-state nature explicit