### PR TITLE
Updated google3 summary paths location

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -188,7 +188,11 @@ class ChromeProxyService implements VmServiceInterface {
           // is not a part of the name.
           // TODO: Save locations of summary kernel files in ddc metadata.
           // Issue: https://github.com/dart-lang/sdk/issues/44742
-          p.setExtension(serverPath.replaceAll('.ddk.', '.ddc.'), '.dill'));
+          p.setExtension(
+              serverPath
+                  .replaceAll('.ddk.', '.ddc.')
+                  .replaceAll('.ddk_sns.', '.ddc_sns.'),
+              '.dill'));
     }
     await _compiler?.updateDependencies(dependencies);
   }


### PR DESCRIPTION
Updated temporary guessing of summary location paths to work with sound null safety in google3.