### PR TITLE
Remove obfuscation from late fields, update example to not crash

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Return empty library from `ChromeProxyService.getObject` for
   libraries present in medatata but not lodaded at runtime.
 - Log failures to load kernel during expression evaluation.
+- Show lowered final fields using their original dart names.
 
 ## 11.1.1
 

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -299,11 +299,17 @@ class InstanceHelper extends Domain {
         return fields.join(',');
       }
       const privateFields = sdk_utils.getOwnPropertySymbols(fields);
-      const nonSymbolNames = privateFields.map(sym => sym.description);
+      const nonSymbolNames = privateFields
+                            .map(sym => sym.description
+                              .split('#').slice(-1)[0]);
       const publicFieldNames = sdk_utils.getOwnPropertyNames(fields);
       const symbolNames =  Object.getOwnPropertySymbols(this)
-                            .map(sym => sym.description.split('.').slice(-1)[0]);
-      return nonSymbolNames.concat(publicFieldNames).concat(symbolNames).join(',');
+                            .map(sym => sym.description
+                              .split('#').slice(-1)[0]
+                              .split('.').slice(-1)[0]);
+      return nonSymbolNames
+        .concat(publicFieldNames)
+        .concat(symbolNames).join(',');
     }
     ''';
     var allNames = (await inspector

--- a/dwds/lib/src/utilities/objects.dart
+++ b/dwds/lib/src/utilities/objects.dart
@@ -45,6 +45,11 @@ class Property {
     var nonSymbol = (rawName.startsWith(prefix))
         ? rawName.substring(prefix.length, rawName.length - 1)
         : rawName;
+    // Adjust names for late fields:
+    // '_#MyTestClass#myselfField' -> 'myselfField'
+    // TODO(annagrin): Use debug symbols to map from dart to JS symbols.
+    // https://github.com/dart-lang/sdk/issues/40273
+    nonSymbol = nonSymbol.split('#').last;
     return nonSymbol.split('.').last;
   }
 

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -137,16 +137,16 @@ Function? someFunction() => null;
 // ignore: unused_element
 int _libraryPrivateFunction(int a, int b) => a + b;
 
-class NotReallyAList extends ListBase<Object> {
-  final List<Object> _internal;
+class NotReallyAList extends ListBase<Object?> {
+  final List<Object?> _internal;
 
   NotReallyAList() : _internal = [];
 
   @override
-  Object operator [](x) => _internal[x];
+  Object? operator [](x) => _internal[x];
 
   @override
-  operator []=(int x, Object y) => _internal[x] = y;
+  operator []=(int x, Object? y) => _internal[x] = y;
 
   @override
   int get length => _internal.length;


### PR DESCRIPTION
Fix problems uncovered after https://github.com/dart-lang/webdev/pull/1352

- Remove obfuscation from late fields. 
Closes: https://github.com/dart-lang/webdev/issues/1179

- Update example to run without throwing exceptions.
Related: https://github.com/dart-lang/sdk/issues/46646