### PR TITLE
Add a redirect handler to the debug extension backend

### DIFF
--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -18,6 +18,7 @@ import 'src/connections/debug_connection.dart';
 import 'src/events.dart';
 import 'src/handlers/dev_handler.dart';
 import 'src/handlers/injector.dart';
+import 'src/handlers/redirector.dart';
 import 'src/handlers/socket_connections.dart';
 import 'src/loaders/strategy.dart';
 import 'src/readers/asset_reader.dart';
@@ -131,7 +132,8 @@ class Dwds {
               keepAlive: const Duration(seconds: 5)))
           : WebSocketSocketHandler();
 
-      extensionBackend = await ExtensionBackend.start(handler, hostname);
+      extensionBackend = await ExtensionBackend.start(handler, hostname,
+          redirectHandler: redirectHandler);
       extensionUri = Uri(
               scheme: useSseForDebugBackend ? 'http' : 'ws',
               host: extensionBackend.hostname,

--- a/dwds/lib/src/handlers/redirector.dart
+++ b/dwds/lib/src/handlers/redirector.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart = 2.9
+
+import 'dart:async';
+
+import 'package:shelf/shelf.dart';
+
+FutureOr<Response> redirectHandler(Request request) {
+  // VS Code's URI class incorrectly encodes values in URLs so we need
+  // to handle values that are over-encoded, such as:
+  // http://127.0.0.1:50308/%24redir?url%3Dhttp%253A%252F%252Flocalhost%253A50306
+
+  final isRedirectRequest =
+      request.url.path == r'$redir' || request.url.path == r'%24redir';
+
+  if (isRedirectRequest && request.url.queryParameters.containsKey('url')) {
+    final potentiallyEncodedUrl = request.url.queryParameters['url'];
+    final url = Uri.decodeQueryComponent(potentiallyEncodedUrl);
+    return Response.found(url);
+  }
+  return null;
+}


### PR DESCRIPTION
@grouma I don't know if we'd want to land this with #1277 on the way, but it's what I have so far (and seems to work great - with one niggle of having to select your account twice if you're logged in with multiple accounts, since both domains will trigger the selection - although I think that's an uncommon edge case or at least undestandable).

It was slightly messier than I hoped, as VS Code has [a never-fixable bug](https://github.com/microsoft/vscode/issues/83645) with URI encoding that means the querystring comes through over-encoded. There's unfortunately no workaround as to work in cloud IDEs we _must_ use the VS Code "open browser tab" API, and it only accepts a VS Code `Uri` (which has the bug).

The advantage this has over #1277 is that (if you don't hit the account selector) it's a little more seamless and requires no input from the user (we can do the redirect before ever hitting the app, because we're connecting the debugger right at the start, as we need to do unpause it).
