### PR TITLE
Do not send service registration events on terminating isolate during hot restart

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 11.0.1-dev
+
+- Do not send `kServiceExtensionAdded` events to subscribers
+  on the terminating isolate during hot restart.
+
 ## 11.0.0-dev
 
 - Support `vm_service` version `6.2.0`.
@@ -6,10 +11,8 @@
 - Fix not working breakpoints in library part files.
 - Fix data race in calculating locations for a module.
 - Fix uninitialized isolate after hot restart.
-- Fix intermittent failure caused by evaluation not waiting
-  for dependencies to be updated.
-- Do not send `kServiceExtensionAdded` events to subscribers
-  on the terminating isolate during hot restart.
+- Fix intermittent failure caused by evaluation not waiting for dependencies
+  to be updated.
 
 **Breaking changes:**
 - `Dwds.start` no longer supports automatically injecting a devtools server. A `devtoolsLauncher`

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -6,8 +6,10 @@
 - Fix not working breakpoints in library part files.
 - Fix data race in calculating locations for a module.
 - Fix uninitialized isolate after hot restart.
-- Fix intermittent failure caused by evaluation not waiting for dependencies
-  to be updated.
+- Fix intermittent failure caused by evaluation not waiting
+  for dependencies to be updated.
+- Do not send `kServiceExtensionAdded` events to subscribers
+  on the terminating isolate during hot restart.
 
 **Breaking changes:**
 - `Dwds.start` no longer supports automatically injecting a devtools server. A `devtoolsLauncher`

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -51,6 +51,7 @@ class MetadataProvider {
         'dart:async',
         'dart:collection',
         'dart:convert',
+        'dart:core',
         'dart:developer',
         'dart:io',
         'dart:isolate',

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -60,6 +60,8 @@ class DwdsVmClient {
 
     client.registerServiceCallback('hotRestart', (request) async {
       _logger.info('Attempting a hot restart');
+
+      chromeProxyService.terminatingIsolates = true;
       await _disableBreakpointsAndResume(client, chromeProxyService);
       int context;
       try {
@@ -105,6 +107,8 @@ class DwdsVmClient {
 
       _logger.info('Waiting for Isolate Start event.');
       await stream.firstWhere((event) => event.kind == EventKind.kIsolateStart);
+      chromeProxyService.terminatingIsolates = false;
+
       _logger.info('Successful hot restart');
       return {'result': Success().toJson()};
     });

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -96,6 +96,8 @@ class ChromeProxyService implements VmServiceInterface {
   final ExpressionCompiler _compiler;
   ExpressionEvaluator _expressionEvaluator;
 
+  bool terminatingIsolates = false;
+
   ChromeProxyService._(
     this._vm,
     this.uri,
@@ -834,10 +836,12 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   void _setUpChromeConsoleListeners(IsolateRef isolateRef) {
     _consoleSubscription =
         remoteDebugger.onConsoleAPICalled.listen((event) async {
+      if (terminatingIsolates) return;
       if (event.type != 'debug') return;
 
       var isolate = _inspector?.isolate;
       if (isolate == null) return;
+      if (isolateRef.id != isolate.id) return;
 
       var firstArgValue = event.args[0].value as String;
       switch (firstArgValue) {

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '11.0.0-dev';
+const packageVersion = '11.0.1-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 11.0.0-dev
+version: 11.0.1-dev
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM


### PR DESCRIPTION
This fixes failures observed in VSCode during hot restart while paused. 

- Let VM proxy server know hen isolate is about to be terminated for hot restart.
- Make VM proxy not send service registration events for the terminating isolate.
- Fix errors showing classes from dart:core library.

Towards: https://github.com/flutter/flutter/issues/74903