### PR TITLE
Update keepAlive configs

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Add `DwdsEvent`s around stepping and evaluation.
 - Send an event to the Dart Debug Extension that contains VM service protocol URI. 
 - Depend on `package:vm_service` version `6.1.0+1`.
+- Update the `keepAlive` configs to prevent accidental reuse of a connection after stopping
+  a debug session.
 
 **Breaking changes:**
 - `LoadStrategy`s now require a `moduleInfoForEntrypoint`.

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -119,7 +119,7 @@ class Dwds {
     if (enableDebugExtension) {
       final handler = useSseForDebugBackend
           ? SseSocketHandler(SseHandler(Uri.parse('/\$debug'),
-              keepAlive: const Duration(seconds: 30)))
+              keepAlive: const Duration(seconds: 2)))
           : WebSocketSocketHandler();
 
       extensionBackend = await ExtensionBackend.start(handler, hostname);

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -119,6 +119,10 @@ class Dwds {
     if (enableDebugExtension) {
       final handler = useSseForDebugBackend
           ? SseSocketHandler(SseHandler(Uri.parse('/\$debug'),
+              // Proxy servers may actively kill long standing connections.
+              // Allow for clients to reconnect in a short window. Making the
+              // window too long may cause issues if the user closes a debug
+              // session and initites a new one during the keepAlive window.
               keepAlive: const Duration(seconds: 2)))
           : WebSocketSocketHandler();
 

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -230,7 +230,7 @@ class DebugService {
     // DDS will always connect to DWDS via web sockets.
     if (useSse && !spawnDds) {
       var sseHandler = SseHandler(Uri.parse('/$authToken/\$debugHandler'),
-          keepAlive: const Duration(seconds: 30));
+          keepAlive: const Duration(seconds: 2));
       handler = sseHandler.handler;
       unawaited(_handleSseConnections(
           sseHandler, chromeProxyService, serviceExtensionRegistry,


### PR DESCRIPTION
We use `keepAlive` with `package:sse` as our internal proxy servers will actively kill connections after a set period of time. Keeping the `keepAlive` timeout too long causes issues if a user closes a debug session and tries to start a new one in the `keepAlive` window. Ideally, the Dart Debug Extension would send a close event. Or alternatively an implicit close event is sent as a part of the `package:sse` protocol.