### PR TITLE
Initialize new isolate after restart

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fix not working breakpoints in library part files.
 - Fix data race in calculating locations for a module.
 - Fix uninitialized isolate after hot restart.
+- Fix intermittent failure caused by evaluation not waiting for dependencies
+  to be updated.
 
 ## 10.0.1
 

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix incorrect `rootLib` returned by `ChromeProxyService`.
 - Fix not working breakpoints in library part files.
 - Fix data race in calculating locations for a module.
+- Fix uninitialized isolate after hot restart.
 
 ## 10.0.1
 

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -90,7 +90,7 @@ void main() {
 
   group('Injected client', () {
     setUp(() async {
-      await context.setUp();
+      await context.setUp(enableExpressionEvaluation: true);
     });
 
     tearDown(() async {
@@ -204,13 +204,66 @@ void main() {
       expect(source.contains('Hello World!'), isTrue);
       expect(source.contains('Gary is awesome!'), isTrue);
 
-      // Should not be paused.
       vm = await client.getVM();
       isolateId = vm.isolates.first.id;
       var isolate = await client.getIsolate(isolateId);
-      expect(isolate.pauseEvent.kind, EventKind.kResume);
+
       // Previous breakpoint should still exist.
       expect(isolate.breakpoints.isNotEmpty, isTrue);
+      var bp = isolate.breakpoints.first;
+
+      // Should pause eventually.
+      await stream
+          .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
+
+      expect(await client.removeBreakpoint(isolate.id, bp.id), isA<Success>());
+      expect(await client.resume(isolate.id), isA<Success>());
+    });
+
+    test('can evaluate expressions after hot restart ', () async {
+      var client = context.debugConnection.vmService;
+      var vm = await client.getVM();
+      var isolateId = vm.isolates.first.id;
+      await client.streamListen('Debug');
+      var stream = client.onEvent('Debug');
+      var scriptList = await client.getScripts(isolateId);
+      var main = scriptList.scripts
+          .firstWhere((script) => script.uri.contains('main.dart'));
+      var bpLine =
+          await context.findBreakpointLine('printCount', isolateId, main);
+      await client.addBreakpoint(isolateId, main.id, bpLine);
+      await stream
+          .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
+
+      await client.callServiceExtension('hotRestart');
+
+      vm = await client.getVM();
+      isolateId = vm.isolates.first.id;
+      var isolate = await client.getIsolate(isolateId);
+      var library = isolate.rootLib.uri;
+      var bp = isolate.breakpoints.first;
+
+      // Should pause eventually.
+      var event = await stream
+          .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
+
+      // Expression evaluation while paused on a breakpoint should work.
+      var result = await client.evaluateInFrame(
+          isolate.id, event.topFrame.index, 'count');
+      expect(
+          result,
+          isA<InstanceRef>().having((instance) => instance.valueAsString,
+              'valueAsString', greaterThanOrEqualTo('0')));
+
+      await client.removeBreakpoint(isolateId, bp.id);
+      await client.resume(isolateId);
+
+      // Expression evaluation while running should work.
+      result = await client.evaluate(isolateId, library, 'true');
+      expect(
+          result,
+          isA<InstanceRef>().having(
+              (instance) => instance.valueAsString, 'valueAsString', 'true'));
     });
   });
 


### PR DESCRIPTION
Dart devtools sometimes gets erroneous isolate information from dwds in the middle of hot restart,
for example, `getIsolate` does not wait for initializations of the new isolate after restart and returns 
an isolate with null ID.

This seems to cause various issues after hot restart, including exceptions in debug console, non-working
layout explorer, and disabled breakpoints in the UI. While this PR does not solve all of them yet, it makes
sure that the new isolate is initialized before VM replies to the clients after hot restart:

- reset initialization completer on `destroyIsolate`.
- make all supported VM API wait for isolate initialization before proceeding.
- add expression evaluation tests after hot restart.

Towards: https://github.com/flutter/flutter/issues/74903
Closes: https://github.com/dart-lang/webdev/issues/1304