### PR TITLE
Do not show native JavaScript fields, include dart:ui library

### DIFF
--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -325,17 +325,9 @@ class Debugger extends Domain {
     // JavaScript objects
     return boundVariables
         .where((bv) =>
-            bv != null &&
-            !_isNativeJsObject(bv.value as vm_service.InstanceRef))
+            bv != null && !isNativeJsObject(bv.value as vm_service.InstanceRef))
         .toList();
   }
-
-  bool _isNativeJsObject(vm_service.InstanceRef instanceRef) =>
-      // New type representation of JS objects reifies them to JavaScriptObject.
-      (instanceRef?.classRef?.name == 'JavaScriptObject' &&
-          instanceRef?.classRef?.library?.uri == 'dart:_interceptors') ||
-      // Old type representation still needed to support older SDK versions.
-      instanceRef?.classRef?.name == 'NativeJavaScriptObject';
 
   Future<BoundVariable> _boundVariable(Property property) async {
     // We return one level of properties from this object. Sub-properties are
@@ -511,7 +503,7 @@ class Debugger extends Domain {
 
           // TODO: The exception object generally doesn't get converted to a
           // Dart object (and instead has a classRef name of 'NativeJavaScriptObject').
-          if (_isNativeJsObject(exception)) {
+          if (isNativeJsObject(exception)) {
             if (obj.description != null) {
               // Create a string exception object.
               exception = await inspector.instanceHelper
@@ -638,6 +630,13 @@ class Debugger extends Domain {
     }
   }
 }
+
+bool isNativeJsObject(vm_service.InstanceRef instanceRef) =>
+    // New type representation of JS objects reifies them to JavaScriptObject.
+    (instanceRef?.classRef?.name == 'JavaScriptObject' &&
+        instanceRef?.classRef?.library?.uri == 'dart:_interceptors') ||
+    // Old type representation still needed to support older SDK versions.
+    instanceRef?.classRef?.name == 'NativeJavaScriptObject';
 
 /// Returns the Dart line number for the provided breakpoint.
 int _lineNumberFor(Breakpoint breakpoint) =>

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -15,6 +15,7 @@ import '../utilities/domain.dart';
 import '../utilities/objects.dart';
 import '../utilities/shared.dart';
 import 'classes.dart';
+import 'debugger.dart';
 import 'inspector.dart';
 import 'metadata/class.dart';
 import 'metadata/function.dart';
@@ -169,16 +170,18 @@ class InstanceHelper extends Domain {
   Future<Instance> _plainInstanceFor(ClassRef classRef,
       RemoteObject remoteObject, List<Property> properties) async {
     var dartProperties = await _dartFieldsFor(properties, remoteObject);
-    var fields = await Future.wait(
+    var boundFields = await Future.wait(
         dartProperties.map<Future<BoundField>>((p) => _fieldFor(p, classRef)));
-    fields = fields.toList()
+    boundFields = boundFields
+        .where((bv) => bv != null && !isNativeJsObject(bv.value as InstanceRef))
+        .toList()
       ..sort((a, b) => a.decl.name.compareTo(b.decl.name));
     var result = Instance(
         kind: InstanceKind.kPlainInstance,
         id: remoteObject.objectId,
         identityHashCode: remoteObject.objectId.hashCode,
         classRef: classRef)
-      ..fields = fields;
+      ..fields = boundFields;
     return result;
   }
 

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -65,7 +65,8 @@ class MetadataProvider {
         'dart:svg',
         'dart:web_audio',
         'dart:web_gl',
-        'dart:web_sql'
+        'dart:web_sql',
+        'dart:ui',
       ];
 
   MetadataProvider(this.entrypoint, this._assetReader)

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -198,7 +198,10 @@ void main() async {
                       isA<Instance>().having(
                           (instance) => instance.classRef.name,
                           'Type.$name.$nestedName: classRef.name',
-                          isNot(contains('JavaScriptObject'))));
+                          isNot(isIn([
+                            'NativeJavaScriptObject',
+                            'JavaScriptObject',
+                          ]))));
                 }
               }
             });


### PR DESCRIPTION
Fix bugs discovered in manual testing debugging on flutter apps:

We made sure that BoundVariables are not showing native JS objects, but  missed another case - BoundFields. 
Remove native JS objects from them as well, add tests.

Closes: https://github.com/dart-lang/webdev/issues/1366

In flutter, dart:ui is an included library (from web engine) that dwds does not have in the metadata. Add it manually.

Closes: https://github.com/dart-lang/webdev/issues/1365