### PR TITLE
Fix hot restart race by pausing the app before hot restart

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## 11.1.2-dev
 
 - Return empty library from `ChromeProxyService.getObject` for
-  libraries present in medatata but not lodaded at runtime.
+  libraries present in medatata but not loaded at runtime.
 - Log failures to load kernel during expression evaluation.
 - Show lowered final fields using their original dart names.
 - Limit simultaneous connections to asset server to prevent broken sockets.
+- Fix hangs in hot restart.
 
 ## 11.1.1
 


### PR DESCRIPTION
**Issue**

A race between the app hitting a breakpoint and a hot restart was causing hot restart to hang periodically.

The race sequence was as following:
- app hits a breakpoint
- dwds gets the isolate, its eventPaused shows "Resumed", so dwds removes the breakpoints but does
  not resume the isolate.
- dwds issues hot restart command to the browser
- now the breakpoint has finished processing and notification is sent to the "Debug" event stream. 

As a result, the app is paused and hot restart hangs.

**Solution**

Pause the app (if it is not already paused) forcefully and wait for the either breakpoint or the pause event on 
the debug stream before hot restarting to prevent this from happening.

Closes: https://github.com/dart-lang/webdev/issues/1359