### PR TITLE
Update keep-alive configs

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Fix an issue where relative worker paths provided to the `ExpressionCompilerService`
   would cause a crash. 
+- Fix an issue where the injected client connection could be lost while the application
+  is paused.
+- Support keep-alive for debug service connections.
 
 ## 8.0.3
 

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -406,7 +406,11 @@ class DevHandler {
       if (!_sseHandlers.containsKey(uri.path)) {
         // TODO(dantup): WS is not currently supported for injected client.
         var handler = SseSocketHandler(
-            SseHandler(uri, keepAlive: const Duration(seconds: 30)));
+            // We provide an essentially indefinite keep alive duration because
+            // the underlying connection could be lost while the application
+            // is paused. The connection will get re-established after a resume
+            // or cleaned up on a full page refresh.
+            SseHandler(uri, keepAlive: const Duration(days: 3000)));
         _sseHandlers[uri.path] = handler;
         var injectedConnections = handler.connections;
         while (await injectedConnections.hasNext) {

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -229,7 +229,8 @@ class DebugService {
     Handler handler;
     // DDS will always connect to DWDS via web sockets.
     if (useSse && !spawnDds) {
-      var sseHandler = SseHandler(Uri.parse('/$authToken/\$debugHandler'));
+      var sseHandler = SseHandler(Uri.parse('/$authToken/\$debugHandler'),
+          keepAlive: const Duration(seconds: 30));
       handler = sseHandler.handler;
       unawaited(_handleSseConnections(
           sseHandler, chromeProxyService, serviceExtensionRegistry,


### PR DESCRIPTION
Our internal infrastructure actively kills long standing connections after a set period of time. We work around this issue by providing keep-alive configs to `package:sse`. However, our configuration was either missing or invalid for certain situations. See included comment for further details.