### PR TITLE
Serve the injected client if available

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Change `ExpressionCompiler` to accept `FutureOr<int>` port configuration.
 - Depend on `package:vm_service` version `6.0.1-nullsafety.1`.
+- Serve the injected client source map if available.
 
 ## 8.0.1
 

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -47,10 +47,13 @@ class DwdsInjector {
 
   Middleware get middleware => (innerHandler) {
         return (Request request) async {
-          if (request.url.path.endsWith('$_clientScript.js')) {
+          if (request.url.path.endsWith('$_clientScript.js') ||
+              request.url.path.endsWith('$_clientScript.js.map')) {
             var uri = await Isolate.resolvePackageUri(
                 Uri.parse('package:$_clientScript.js'));
-            var result = await File(uri.toFilePath()).readAsString();
+            var result = await File(uri.toFilePath() +
+                    (request.url.path.endsWith('.map') ? '.map' : ''))
+                .readAsString();
             return Response.ok(result, headers: {
               HttpHeaders.contentTypeHeader: 'application/javascript'
             });


### PR DESCRIPTION
We don't produce the source map for the injected client for external users but we do for internal usage. Serve it if it's available.