### PR TITLE
Log failures to load kernel during eval

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Return empty library from `ChromeProxyService.getObject` for
   libraries present in medatata but not lodaded at runtime.
+- Log failures to load kernel during expression evaluation.
 
 ## 11.1.1
 

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -317,7 +317,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
     var uri = request.requestedUri.queryParameters['uri'];
     try {
       var query = request.requestedUri.path;
-      _logger.finest('request: ${request.requestedUri}');
+      _logger.finest('request: ${request.method} ${request.requestedUri}');
 
       if (query != '/getResource' || uri == null) {
         return Response.notFound(uri);
@@ -335,7 +335,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
       _logger.finest('serverpath for $uri: $serverPath');
 
       request = Request(
-          'GET',
+          request.method,
           Uri(
             scheme: request.requestedUri.scheme,
             host: request.requestedUri.host,

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -313,7 +313,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
   /// or a server path for a full dill file.
   /// Translates given resource uri to a server path and redirects
   /// the request to the asset handler.
-  FutureOr<Response> handler(Request request) {
+  FutureOr<Response> handler(Request request) async {
     var uri = request.requestedUri.queryParameters['uri'];
     try {
       var query = request.requestedUri.path;
@@ -343,7 +343,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
             path: serverPath,
           ));
 
-      return _assetHandler(request);
+      return await _assetHandler(request);
     } catch (e, s) {
       _logger.severe('Error loading $uri: $e:$s');
       return Response.notFound(uri);

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -334,14 +334,35 @@ class ExpressionCompilerService implements ExpressionCompiler {
 
       _logger.finest('serverpath for $uri: $serverPath');
 
+      _logger.finest('Request for $uri:');
+      _logger.finest({
+        'handlerPath': request.handlerPath,
+        'method': request.method,
+        'protocolVersion': request.protocolVersion,
+        'requestedUri': request.requestedUri,
+        'url': request.url,
+        'contentLength': request.contentLength,
+        'context': request.context,
+        'encoding': request.encoding,
+        'headers': request.headers,
+        'isEmpty': request.isEmpty,
+        'mimeType': request.mimeType,
+      }.toString());
+
       request = Request(
-          request.method,
-          Uri(
-            scheme: request.requestedUri.scheme,
-            host: request.requestedUri.host,
-            port: request.requestedUri.port,
-            path: serverPath,
-          ));
+        request.method,
+        Uri(
+          scheme: request.requestedUri.scheme,
+          host: request.requestedUri.host,
+          port: request.requestedUri.port,
+          path: serverPath,
+        ),
+        protocolVersion: request.protocolVersion,
+        context: request.context,
+        headers: request.headers,
+        handlerPath: request.handlerPath,
+        encoding: request.encoding,
+      );
 
       return await _assetHandler(request);
     } catch (e, s) {

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -334,21 +334,6 @@ class ExpressionCompilerService implements ExpressionCompiler {
 
       _logger.finest('serverpath for $uri: $serverPath');
 
-      _logger.finest('Request for $uri:');
-      _logger.finest({
-        'handlerPath': request.handlerPath,
-        'method': request.method,
-        'protocolVersion': request.protocolVersion,
-        'requestedUri': request.requestedUri,
-        'url': request.url,
-        'contentLength': request.contentLength,
-        'context': request.context,
-        'encoding': request.encoding,
-        'headers': request.headers,
-        'isEmpty': request.isEmpty,
-        'mimeType': request.mimeType,
-      }.toString());
-
       request = Request(
         request.method,
         Uri(
@@ -367,7 +352,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
       return await _assetHandler(request);
     } catch (e, s) {
       _logger.severe('Error loading $uri: $e:$s');
-      return Response.notFound(uri);
+      rethrow;
     }
   }
 }

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -40,8 +40,14 @@ class TestSetup {
       fetchChromeProxyService(context.debugConnection);
   WipConnection get tabConnection => context.tabConnection;
 
+  /// Redirect the logs for the current zone to emit on failure.
+  ///
+  /// All messages are stored and reported on test failure.
+  /// Needs to be called in both setUpAll() and setUp() to store
+  /// the logs in the current zone.
+  ///
+  /// Note: change 'printOnFailure' to 'print' for debug printing.
   static void setCurrentLogWriter() {
-    // Note: change 'printOnFailure' to 'print' for debug printing
     configureLogWriter(
         customLogWriter: (level, message,
                 {loggerName, error, stackTrace, verbose}) =>

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -74,7 +74,7 @@ void main() async {
       group('shared context with evaluation', () {
         setUpAll(() async {
           TestSetup.setCurrentLogWriter();
-          await context.setUp(enableExpressionEvaluation: true, verbose: false);
+          await context.setUp(enableExpressionEvaluation: true, verbose: true);
         });
 
         tearDownAll(() async {

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -39,6 +39,14 @@ class TestSetup {
   ChromeProxyService get service =>
       fetchChromeProxyService(context.debugConnection);
   WipConnection get tabConnection => context.tabConnection;
+
+  static void setCurrentLogWriter() {
+    // Note: change 'printOnFailure' to 'print' for debug printing
+    configureLogWriter(
+        customLogWriter: (level, message,
+                {loggerName, error, stackTrace, verbose}) =>
+            printOnFailure('[$level] $loggerName: $message'));
+  }
 }
 
 void main() async {
@@ -65,17 +73,16 @@ void main() async {
 
       group('shared context with evaluation', () {
         setUpAll(() async {
-          // Note: change 'printOnFailure' to 'print' for debug printing
-          configureLogWriter(
-              customLogWriter: (level, message,
-                      {loggerName, error, stackTrace, verbose}) =>
-                  printOnFailure('[$level] $loggerName: $message'));
-
+          TestSetup.setCurrentLogWriter();
           await context.setUp(enableExpressionEvaluation: true, verbose: false);
         });
 
         tearDownAll(() async {
           await context.tearDown();
+        });
+
+        setUp(() async {
+          TestSetup.setCurrentLogWriter();
         });
 
         group('evaluateInFrame', () {
@@ -504,12 +511,17 @@ void main() async {
 
       group('shared context with no evaluation', () {
         setUpAll(() async {
+          TestSetup.setCurrentLogWriter();
           await context.setUp(
               enableExpressionEvaluation: false, verbose: false);
         });
 
         tearDownAll(() async {
           await context.tearDown();
+        });
+
+        setUp(() async {
+          TestSetup.setCurrentLogWriter();
         });
 
         group('evaluateInFrame', () {

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -65,7 +65,7 @@ void main() async {
 
       // setup asset server
       server = await HttpMultiServer.bind('localhost', port);
-      shelf_io.serveRequests(server, service.handler);
+      shelf_io.serveRequests(server, assetHandler);
 
       // generate full dill
       File.fromUri(source)

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -65,7 +65,8 @@ void main() async {
 
       // setup asset server
       server = await HttpMultiServer.bind('localhost', port);
-      shelf_io.serveRequests(server, assetHandler);
+      shelf_io.serveRequests(
+          server, Cascade().add(service.handler).add(assetHandler).handler);
 
       // generate full dill
       File.fromUri(source)

--- a/dwds/test/fixtures/logging.dart
+++ b/dwds/test/fixtures/logging.dart
@@ -33,7 +33,8 @@ StreamSubscription<LogRecord> _loggerSub;
 void configureLogWriter({LogWriter customLogWriter}) {
   _logWriter = customLogWriter ?? _logWriter;
   Logger.root.level = Level.ALL;
-  _loggerSub ??= Logger.root.onRecord.listen((event) {
+  _loggerSub?.cancel();
+  _loggerSub = Logger.root.onRecord.listen((event) {
     logWriter(event.level, event.message,
         error: '${event.error}',
         loggerName: event.loggerName,

--- a/dwds/test/fixtures/logging.dart
+++ b/dwds/test/fixtures/logging.dart
@@ -16,20 +16,37 @@ StreamSubscription<LogRecord> _loggerSub;
 
 /// Configure test log writer.
 ///
-/// Tests and groups of tests can use this to configure
-/// individual log writers on setup.
+/// Tests and groups of tests can use this to configure individual
+/// log writers on setup.
 ///
-/// For example, to verbose printing during debugging:
+/// Note that the logwriter needs to be set in both `setUpAll` and
+/// `setUp` to store messages for the same zone as the failure in
+/// order to report all stored messages on that failure.
+///
+/// For example, to enable verbose printing during debugging:
+///
+/// void setCurrentLogWriter() {
+///   // Note: change 'printOnFailure' to 'print' for debug printing.
+///   configureLogWriter(
+///        customLogWriter: (level, message,
+///                {loggerName, error, stackTrace, verbose}) =>
+///            printOnFailure('[$level] $loggerName: $message'));
+///  }
 ///
 /// group('shared context', () {
 ///     setUpAll(() async {
-///       configureLogWriter(
-///           customLogWriter: (level, message,
-///                   {loggerName, error, stackTrace, verbose}) =>
-///               print(message));
-///
+///       // Set the logger for the current group.
+///       setCurrentLogWriter();
 ///       await context.setUp();
 ///     });
+///
+///     setUp(() async {
+///       // Reset the logger for the current test.
+///       setCurrentLogWriter();
+///     });
+///
+///     ...
+/// });
 void configureLogWriter({LogWriter customLogWriter}) {
   _logWriter = customLogWriter ?? _logWriter;
   Logger.root.level = Level.ALL;

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -31,6 +31,14 @@ class TestSetup {
   ChromeProxyService get service =>
       fetchChromeProxyService(context.debugConnection);
   WipConnection get tabConnection => context.tabConnection;
+
+  static void setCurrentLogWriter() {
+    // Note: change 'printOnFailure' to 'print' for debug printing
+    configureLogWriter(
+        customLogWriter: (level, message,
+                {loggerName, error, stackTrace, verbose}) =>
+            printOnFailure('[$level] $loggerName: $message'));
+  }
 }
 
 void main() async {
@@ -56,12 +64,7 @@ void main() async {
 
   group('shared context with evaluation', () {
     setUpAll(() async {
-      // Note: change 'printOnFailure' to 'print' for debug printing
-      configureLogWriter(
-          customLogWriter: (level, message,
-                  {loggerName, error, stackTrace, verbose}) =>
-              printOnFailure('[$level] $loggerName: $message'));
-
+      TestSetup.setCurrentLogWriter();
       await context.setUp(
           enableExpressionEvaluation: true,
           compilationMode: CompilationMode.frontendServer,
@@ -70,6 +73,10 @@ void main() async {
 
     tearDownAll(() async {
       await context.tearDown();
+    });
+
+    setUp(() async {
+      TestSetup.setCurrentLogWriter();
     });
 
     group('evaluateInFrame', () {
@@ -462,6 +469,7 @@ void main() async {
 
   group('shared context with no evaluation', () {
     setUpAll(() async {
+      TestSetup.setCurrentLogWriter();
       await context.setUp(
           enableExpressionEvaluation: false,
           compilationMode: CompilationMode.frontendServer,
@@ -470,6 +478,10 @@ void main() async {
 
     tearDownAll(() async {
       await context.tearDown();
+    });
+
+    setUp(() async {
+      TestSetup.setCurrentLogWriter();
     });
 
     group('evaluateInFrame', () {

--- a/dwds/test/restore_breakpoints_test.dart
+++ b/dwds/test/restore_breakpoints_test.dart
@@ -5,6 +5,8 @@
 // @dart = 2.9
 
 @TestOn('vm')
+import 'dart:async';
+
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:test/test.dart';
@@ -98,5 +100,5 @@ void main() {
 
       expect(isolate.breakpoints.length, equals(1));
     });
-  });
+  }, timeout: const Timeout.factor(2));
 }

--- a/dwds/test/restore_breakpoints_test.dart
+++ b/dwds/test/restore_breakpoints_test.dart
@@ -75,7 +75,7 @@ void main() {
       isolate = await service.getIsolate(vm.isolates.first.id);
 
       expect(isolate.breakpoints.length, equals(1));
-    });
+    }, timeout: const Timeout.factor(2));
 
     test('restore after hot restart', () async {
       var firstBp = await service.addBreakpoint(isolate.id, mainScript.id, 23);
@@ -99,6 +99,6 @@ void main() {
       isolate = await service.getIsolate(vm.isolates.first.id);
 
       expect(isolate.breakpoints.length, equals(1));
-    });
-  }, timeout: const Timeout.factor(2));
+    }, timeout: const Timeout.factor(2));
+  });
 }


### PR DESCRIPTION
Recent flakes in CI show failures to compile expressions due to
a failure to load full kernel files. The logs are missing messages
preceding the failure. This change adds a message on kernel load
failure and makes sure the messages are printed when a test fails.

- Add reporting to load kernel in ExpressionCompilerService
- Reset logwriter for each test. Previously the messages from a
  failed test were lost because the group's logwriter was using
  the invoker for that group in printOnFailure.

Helps: https://github.com/dart-lang/webdev/issues/1345