### PR TITLE
FutureOr<int> port ExpressionCompilerService

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.2-dev
+
+- Change `ExpressionCompiler` to accept `FutureOr<int>` port configuration.
+
 ## 8.0.1
 
 - Support null safe versions of `package:crypto`, `package:uuid` and

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -48,9 +48,6 @@ class _Compiler {
   /// Starts expression compiler worker in an isolate and creates the
   /// expression compilation service that communicates to the worker.
   ///
-  /// Uses [address] and [port] to communicate and [assetHandler] to
-  /// redirect asset requests to the asset server.
-  ///
   /// [workerPath] is the path for the expression compiler worker,
   /// [sdkSummaryPath] is the path to the sdk summary dill file
   /// [librariesPath] is the path to libraries definitions file
@@ -67,7 +64,6 @@ class _Compiler {
   static Future<_Compiler> start(
     String address,
     int port,
-    Handler assetHandler,
     String workerPath,
     String sdkSummaryPath,
     String librariesPath,
@@ -243,7 +239,7 @@ class _Compiler {
 class ExpressionCompilerService implements ExpressionCompiler {
   final _compiler = Completer<_Compiler>();
   final String _address;
-  final int _port;
+  final FutureOr<int> _port;
   final Handler _assetHandler;
   final bool _verbose;
 
@@ -289,8 +285,8 @@ class ExpressionCompilerService implements ExpressionCompiler {
     var workerPath =
         _workerPath ?? p.join(binDir, 'snapshots', 'dartdevc.dart.snapshot');
 
-    var compiler = await _Compiler.start(_address, _port, _assetHandler,
-        workerPath, sdkSummaryPath, librariesPath, _verbose, soundNullSafety);
+    var compiler = await _Compiler.start(_address, await _port, workerPath,
+        sdkSummaryPath, librariesPath, _verbose, soundNullSafety);
 
     _compiler.complete(compiler);
   }

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '8.0.1';
+const packageVersion = '8.0.2-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 8.0.1
+version: 8.0.2-dev
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM


### PR DESCRIPTION
Some users of ExpressionCompilerService do not have the port at time of construction. Allow for `FutureOr` to lazily provide the port.