### PR TITLE
Fix error with getObject on a ClassRef

### DIFF
--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -100,7 +100,6 @@ class ClassHelper extends Domain {
         var methods = Object.getOwnPropertyNames(proto);
         for (var i = 0; i < methods.length; i++) {
           if (methodNames.indexOf(methods[i]) == -1
-              && typeof Object.getOwnPropertyDescriptor(proto,methods[i])['value'] == 'function'
               && methods[i] != 'constructor') {
               methodNames.push(methods[i]);
           }

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -100,7 +100,7 @@ class ClassHelper extends Domain {
         var methods = Object.getOwnPropertyNames(proto);
         for (var i = 0; i < methods.length; i++) {
           if (methodNames.indexOf(methods[i]) == -1
-              && typeof proto[methods[i]] == 'function'
+              && typeof Object.getOwnPropertyDescriptor(proto,methods[i])['value'] == 'function'
               && methods[i] != 'constructor') {
               methodNames.push(methods[i]);
           }

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -407,14 +407,17 @@ void main() {
       test('Classes', () async {
         var testClass = await service.getObject(
             isolate.id, rootLibrary.classes.first.id) as Class;
-
         expect(
             testClass.functions,
             unorderedEquals([
+              predicate((FuncRef f) => f.name == 'message' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic),
               predicate((FuncRef f) => f.name == 'hello' && !f.isStatic),
               predicate((FuncRef f) => f.name == '_equals' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'hashCode' && !f.isStatic),
               predicate((FuncRef f) => f.name == 'toString' && !f.isStatic),
               predicate((FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'runtimeType' && !f.isStatic),
             ]));
         expect(
             testClass.fields,


### PR DESCRIPTION
`Object.getOwnPropertyNames` returns setters, getters and functions. We don't need to filter this list besides the constructor. Before this change calling `proto[method[i]]` could cause a runtime issue as we were actually calling the getter or setter.