### PR TITLE
allow the latest build_runner, build_web_compilers, and build_daemon

### DIFF
--- a/fixtures/_test/pubspec.yaml
+++ b/fixtures/_test/pubspec.yaml
@@ -12,5 +12,5 @@ dependencies:
   path: ^1.6.1
 
 dev_dependencies:
-  build_runner: ^1.6.7
-  build_web_compilers: ^2.12.0
+  build_runner: ^2.0.0
+  build_web_compilers: ^3.0.0

--- a/fixtures/_testPackage/pubspec.yaml
+++ b/fixtures/_testPackage/pubspec.yaml
@@ -12,5 +12,5 @@ dependencies:
     path: ../_test
 
 dev_dependencies:
-  build_runner: ^1.0.0
-  build_web_compilers: ^2.12.0
+  build_runner: ^2.0.0
+  build_web_compilers: ^3.0.0

--- a/fixtures/_testPackageSound/pubspec.yaml
+++ b/fixtures/_testPackageSound/pubspec.yaml
@@ -12,5 +12,5 @@ dependencies:
     path: ../_testSound
 
 dev_dependencies:
-  build_runner: ^1.0.0
-  build_web_compilers: ^2.12.0
+  build_runner: ^2.0.0
+  build_web_compilers: ^3.0.0

--- a/fixtures/_testSound/pubspec.yaml
+++ b/fixtures/_testSound/pubspec.yaml
@@ -12,5 +12,5 @@ dependencies:
   path: ^1.6.1
 
 dev_dependencies:
-  build_runner: ^1.6.7
-  build_web_compilers: ^2.12.0
+  build_runner: ^2
+  build_web_compilers: ^3.0.0

--- a/fixtures/_webdevSmoke/pubspec.yaml
+++ b/fixtures/_webdevSmoke/pubspec.yaml
@@ -10,5 +10,5 @@ environment:
   sdk: '>=2.13.0-144.0.dev <3.0.0'
 
 dev_dependencies:
-  build_runner: '>=1.6.2 <2.0.0'
-  build_web_compilers: '>=2.12.0 <3.0.0'
+  build_runner: '>=1.6.2 <3.0.0'
+  build_web_compilers: '>=2.12.0 <4.0.0'

--- a/fixtures/_webdevSoundSmoke/pubspec.yaml
+++ b/fixtures/_webdevSoundSmoke/pubspec.yaml
@@ -5,6 +5,6 @@ environment:
   sdk: '>=2.12.0-259.0.dev <3.0.0'
 
 dev_dependencies:
-  build_runner: '>=1.6.2 <2.0.0'
-  build_web_compilers: '>=2.12.0 <3.0.0'
+  build_runner: '>=1.6.2 <3.0.0'
+  build_web_compilers: '>=2.12.0 <4.0.0'
 

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7.4
+
+- Allow the latest build_runner, build_web_compilers, and build_daemon
+  packages.
+
 ## 2.7.3
 
 - Depend on the latest `package:dwds`.

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -127,7 +127,7 @@ class PubspecLock {
 
 Future<List<PackageExceptionDetails>> _validateBuildDaemonVersion(
     PubspecLock pubspecLock) async {
-  var buildDaemonConstraint = '>=2.0.0 <3.0.0';
+  var buildDaemonConstraint = '>=2.0.0 <4.0.0';
 
   var issues = <PackageExceptionDetails>[];
 
@@ -162,8 +162,8 @@ Future<List<PackageExceptionDetails>> _validateBuildDaemonVersion(
   return issues;
 }
 
-final buildRunnerConstraint = VersionConstraint.parse('>=1.6.2 <2.0.0');
-final buildWebCompilersContraint = VersionConstraint.parse('>=2.12.0 <3.0.0');
+final buildRunnerConstraint = VersionConstraint.parse('>=1.6.2 <3.0.0');
+final buildWebCompilersContraint = VersionConstraint.parse('>=2.12.0 <4.0.0');
 
 // Note the minimum versions should never be dev versions as users will not
 // get them by default.

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.7.3';
+const packageVersion = '2.7.4';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `pub run build_runner build`.
-version: 2.7.3
+version: 2.7.4
 # We should not depend on a dev SDK before publishing.
 # publish_to: none
 homepage: https://github.com/dart-lang/webdev
@@ -14,14 +14,14 @@ environment:
 dependencies:
   args: ^2.0.0
   async: ^2.2.0
-  build_daemon: ^2.0.0
+  build_daemon: '>=2.0.0 <4.0.0'
   browser_launcher: ^0.1.5
   crypto: ^3.0.0
   dds: ^1.4.1
   dwds: ^11.0.0
   http: ^0.13.0
   http_multi_server: ^3.0.0
-  io: ^0.3.2+1
+  io: '>=0.3.2+1 <2.0.0'
   logging: ^1.0.0
   pedantic: ^1.5.0
   meta: ^1.1.2
@@ -42,7 +42,7 @@ dependencies:
 
 dev_dependencies:
   build: ^2.0.0
-  build_runner: ^1.6.2
+  build_runner: ^2.0.0
   build_verify: ^1.0.0
   build_version: ^2.0.0
   test: ^1.15.0

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -14,14 +14,14 @@ environment:
 dependencies:
   args: ^2.0.0
   async: ^2.2.0
-  build_daemon: '>=2.0.0 <4.0.0'
+  build_daemon: ^2.0.0
   browser_launcher: ^0.1.5
   crypto: ^3.0.0
   dds: ^1.4.1
   dwds: ^11.0.0
   http: ^0.13.0
   http_multi_server: ^3.0.0
-  io: '>=0.3.2+1 <2.0.0'
+  io: ^0.3.2+1
   logging: ^1.0.0
   pedantic: ^1.5.0
   meta: ^1.1.2
@@ -42,7 +42,7 @@ dependencies:
 
 dev_dependencies:
   build: ^2.0.0
-  build_runner: ^2.0.0
+  build_runner: ^1.6.2
   build_verify: ^1.0.0
   build_version: ^2.0.0
   test: ^1.15.0

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -59,9 +59,9 @@ name: sample
   });
 
   var invalidRanges = <String, List<String>>{
-    'build_runner': ['0.8.9', '2.0.0'],
-    'build_web_compilers': ['0.3.5', '3.0.0'],
-    'build_daemon': ['0.3.0', '0.4.1'],
+    'build_runner': ['0.8.9', '3.0.0'],
+    'build_web_compilers': ['0.3.5', '4.0.0'],
+    'build_daemon': ['0.3.0', '4.0.0'],
   };
 
   for (var command in ['build', 'serve', 'daemon']) {
@@ -152,15 +152,15 @@ name: sample
               switch (entry.key) {
                 case 'build_runner':
                   buildRunnerVersion = version;
-                  supportedRange = '>=$_supportedBuildRunnerVersion <2.0.0';
+                  supportedRange = '>=$_supportedBuildRunnerVersion <3.0.0';
                   break;
                 case 'build_web_compilers':
                   webCompilersVersion = version;
-                  supportedRange = '>=$_supportedWebCompilersVersion <3.0.0';
+                  supportedRange = '>=$_supportedWebCompilersVersion <4.0.0';
                   break;
                 case 'build_daemon':
                   buildDaemonVersion = version;
-                  supportedRange = '^0.4.0';
+                  supportedRange = '>=$_supportedBuildDaemonVersion <4.0.0';
               }
 
               await d.file('pubspec.yaml', '''


### PR DESCRIPTION
I expanded a couple other ranges in the package itself as well in an effort to start getting the example working on the latest build_runner, but this is ultimately blocked on dwds changes.