### PR TITLE
Extend keepAlive

### DIFF
--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -128,7 +128,7 @@ class Dwds {
               // Allow for clients to reconnect in a short window. Making the
               // window too long may cause issues if the user closes a debug
               // session and initites a new one during the keepAlive window.
-              keepAlive: const Duration(seconds: 2)))
+              keepAlive: const Duration(seconds: 5)))
           : WebSocketSocketHandler();
 
       extensionBackend = await ExtensionBackend.start(handler, hostname);

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -232,7 +232,7 @@ class DebugService {
     // DDS will always connect to DWDS via web sockets.
     if (useSse && !spawnDds) {
       var sseHandler = SseHandler(Uri.parse('/$authToken/\$debugHandler'),
-          keepAlive: const Duration(seconds: 2));
+          keepAlive: const Duration(seconds: 5));
       handler = sseHandler.handler;
       unawaited(_handleSseConnections(
           sseHandler, chromeProxyService, serviceExtensionRegistry,


### PR DESCRIPTION
Reducing the `keepAlive` causes the connection to be flaky internally. Extend the timer to prevent flakiness knowing that relaunching in the 5 second window could cause issue. This gives more reason to implement https://github.com/dart-lang/sse/issues/44