### PR TITLE
Add check for new JS object representation

### DIFF
--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -331,6 +331,10 @@ class Debugger extends Domain {
   }
 
   bool _isNativeJsObject(vm_service.InstanceRef instanceRef) =>
+      // New type representation of JS objects reifies them to JavaScriptObject.
+      (instanceRef?.classRef?.name == 'JavaScriptObject' &&
+          instanceRef?.classRef?.library?.uri == 'dart:_interceptors') ||
+      // Old type representation still needed to support older SDK versions.
       instanceRef?.classRef?.name == 'NativeJavaScriptObject';
 
   Future<BoundVariable> _boundVariable(Property property) async {


### PR DESCRIPTION
The debugger filters out native JS objects using the classRef's name. Since DDC will change this representation, we need to check for the new representation.

Checked that `Flutter run for web shows no native javascript objects in static scope` succeeds with and without https://dart-review.googlesource.com/c/sdk/+/199600.