### PR TITLE
Fix default rootlib

### DIFF
--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -29,9 +29,11 @@ class LibraryHelper extends Domain {
     // TODO: read entrypoint from app metadata.
     // Issue: https://github.com/dart-lang/webdev/issues/1290
     var libraries = await libraryRefs;
-    _rootLib = libraries.firstWhere((lib) => lib.name.contains('org-dartlang'));
-    _rootLib =
-        _rootLib ?? libraries.firstWhere((lib) => lib.name.contains('main'));
+    _rootLib = libraries.firstWhere((lib) => lib.name.contains('org-dartlang'),
+        orElse: () => null);
+    _rootLib = _rootLib ??
+        libraries.firstWhere((lib) => lib.name.contains('main'),
+            orElse: () => null);
     _rootLib = _rootLib ?? (libraries.isNotEmpty ? libraries.last : null);
     return _rootLib;
   }


### PR DESCRIPTION
Without `orElse`, `firstWhere` throws. We handle `null` appropriately. 