### PR TITLE
Fix disappearing current directory during isolate creation

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -203,9 +203,10 @@ class ChromeProxyService implements VmServiceInterface {
     // Waiting for the debugger to be ready before initializing the entrypoint.
     //
     // Note: moving `await _debugger` after the `_initalizeEntryPoint` call
-    // causes `getcwd` system calls  to fail. Since that system call is used
-    // in first `Uri.base` call in the isolate, the expression compiler service
-    // will fail to start and load dependencies.
+    // causes `getcwd` system calls to fail. Since that system call is used
+    // in first `Uri.base` call in the expression compiler service isolate,
+    // the expression compiler service will fail to start.
+    // Issue: https://github.com/dart-lang/webdev/issues/1282
     var debugger = await _debugger;
     await _initializeEntrypoint(appConnection.request.entrypointPath);
 


### PR DESCRIPTION
We encounter an intermittent failure to start expression compiler that manifests as failing `getcwd` system call.

Waiting for the debugger to be ready before initializing the entrypoint fixes the problem - looks like there is a race condition between expression compiler isolate calling `getcwd` (in `Uri.base()` and other calls) and `runZoneGuarded` (in `debugger._initialize()`) somehow setting or loosing it for the current process and therefore the isolate as well.

This PR unblocks expression evaluation work. 
Created an issue to follow up more thoroughly: https://github.com/dart-lang/webdev/issues/1282