### PR TITLE
Hide variables with names that start with '__t$'

### DIFF
--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -11,7 +11,7 @@ import 'debugger.dart';
 
 // TODO(sdk/issues/44262) - use an alternative way to identify synthetic
 // variables.
-final ddcTemporaryVariableRegExp = RegExp(r'^t([0-9])+(\$)?([0-9])*$');
+final ddcTemporaryVariableRegExp = RegExp(r'^(t[0-9]+\$?[0-9]*|__t\$\w*)$');
 
 /// Find the visible Dart properties from a JS Scope Chain, coming from the
 /// scopeChain attribute of a Chrome CallFrame corresponding to [frame].

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -37,6 +37,8 @@ void main() {
       expect(ddcTemporaryVariableRegExp.hasMatch(r't4$0'), isTrue);
       expect(ddcTemporaryVariableRegExp.hasMatch(r't1'), isTrue);
       expect(ddcTemporaryVariableRegExp.hasMatch(r't10'), isTrue);
+      expect(ddcTemporaryVariableRegExp.hasMatch(r'__t$TL'), isTrue);
+      expect(ddcTemporaryVariableRegExp.hasMatch(r'__t$StringN'), isTrue);
 
       expect(ddcTemporaryVariableRegExp.hasMatch(r't'), isFalse);
       expect(ddcTemporaryVariableRegExp.hasMatch(r't10foo'), isFalse);


### PR DESCRIPTION
These are variables introduced by the compiler and should not be
visible in debug tools.

This is building on a temporary fix that will be removed when we
switch to metadata based solution for knowing what variables should
be visible.