### PR TITLE
Fix hot restarts with Flutter SDK sources

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.0.3
+
+- Fix an issue where failed hot restarts would hang indefinitely. 
+
+
 ## 8.0.2
 
 - Change `ExpressionCompiler` to accept `FutureOr<int>` port configuration.

--- a/dwds/lib/src/injected/client.js
+++ b/dwds/lib/src/injected/client.js
@@ -22477,7 +22477,7 @@
     _reload$body$RequireRestarter: function(modules) {
       var $async$goto = 0,
         $async$completer = P._makeAsyncAwaitCompleter(type$.legacy_bool),
-        $async$returnValue, $async$handler = 2, $async$currentError, $async$next = [], $async$self = this, reloadedModules, previousModuleId, moduleId, parentIds, childModule, e, t1, t2, t3, t4, t5, exception, $async$exception;
+        $async$returnValue, $async$handler = 2, $async$currentError, $async$next = [], $async$self = this, reloadedModules, previousModuleId, moduleId, parentIds, childModule, e, t2, t3, t4, t5, exception, t1, $async$exception;
       var $async$_reload$1 = P._wrapJsFunctionForAsync(function($async$errorCode, $async$result) {
         if ($async$errorCode === 1) {
           $async$currentError = $async$result;
@@ -22487,7 +22487,6 @@
           switch ($async$goto) {
             case 0:
               // Function start
-              $async$self._dirtyModules.addAll$1(0, modules);
               t1 = $async$self._running.future;
               $async$goto = t1._state === 0 ? 3 : 4;
               break;
@@ -22506,6 +22505,7 @@
               $async$self.set$_running(new P._AsyncCompleter(new P._Future($.Zone__current, type$._Future_legacy_bool), type$._AsyncCompleter_legacy_bool));
               reloadedModules = 0;
               $async$handler = 7;
+              $async$self._dirtyModules.addAll$1(0, modules);
               previousModuleId = null;
               t1 = $async$self.get$_moduleTopologicalCompare(), t2 = type$.legacy_String, t3 = type$.JSArray_legacy_Object, t4 = type$.legacy_dynamic_Function;
             case 10:

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '8.0.2';
+const packageVersion = '8.0.3';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 8.0.2
+version: 8.0.3
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/web/reloader/require_restarter.dart
+++ b/dwds/web/reloader/require_restarter.dart
@@ -173,8 +173,6 @@ class RequireRestarter implements Restarter {
   /// Returns `true` if the reload was fully handled, `false` if it failed
   /// explicitly, or `null` for an unhandled reload.
   Future<bool> _reload(List<String> modules) async {
-    _dirtyModules.addAll(modules);
-
     // As function is async, it can potentially be called second time while
     // first invocation is still running. In this case just mark as dirty and
     // wait until loop from the first call will do the work
@@ -183,6 +181,7 @@ class RequireRestarter implements Restarter {
 
     var reloadedModules = 0;
     try {
+      _dirtyModules.addAll(modules);
       String previousModuleId;
       while (_dirtyModules.isNotEmpty) {
         var moduleId = _dirtyModules.first;


### PR DESCRIPTION
When we add modules to the `_dirtyModule` `SplayTree` we add them in topological order. If we don't have order information, for example for SDK sources, we throw an exception. Previous this exception wasn't caught which would cause the hot restart to hang. Now we capture the exception and fall back on a full reload.

Fixes https://github.com/flutter/flutter/issues/74527