### PR TITLE
Show inherited methods in Class object

### DIFF
--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -92,8 +92,8 @@ class ClassHelper extends Domain {
           'dartName': sdkUtils.typeName(clazz)
         };
 
-      // TODO(grouma) - we display all inherited methods. Ideally this
-      // information is collected through the DDC metadata files.
+      // TODO(grouma) - we display all inherited methods since we don't provide
+      // the superClass information. This is technically not correct.
       var proto = clazz.prototype;
       var methodNames = [];
       for (; proto != null; proto = Object.getPrototypeOf(proto)) {

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -98,7 +98,7 @@ class ClassHelper extends Domain {
       var methodNames = [];
       for (; proto != null; proto = Object.getPrototypeOf(proto)) {
         var methods = Object.getOwnPropertyNames(proto);
-        for (var i=0; i<methods.length; i++){
+        for (var i = 0; i < methods.length; i++){
           if (methodNames.indexOf(methods[i]) == -1
               && typeof proto[methods[i]] == 'function'
               && methods[i] != 'constructor'){

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -98,14 +98,14 @@ class ClassHelper extends Domain {
       var methodNames = [];
       for (; proto != null; proto = Object.getPrototypeOf(proto)) {
         var methods = Object.getOwnPropertyNames(proto);
-        for (var i = 0; i < methods.length; i++){
+        for (var i = 0; i < methods.length; i++) {
           if (methodNames.indexOf(methods[i]) == -1
               && typeof proto[methods[i]] == 'function'
-              && methods[i] != 'constructor'){
+              && methods[i] != 'constructor') {
               methodNames.push(methods[i]);
           }
         }
-        if(proto.constructor.name == 'Object') break;
+        if (proto.constructor.name == 'Object') break;
       }
 
       descriptor['methods'] = {};

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -91,12 +91,25 @@ class ClassHelper extends Domain {
           'name': clazz.name,
           'dartName': sdkUtils.typeName(clazz)
         };
-      // TODO(jakemac): static methods once ddc supports them
-      var methods = sdkUtils.getMethods(clazz);
-      var methodNames = methods ? Object.keys(methods) : [];
+
+      // TODO(grouma) - we display all inherited methods. Ideally this
+      // information is collected through the DDC metadata files.
+      var proto = clazz.prototype;
+      var methodNames = [];
+      for (; proto != null; proto = Object.getPrototypeOf(proto)) {
+        var methods = Object.getOwnPropertyNames(proto);
+        for (var i=0; i<methods.length; i++){
+          if (methodNames.indexOf(methods[i]) == -1
+              && typeof proto[methods[i]] == 'function'
+              && methods[i] != 'constructor'){
+              methodNames.push(methods[i]);
+          }
+        }
+        if(proto.constructor.name == 'Object') break;
+      }
+
       descriptor['methods'] = {};
       for (var name of methodNames) {
-        var method = methods[name];
         descriptor['methods'][name] = {
           // TODO(jakemac): how can we get actual const info?
           "isConst": false,

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -412,6 +412,9 @@ void main() {
             testClass.functions,
             unorderedEquals([
               predicate((FuncRef f) => f.name == 'hello' && !f.isStatic),
+              predicate((FuncRef f) => f.name == '_equals' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'toString' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic),
             ]));
         expect(
             testClass.fields,


### PR DESCRIPTION
The Class object technically should not show inherited methods. However, since we do not provide a reference to the superClass it's impossible to get this information. For now, return all inherited methods until we have the correct information in the DDC metadata files.