### PR TITLE
Display inherited fields

### DIFF
--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -288,7 +288,6 @@ class InstanceHelper extends Domain {
     //
     // For maps and lists it's more complicated. Treat the actual SDK versions
     // of these as special.
-    // TODO(alanknight): Handle superclass fields.
     final fieldNameExpression = '''function() {
       const sdk = ${globalLoadStrategy.loadModuleSnippet}("dart_sdk");
       const sdk_utils = sdk.dart;
@@ -302,7 +301,9 @@ class InstanceHelper extends Domain {
       const privateFields = sdk_utils.getOwnPropertySymbols(fields);
       const nonSymbolNames = privateFields.map(sym => sym.description);
       const publicFieldNames = sdk_utils.getOwnPropertyNames(fields);
-      return nonSymbolNames.concat(publicFieldNames).join(',');
+      const symbolNames =  Object.getOwnPropertySymbols(this)
+                            .map(sym => sym.description.split('.').slice(-1)[0]);
+      return nonSymbolNames.concat(publicFieldNames).concat(symbolNames).join(',');
     }
     ''';
     var allNames = (await inspector

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -84,6 +84,7 @@ void main() {
         properties.map((p) => p.name).where((x) => x != '__proto__').toList();
     var expected = [
       '_privateField',
+      'abstractField',
       'closure',
       'count',
       'message',

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -141,6 +141,7 @@ void main() {
           instance.fields.map((boundField) => boundField.decl.name).toList();
       expect(fieldNames, [
         '_privateField',
+        'abstractField',
         'closure',
         'count',
         'message',

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// An example with more complicated scope
-
 import 'dart:async';
 import 'dart:collection';
 
@@ -75,7 +74,11 @@ String libraryFunction(String arg) {
   return concat;
 }
 
-class MyTestClass<T> {
+abstract class MyAbstractClass {
+  String abstractField = 'abstract-field-value';
+}
+
+class MyTestClass<T> extends MyAbstractClass {
   final String message;
 
   String notFinal;


### PR DESCRIPTION
Related to https://github.com/dart-lang/sdk/issues/45387

The JS object has inherited fields represented as `Symbol`s. Do a best effort collection of these fields.