### PR TITLE
Fix intermittent broken sockets on connection to asset server.

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -4,6 +4,7 @@
   libraries present in medatata but not lodaded at runtime.
 - Log failures to load kernel during expression evaluation.
 - Show lowered final fields using their original dart names.
+- Limit simultaneous connections to asset server to prevent broken sockets.
 
 ## 11.1.1
 

--- a/dwds/lib/src/readers/proxy_server_asset_reader.dart
+++ b/dwds/lib/src/readers/proxy_server_asset_reader.dart
@@ -29,10 +29,13 @@ class ProxyServerAssetReader implements AssetReader {
     root ??= '';
     isHttps ??= false;
     var scheme = isHttps ? 'https://' : 'http://';
+    var inner = HttpClient()
+      ..maxConnectionsPerHost = 200
+      ..idleTimeout = const Duration(seconds: 30)
+      ..connectionTimeout = const Duration(seconds: 30);
     _client = isHttps
-        ? IOClient(
-            HttpClient()..badCertificateCallback = (cert, host, port) => true)
-        : http.Client();
+        ? IOClient(inner..badCertificateCallback = (cert, host, port) => true)
+        : IOClient(inner);
     var url = '$scheme$host:$assetServerPort/';
     if (root?.isNotEmpty ?? false) url += '$root/';
     _handler = proxyHandler(url, client: _client);

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -80,7 +80,10 @@ void main() async {
       group('shared context with evaluation', () {
         setUpAll(() async {
           TestSetup.setCurrentLogWriter();
-          await context.setUp(enableExpressionEvaluation: true, verbose: true);
+          await context.setUp(
+            enableExpressionEvaluation: true,
+            verbose: false,
+          );
         });
 
         tearDownAll(() async {
@@ -519,7 +522,9 @@ void main() async {
         setUpAll(() async {
           TestSetup.setCurrentLogWriter();
           await context.setUp(
-              enableExpressionEvaluation: false, verbose: false);
+            enableExpressionEvaluation: false,
+            verbose: false,
+          );
         });
 
         tearDownAll(() async {

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -37,7 +37,7 @@ void main() {
           customLogWriter: (level, message,
                   {loggerName, error, stackTrace, verbose}) =>
               printOnFailure('[$level] $loggerName: $message'));
-      await context.setUp(verbose: true);
+      await context.setUp(verbose: false);
     });
 
     tearDownAll(() async {

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -55,15 +55,6 @@ void main() {
     await context.webDriver.driver.keyboard.sendChord([Keyboard.alt, 'd']);
   });
 
-  test('emits COMPILER_UPDATE_DEPENDENCIES event', () async {
-    // The events stream is a broadcast stream so start listening before the
-    // action.
-    expect(
-        context.testServer.dwds.events,
-        emits(predicate((DwdsEvent event) =>
-            event.type == 'COMPILER_UPDATE_DEPENDENCIES')));
-  });
-
   test('events can be listened to multiple times', () async {
     context.testServer.dwds.events.listen((_) {});
     context.testServer.dwds.events.listen((_) {});
@@ -102,7 +93,7 @@ void main() {
       var expression = "helloString('world')";
       expect(
           context.testServer.dwds.events,
-          emits(predicate((DwdsEvent event) =>
+          emitsThrough(predicate((DwdsEvent event) =>
               event.type == 'EVALUATE' &&
               event.payload['expression'] == expression)));
       await service.evaluate(
@@ -116,7 +107,7 @@ void main() {
       var expression = 'some-bad-expression';
       expect(
           context.testServer.dwds.events,
-          emits(predicate((DwdsEvent event) =>
+          emitsThrough(predicate((DwdsEvent event) =>
               event.type == 'EVALUATE' &&
               event.payload['expression'] == expression &&
               event.payload['exception'] is ErrorRef)));
@@ -153,7 +144,7 @@ void main() {
     test('emits EVALUATE_IN_FRAME events on RPC error', () async {
       expect(
           context.testServer.dwds.events,
-          emits(predicate((DwdsEvent event) =>
+          emitsThrough(predicate((DwdsEvent event) =>
               event.type == 'EVALUATE_IN_FRAME' &&
               event.payload['success'] == false &&
               event.payload['exception'] is RPCError &&
@@ -181,7 +172,7 @@ void main() {
       // so event is marked as success.
       expect(
           context.testServer.dwds.events,
-          emits(predicate((DwdsEvent event) =>
+          emitsThrough(predicate((DwdsEvent event) =>
               event.type == 'EVALUATE_IN_FRAME' &&
               event.payload['success'] == false &&
               event.payload['exception'] is ErrorRef)));
@@ -210,7 +201,7 @@ void main() {
       // so event is marked as success.
       expect(
           context.testServer.dwds.events,
-          emits(predicate((DwdsEvent event) =>
+          emitsThrough(predicate((DwdsEvent event) =>
               event.type == 'EVALUATE_IN_FRAME' &&
               event.payload['success'] == true)));
       try {

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -149,10 +149,22 @@ class TestContext {
             ['--port=$chromeDriverPort', '--url-base=$chromeDriverUrlBase']);
         // On windows this takes a while to boot up, wait for the first line
         // of stdout as a signal that it is ready.
-        await chromeDriver.stdout
+        final stdOutLines = chromeDriver.stdout
             .transform(utf8.decoder)
             .transform(const LineSplitter())
-            .first;
+            .asBroadcastStream();
+
+        final stdErrLines = chromeDriver.stderr
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .asBroadcastStream();
+
+        stdOutLines
+            .listen((line) => _logger.finest('ChromeDriver stdout: $line'));
+        stdErrLines
+            .listen((line) => _logger.warning('ChromeDriver stderr: $line'));
+
+        await stdOutLines.first;
       } catch (e) {
         throw StateError(
             'Could not start ChromeDriver. Is it installed?\nError: $e');

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -18,6 +18,7 @@ import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:dwds/src/utilities/shared.dart';
 import 'package:frontend_server_common/src/resident_runner.dart';
 import 'package:http/http.dart';
+import 'package:http/io_client.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:path/path.dart' as p;
 import 'package:shelf/shelf.dart';
@@ -133,7 +134,10 @@ class TestContext {
     try {
       configureLogWriter();
 
-      client = Client();
+      client = IOClient(HttpClient()
+        ..maxConnectionsPerHost = 200
+        ..idleTimeout = const Duration(seconds: 30)
+        ..connectionTimeout = const Duration(seconds: 30));
 
       var systemTempDir = Directory.systemTemp;
       _outputDir = systemTempDir.createTempSync('foo bar');

--- a/dwds/test/handlers/asset_handler_test.dart
+++ b/dwds/test/handlers/asset_handler_test.dart
@@ -47,11 +47,8 @@ void main() {
     });
 
     tearDownAll(() async {
-      print('stopppping....');
       client.close();
-      print('client closed');
       await context.tearDown();
-      print('service closed');
     });
 
     setUp(setCurrentLogWriter);

--- a/dwds/test/handlers/asset_handler_test.dart
+++ b/dwds/test/handlers/asset_handler_test.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart = 2.9
+
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf_proxy/shelf_proxy.dart';
+import 'package:test/test.dart';
+
+import '../fixtures/context.dart';
+import '../fixtures/utilities.dart';
+
+void main() {
+  group('Asset handler', () {
+    final context = TestContext();
+    Handler assetHandler;
+    http.Client client;
+
+    setUpAll(() async {
+      await context.setUp(enableExpressionEvaluation: true);
+
+      client = IOClient(HttpClient()
+        ..maxConnectionsPerHost = 200
+        ..idleTimeout = const Duration(seconds: 30)
+        ..connectionTimeout = const Duration(seconds: 30));
+
+      var assetServerPort = daemonPort(context.workingDirectory);
+      var pathToServe = context.pathToServe;
+
+      assetHandler = proxyHandler(
+          'http://localhost:$assetServerPort/$pathToServe/',
+          client: client);
+    });
+
+    tearDownAll(() {
+      client.close();
+    });
+
+    Future<void> readAsString(String path) async {
+      var request = Request('GET', Uri.parse('http://foo:0000/$path'));
+      var response = await assetHandler(request);
+      var result = await response.readAsString();
+      expect(result, isNotNull, reason: 'Failed to read $path');
+    }
+
+    Future<void> readAsBytes(String path) async {
+      var request = Request('GET', Uri.parse('http://foo:0000/$path'));
+      var response = await assetHandler(request);
+      var result = response.read().toList();
+      expect(result, isNotNull, reason: 'Failed to read $path');
+    }
+
+    test('can read dill files', () async {
+      var path = 'hello_world/main.unsound.ddc.full.dill';
+      await readAsBytes(path);
+    });
+
+    test('can read large number of resources simultaneously', () async {
+      final n = 1000;
+      var futures = [
+        for (var i = 0; i < n; i++)
+          readAsString('hello_world/main.unsound.ddc.js.map'),
+        for (var i = 0; i < n; i++)
+          readAsString('hello_world/main.unsound.ddc.js'),
+        for (var i = 0; i < n; i++)
+          readAsBytes('hello_world/main.unsound.ddc.full.dill'),
+      ];
+
+      await expectLater(Future.wait(futures), completes);
+    });
+  });
+}

--- a/dwds/test/handlers/asset_handler_test.dart
+++ b/dwds/test/handlers/asset_handler_test.dart
@@ -45,14 +45,16 @@ void main() {
       var request = Request('GET', Uri.parse('http://foo:0000/$path'));
       var response = await assetHandler(request);
       var result = await response.readAsString();
-      expect(result, isNotNull, reason: 'Failed to read $path');
+      expect(result, isNotNull,
+          reason: 'Failed to read $path: ${response.statusCode}');
     }
 
     Future<void> readAsBytes(String path) async {
       var request = Request('GET', Uri.parse('http://foo:0000/$path'));
       var response = await assetHandler(request);
       var result = response.read().toList();
-      expect(result, isNotNull, reason: 'Failed to read $path');
+      expect(result, isNotNull,
+          reason: 'Failed to read $path: ${response.statusCode}');
     }
 
     test('can read dill files', () async {

--- a/dwds/test/restore_breakpoints_test.dart
+++ b/dwds/test/restore_breakpoints_test.dart
@@ -25,7 +25,7 @@ void setCurrentLogWriter() {
   configureLogWriter(
       customLogWriter: (level, message,
               {loggerName, error, stackTrace, verbose}) =>
-          print('[$level] $loggerName: $message'));
+          printOnFailure('[$level] $loggerName: $message'));
 }
 
 void main() {

--- a/dwds/test/restore_breakpoints_test.dart
+++ b/dwds/test/restore_breakpoints_test.dart
@@ -25,7 +25,7 @@ void setCurrentLogWriter() {
   configureLogWriter(
       customLogWriter: (level, message,
               {loggerName, error, stackTrace, verbose}) =>
-          printOnFailure('[$level] $loggerName: $message'));
+          print('[$level] $loggerName: $message'));
 }
 
 void main() {

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -11,8 +11,8 @@ import 'package:build_daemon/data/build_status.dart' as daemon;
 import 'package:devtools_server/devtools_server.dart';
 import 'package:dwds/data/build_result.dart';
 import 'package:dwds/dwds.dart';
-import 'package:http/http.dart';
 import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
@@ -104,7 +104,10 @@ class WebDevServer {
     });
 
     var cascade = Cascade();
-    var client = Client();
+    var client = IOClient(HttpClient()
+      ..maxConnectionsPerHost = 200
+      ..idleTimeout = const Duration(seconds: 30)
+      ..connectionTimeout = const Duration(seconds: 30));
     var assetHandler = proxyHandler(
         'http://localhost:${options.daemonPort}/${options.target}/',
         client: client);


### PR DESCRIPTION
Limit number of simultaneous connections to prevent SocketExceptions.

Restricting number of connections on the client to 200 causes all the extra connections 
to buffer, and eventually connect when the number of active connections drops below
the limit. This prevents SocketExceptions that cause flakes in the CI.

Removing the `maxConnectionsPerHost` on the client in new tests will repro the issue.

Hopefully fixes flaky behavior in DDR as well (pending performance measurements).

Closes: https://github.com/dart-lang/webdev/issues/1345