### PR TITLE
Improve logging in tests

### DIFF
--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -371,7 +371,7 @@ function($argsString) {
         return instance;
       }
     } catch (e, s) {
-      _logger.log(Level.FINE, 'getObject failed with exception: $e:$s');
+      _logger.fine('getObject $objectId failed', e, s);
       rethrow;
     }
     throw UnsupportedError('Only libraries, instances, classes, and scripts '

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -39,6 +39,8 @@ import 'injector.dart';
 /// Note: this should not be checked in enabled.
 const _enableLogging = false;
 
+final _logger = Logger('DevHandler');
+
 /// SSE handler to enable development features like hot reload and
 /// opening DevTools.
 class DevHandler {
@@ -53,7 +55,6 @@ class DevHandler {
   final _servicesByAppId = <String, AppDebugServices>{};
   final _appConnectionByAppId = <String, AppConnection>{};
   final Stream<BuildResult> buildResults;
-  final _logger = Logger('DevHandler');
   final Future<ChromeConnection> Function() _chromeConnection;
   final ExtensionBackend _extensionBackend;
   final StreamController<DebugConnection> extensionDebugConnections =

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -351,7 +351,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
 
       return await _assetHandler(request);
     } catch (e, s) {
-      _logger.severe('Error loading $uri: $e:$s');
+      _logger.severe('Error loading $uri', e, s);
       rethrow;
     }
   }

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -39,19 +39,19 @@ class TestSetup {
   ChromeProxyService get service =>
       fetchChromeProxyService(context.debugConnection);
   WipConnection get tabConnection => context.tabConnection;
-
-  /// Redirect the logs for the current zone to emit on failure.
-  ///
-  /// All messages are stored and reported on test failure.
-  /// Needs to be called in both setUpAll() and setUp() to store
-  /// the logs in the current zone.
-  ///
-  /// Note: set 'debug' to 'true' for debug printing.
-  static void setCurrentLogWriter() =>
-      configureLogWriter(customLogWriter: createLogWriter(debug: false));
 }
 
 void main() async {
+  // Enable verbose logging for debugging.
+  var debug = false;
+
+  // Change to 'true' to print expression compiler messages to console.
+  //
+  // Note: expression compiler runs in an isolate, so its output is not
+  // currently redirected to a logger. As a result, it will be printed
+  // regardless of the logger settings.
+  var verboseCompiler = false;
+
   for (var soundNullSafety in [false, true]) {
     var setup = soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
     var context = setup.context;
@@ -75,10 +75,10 @@ void main() async {
 
       group('shared context with evaluation', () {
         setUpAll(() async {
-          TestSetup.setCurrentLogWriter();
+          setCurrentLogWriter(debug: debug);
           await context.setUp(
             enableExpressionEvaluation: true,
-            verbose: false,
+            verboseCompiler: verboseCompiler,
           );
         });
 
@@ -86,7 +86,7 @@ void main() async {
           await context.tearDown();
         });
 
-        setUp(TestSetup.setCurrentLogWriter);
+        setUp(() => setCurrentLogWriter(debug: debug));
 
         group('evaluateInFrame', () {
           VM vm;
@@ -99,7 +99,7 @@ void main() async {
           Stream<Event> stream;
 
           setUp(() async {
-            TestSetup.setCurrentLogWriter();
+            setCurrentLogWriter(debug: debug);
             vm = await setup.service.getVM();
             isolate = await setup.service.getIsolate(vm.isolates.first.id);
             scripts = await setup.service.getScripts(isolate.id);
@@ -131,7 +131,7 @@ void main() async {
 
               var param = object as InstanceRef;
 
-              expect(
+              await expectLater(
                   () => setup.service.evaluateInFrame(
                         isolate.id,
                         event.topFrame.index,
@@ -515,8 +515,8 @@ void main() async {
               var event = await stream.firstWhere(
                   (event) => event.kind == EventKind.kPauseBreakpoint);
 
-              expect(
-                  () => setup.service
+              await expectLater(
+                  setup.service
                       .evaluateInFrame('bad', event.topFrame.index, 'local'),
                   throwsRPCError);
             });
@@ -528,7 +528,7 @@ void main() async {
           Isolate isolate;
 
           setUp(() async {
-            TestSetup.setCurrentLogWriter();
+            setCurrentLogWriter(debug: debug);
             vm = await setup.service.getVM();
             isolate = await setup.service.getIsolate(vm.isolates.first.id);
 
@@ -598,10 +598,10 @@ void main() async {
 
       group('shared context with no evaluation', () {
         setUpAll(() async {
-          TestSetup.setCurrentLogWriter();
+          setCurrentLogWriter(debug: debug);
           await context.setUp(
             enableExpressionEvaluation: false,
-            verbose: false,
+            verboseCompiler: verboseCompiler,
           );
         });
 
@@ -609,7 +609,7 @@ void main() async {
           await context.tearDown();
         });
 
-        setUp(TestSetup.setCurrentLogWriter);
+        setUp(() => setCurrentLogWriter(debug: debug));
 
         group('evaluateInFrame', () {
           VM vm;
@@ -639,8 +639,8 @@ void main() async {
               var event = await stream.firstWhere(
                   (event) => event.kind == EventKind.kPauseBreakpoint);
 
-              expect(
-                  () => setup.service.evaluateInFrame(
+              await expectLater(
+                  setup.service.evaluateInFrame(
                       isolate.id, event.topFrame.index, 'local'),
                   throwsRPCError);
             });

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -46,13 +46,9 @@ class TestSetup {
   /// Needs to be called in both setUpAll() and setUp() to store
   /// the logs in the current zone.
   ///
-  /// Note: change 'printOnFailure' to 'print' for debug printing.
-  static void setCurrentLogWriter() {
-    configureLogWriter(
-        customLogWriter: (level, message,
-                {loggerName, error, stackTrace, verbose}) =>
-            printOnFailure('[$level] $loggerName: $message'));
-  }
+  /// Note: set 'debug' to 'true' for debug printing.
+  static void setCurrentLogWriter() =>
+      configureLogWriter(customLogWriter: createLogWriter(debug: false));
 }
 
 void main() async {
@@ -90,9 +86,7 @@ void main() async {
           await context.tearDown();
         });
 
-        setUp(() async {
-          TestSetup.setCurrentLogWriter();
-        });
+        setUp(TestSetup.setCurrentLogWriter);
 
         group('evaluateInFrame', () {
           VM vm;
@@ -105,6 +99,7 @@ void main() async {
           Stream<Event> stream;
 
           setUp(() async {
+            TestSetup.setCurrentLogWriter();
             vm = await setup.service.getVM();
             isolate = await setup.service.getIsolate(vm.isolates.first.id);
             scripts = await setup.service.getScripts(isolate.id);
@@ -533,6 +528,7 @@ void main() async {
           Isolate isolate;
 
           setUp(() async {
+            TestSetup.setCurrentLogWriter();
             vm = await setup.service.getVM();
             isolate = await setup.service.getIsolate(vm.isolates.first.id);
 
@@ -613,9 +609,7 @@ void main() async {
           await context.tearDown();
         });
 
-        setUp(() async {
-          TestSetup.setCurrentLogWriter();
-        });
+        setUp(TestSetup.setCurrentLogWriter);
 
         group('evaluateInFrame', () {
           VM vm;

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -30,13 +30,14 @@ ChromeProxyService get service =>
 
 WipConnection get tabConnection => context.tabConnection;
 
+/// Note: set 'debug' to 'true' for debug printing.
+void setCurrentLogWriter() =>
+    configureLogWriter(customLogWriter: createLogWriter(debug: false));
+
 void main() {
   group('shared context', () {
     setUpAll(() async {
-      configureLogWriter(
-          customLogWriter: (level, message,
-                  {loggerName, error, stackTrace, verbose}) =>
-              printOnFailure('[$level] $loggerName: $message'));
+      setCurrentLogWriter();
       await context.setUp(verbose: false);
     });
 
@@ -52,6 +53,7 @@ void main() {
       ScriptRef mainScript;
 
       setUp(() async {
+        setCurrentLogWriter();
         vm = await fetchChromeProxyService(context.debugConnection).getVM();
         isolate = await fetchChromeProxyService(context.debugConnection)
             .getIsolate(vm.isolates.first.id);
@@ -160,6 +162,8 @@ void main() {
     });
 
     group('callServiceExtension', () {
+      setUp(setCurrentLogWriter);
+
       test('success', () async {
         var serviceMethod = 'ext.test.callServiceExtension';
         await tabConnection.runtime
@@ -208,6 +212,8 @@ void main() {
     });
 
     group('VMTimeline', () {
+      setUp(setCurrentLogWriter);
+
       test('clearVMTimeline', () async {
         await expectLater(service.clearVMTimeline(), throwsRPCError);
       });
@@ -246,12 +252,15 @@ void main() {
       LibraryRef bootstrap;
 
       setUpAll(() async {
+        setCurrentLogWriter();
         var vm = await service.getVM();
         isolate = await service.getIsolate(vm.isolates.first.id);
         bootstrap = isolate.rootLib;
       });
 
       group('top level methods', () {
+        setUp(setCurrentLogWriter);
+
         test('can return strings', () async {
           expect(
               await service.evaluate(
@@ -304,6 +313,8 @@ void main() {
         });
 
         group('with provided scope', () {
+          setUp(setCurrentLogWriter);
+
           Future<InstanceRef> createRemoteObject(String message) async {
             return await service.evaluate(
                     isolate.id, bootstrap.id, 'createObject("$message")')
@@ -362,6 +373,8 @@ void main() {
     });
 
     group('getIsolate', () {
+      setUp(setCurrentLogWriter);
+
       test('works for existing isolates', () async {
         var vm = await service.getVM();
         var result = await service.getIsolate(vm.isolates.first.id);
@@ -393,12 +406,15 @@ void main() {
       Library rootLibrary;
 
       setUpAll(() async {
+        setCurrentLogWriter();
         var vm = await service.getVM();
         isolate = await service.getIsolate(vm.isolates.first.id);
         bootstrap = isolate.rootLib;
         rootLibrary =
             await service.getObject(isolate.id, bootstrap.id) as Library;
       });
+
+      setUp(setCurrentLogWriter);
 
       test('Libraries', () async {
         expect(rootLibrary, isNotNull);
@@ -654,6 +670,8 @@ void main() {
     });
 
     group('getSourceReport', () {
+      setUp(setCurrentLogWriter);
+
       test('Coverage report', () async {
         var vm = await service.getVM();
         var isolateId = vm.isolates.first.id;
@@ -698,6 +716,7 @@ void main() {
       ScriptRef mainScript;
 
       setUp(() async {
+        setCurrentLogWriter();
         var vm = await service.getVM();
         isolateId = vm.isolates.first.id;
         scripts = await service.getScripts(isolateId);
@@ -732,6 +751,7 @@ void main() {
       ScriptRef mainScript;
 
       setUp(() async {
+        setCurrentLogWriter();
         var vm = await service.getVM();
         isolateId = vm.isolates.first.id;
         scripts = await service.getScripts(isolateId);
@@ -800,6 +820,7 @@ void main() {
       ScriptRef mainScript;
 
       setUp(() async {
+        setCurrentLogWriter();
         var vm = await service.getVM();
         isolateId = vm.isolates.first.id;
         scripts = await service.getScripts(isolateId);
@@ -954,6 +975,7 @@ void main() {
       InstanceRef testInstance;
 
       setUp(() async {
+        setCurrentLogWriter();
         vm = await service.getVM();
         isolate = await service.getIsolate(vm.isolates.first.id);
         bootstrap = isolate.rootLib;
@@ -1156,6 +1178,7 @@ void main() {
         Stream<Event> eventStream;
 
         setUp(() async {
+          setCurrentLogWriter();
           expect(await service.streamListen('Debug'),
               const TypeMatcher<Success>());
           eventStream = service.onEvent('Debug');

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -30,15 +30,11 @@ ChromeProxyService get service =>
 
 WipConnection get tabConnection => context.tabConnection;
 
-/// Note: set 'debug' to 'true' for debug printing.
-void setCurrentLogWriter() =>
-    configureLogWriter(customLogWriter: createLogWriter(debug: false));
-
 void main() {
   group('shared context', () {
     setUpAll(() async {
       setCurrentLogWriter();
-      await context.setUp(verbose: false);
+      await context.setUp(verboseCompiler: false);
     });
 
     tearDownAll(() async {

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -30,13 +30,9 @@ final context = TestContext();
 /// Needs to be called in both setUpAll() and setUp() to store
 /// the logs in the current zone.
 ///
-/// Note: change 'printOnFailure' to 'print' for debug printing.
-void setCurrentLogWriter() {
-  configureLogWriter(
-      customLogWriter: (level, message,
-              {loggerName, error, stackTrace, verbose}) =>
-          printOnFailure('[$level] $loggerName: $message'));
-}
+/// Note: set 'debug' to 'true' for debug printing.
+void setCurrentLogWriter() =>
+    configureLogWriter(customLogWriter: createLogWriter(debug: false));
 
 void main() {
   setUpAll(() async {

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -24,16 +24,6 @@ WipConnection get tabConnection => context.tabConnection;
 
 final context = TestContext();
 
-/// Redirect the logs for the current zone to emit on failure.
-///
-/// All messages are stored and reported on test failure.
-/// Needs to be called in both setUpAll() and setUp() to store
-/// the logs in the current zone.
-///
-/// Note: set 'debug' to 'true' for debug printing.
-void setCurrentLogWriter() =>
-    configureLogWriter(customLogWriter: createLogWriter(debug: false));
-
 void main() {
   setUpAll(() async {
     setCurrentLogWriter();

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -50,8 +50,7 @@ void main() async {
       output.stream.listen(printOnFailure);
 
       configureLogWriter(
-          customLogWriter: (level, message,
-                  {loggerName, error, stackTrace, verbose}) =>
+          customLogWriter: (level, message, {error, loggerName, stackTrace}) =>
               output.add('[$level] $loggerName: $message'));
 
       // start expression compilation service

--- a/dwds/test/fixtures/logging.dart
+++ b/dwds/test/fixtures/logging.dart
@@ -29,7 +29,7 @@ StreamSubscription<LogRecord> _loggerSub;
 ///   // Note: change 'printOnFailure' to 'print' for debug printing.
 ///   configureLogWriter(
 ///        customLogWriter: (level, message,
-///                {loggerName, error, stackTrace, verbose}) =>
+///                {error, loggerName, stackTrace}) =>
 ///            printOnFailure('[$level] $loggerName: $message'));
 ///  }
 ///
@@ -53,9 +53,9 @@ void configureLogWriter({LogWriter customLogWriter}) {
   _loggerSub?.cancel();
   _loggerSub = Logger.root.onRecord.listen((event) {
     logWriter(event.level, event.message,
-        error: '${event.error}',
+        error: event.error?.toString(),
         loggerName: event.loggerName,
-        stackTrace: '${event.stackTrace}');
+        stackTrace: event.stackTrace?.toString());
   });
 }
 
@@ -64,8 +64,16 @@ void stopLogWriter() {
   _loggerSub = null;
 }
 
-LogWriter _logWriter = (level, message,
-        {String error, String loggerName, String stackTrace}) =>
-    printOnFailure('[$level] $loggerName: $message');
+LogWriter _logWriter = createLogWriter();
+
+LogWriter createLogWriter({bool debug}) =>
+    (level, message, {String error, String loggerName, String stackTrace}) {
+      var printFn = debug ? print : printOnFailure;
+      var errorMessage = error == null ? '' : ':\n$error';
+      var stackMessage = stackTrace == null ? '' : ':\n$stackTrace';
+      printFn('[$level] $loggerName: $message'
+          '$errorMessage'
+          '$stackMessage');
+    };
 
 LogWriter get logWriter => _logWriter;

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -32,13 +32,9 @@ class TestSetup {
       fetchChromeProxyService(context.debugConnection);
   WipConnection get tabConnection => context.tabConnection;
 
-  static void setCurrentLogWriter() {
-    // Note: change 'printOnFailure' to 'print' for debug printing
-    configureLogWriter(
-        customLogWriter: (level, message,
-                {loggerName, error, stackTrace, verbose}) =>
-            printOnFailure('[$level] $loggerName: $message'));
-  }
+  /// Note: set 'debug' to 'true' for debug printing.
+  static void setCurrentLogWriter() =>
+      configureLogWriter(customLogWriter: createLogWriter(debug: false));
 }
 
 void main() async {

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -31,13 +31,15 @@ class TestSetup {
   ChromeProxyService get service =>
       fetchChromeProxyService(context.debugConnection);
   WipConnection get tabConnection => context.tabConnection;
-
-  /// Note: set 'debug' to 'true' for debug printing.
-  static void setCurrentLogWriter() =>
-      configureLogWriter(customLogWriter: createLogWriter(debug: false));
 }
 
 void main() async {
+  // Enable verbose logging for debugging.
+  var debug = false;
+
+  // Change to 'false' to silence frontend server messages.
+  var verboseCompiler = true;
+
   var setup = TestSetup.unsound();
   var context = setup.context;
 
@@ -60,11 +62,11 @@ void main() async {
 
   group('shared context with evaluation', () {
     setUpAll(() async {
-      TestSetup.setCurrentLogWriter();
+      setCurrentLogWriter(debug: debug);
       await context.setUp(
           enableExpressionEvaluation: true,
           compilationMode: CompilationMode.frontendServer,
-          verbose: false);
+          verboseCompiler: verboseCompiler);
     });
 
     tearDownAll(() async {
@@ -72,7 +74,7 @@ void main() async {
     });
 
     setUp(() async {
-      TestSetup.setCurrentLogWriter();
+      setCurrentLogWriter(debug: debug);
     });
 
     group('evaluateInFrame', () {
@@ -465,11 +467,11 @@ void main() async {
 
   group('shared context with no evaluation', () {
     setUpAll(() async {
-      TestSetup.setCurrentLogWriter();
+      setCurrentLogWriter(debug: debug);
       await context.setUp(
           enableExpressionEvaluation: false,
           compilationMode: CompilationMode.frontendServer,
-          verbose: false);
+          verboseCompiler: verboseCompiler);
     });
 
     tearDownAll(() async {
@@ -477,7 +479,7 @@ void main() async {
     });
 
     setUp(() async {
-      TestSetup.setCurrentLogWriter();
+      setCurrentLogWriter(debug: debug);
     });
 
     group('evaluateInFrame', () {
@@ -508,8 +510,8 @@ void main() async {
           var event = await stream.firstWhere(
               (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
-          expect(
-              () => setup.service
+          await expectLater(
+              setup.service
                   .evaluateInFrame(isolate.id, event.topFrame.index, 'local'),
               throwsRPCError);
         });

--- a/dwds/test/handlers/asset_handler_test.dart
+++ b/dwds/test/handlers/asset_handler_test.dart
@@ -16,10 +16,6 @@ import '../fixtures/context.dart';
 import '../fixtures/logging.dart';
 import '../fixtures/utilities.dart';
 
-/// Note: set 'debug' to 'true' for debug printing.
-void setCurrentLogWriter() =>
-    configureLogWriter(customLogWriter: createLogWriter(debug: false));
-
 void main() {
   group('Asset handler', () {
     final context = TestContext();
@@ -28,7 +24,10 @@ void main() {
 
     setUpAll(() async {
       setCurrentLogWriter();
-      await context.setUp(enableExpressionEvaluation: true, verbose: false);
+      await context.setUp(
+        enableExpressionEvaluation: true,
+        verboseCompiler: false,
+      );
 
       client = IOClient(HttpClient()
         ..maxConnectionsPerHost = 200

--- a/dwds/test/handlers/asset_handler_test.dart
+++ b/dwds/test/handlers/asset_handler_test.dart
@@ -16,12 +16,9 @@ import '../fixtures/context.dart';
 import '../fixtures/logging.dart';
 import '../fixtures/utilities.dart';
 
-void setCurrentLogWriter() {
-  configureLogWriter(
-      customLogWriter: (level, message,
-              {loggerName, error, stackTrace, verbose}) =>
-          printOnFailure('[$level] $loggerName: $message'));
-}
+/// Note: set 'debug' to 'true' for debug printing.
+void setCurrentLogWriter() =>
+    configureLogWriter(customLogWriter: createLogWriter(debug: false));
 
 void main() {
   group('Asset handler', () {
@@ -31,7 +28,7 @@ void main() {
 
     setUpAll(() async {
       setCurrentLogWriter();
-      await context.setUp(enableExpressionEvaluation: true, verbose: true);
+      await context.setUp(enableExpressionEvaluation: true, verbose: false);
 
       client = IOClient(HttpClient()
         ..maxConnectionsPerHost = 200

--- a/dwds/test/restore_breakpoints_test.dart
+++ b/dwds/test/restore_breakpoints_test.dart
@@ -21,14 +21,12 @@ ChromeProxyService get service =>
     fetchChromeProxyService(context.debugConnection);
 WipConnection get tabConnection => context.tabConnection;
 
-/// Note: set 'debug' to 'true' for debug printing.
-void setCurrentLogWriter() =>
-    configureLogWriter(customLogWriter: createLogWriter(debug: false));
-
 void main() {
   setUpAll(() async {
     setCurrentLogWriter();
-    await context.setUp(restoreBreakpoints: true, verbose: true);
+    await context.setUp(
+      restoreBreakpoints: true,
+    );
   });
 
   tearDownAll(() async {

--- a/dwds/test/restore_breakpoints_test.dart
+++ b/dwds/test/restore_breakpoints_test.dart
@@ -21,12 +21,9 @@ ChromeProxyService get service =>
     fetchChromeProxyService(context.debugConnection);
 WipConnection get tabConnection => context.tabConnection;
 
-void setCurrentLogWriter() {
-  configureLogWriter(
-      customLogWriter: (level, message,
-              {loggerName, error, stackTrace, verbose}) =>
-          printOnFailure('[$level] $loggerName: $message'));
-}
+/// Note: set 'debug' to 'true' for debug printing.
+void setCurrentLogWriter() =>
+    configureLogWriter(customLogWriter: createLogWriter(debug: false));
 
 void main() {
   setUpAll(() async {

--- a/frontend_server_common/lib/src/asset_server.dart
+++ b/frontend_server_common/lib/src/asset_server.dart
@@ -21,6 +21,8 @@ import 'package:shelf/shelf.dart' as shelf;
 
 import 'utilities.dart';
 
+Logger _logger = Logger('TestAssetServer');
+
 class TestAssetServer implements AssetReader {
   TestAssetServer(
     this._root,
@@ -34,10 +36,6 @@ class TestAssetServer implements AssetReader {
   // makes no claims as to the structure of the data.
   static const String _defaultMimeType = 'application/octet-stream';
   final FileSystem _fileSystem;
-
-  void _printTrace(String message) {
-    Logger.root.info(message);
-  }
 
   /// Start the web asset server on a [hostname] and [port].
   ///
@@ -160,7 +158,7 @@ class TestAssetServer implements AssetReader {
         castStringKeyedMap(json.decode(manifestFile.readAsStringSync()));
     for (var filePath in manifest.keys) {
       if (filePath == null) {
-        _printTrace('Invalid manfiest file: $filePath');
+        _logger.severe('Invalid manfiest file: $filePath');
         continue;
       }
       var offsets = castStringKeyedMap(manifest[filePath]);
@@ -171,14 +169,14 @@ class TestAssetServer implements AssetReader {
       if (codeOffsets.length != 2 ||
           sourcemapOffsets.length != 2 ||
           metadataOffsets.length != 2) {
-        _printTrace('Invalid manifest byte offsets: $offsets');
+        _logger.severe('Invalid manifest byte offsets: $offsets');
         continue;
       }
 
       var codeStart = codeOffsets[0];
       var codeEnd = codeOffsets[1];
       if (codeStart < 0 || codeEnd > codeBytes.lengthInBytes) {
-        _printTrace('Invalid byte index: [$codeStart, $codeEnd]');
+        _logger.severe('Invalid byte index: [$codeStart, $codeEnd]');
         continue;
       }
       var byteView = Uint8List.view(
@@ -191,7 +189,7 @@ class TestAssetServer implements AssetReader {
       var sourcemapStart = sourcemapOffsets[0];
       var sourcemapEnd = sourcemapOffsets[1];
       if (sourcemapStart < 0 || sourcemapEnd > sourcemapBytes.lengthInBytes) {
-        _printTrace('Invalid byte index: [$sourcemapStart, $sourcemapEnd]');
+        _logger.severe('Invalid byte index: [$sourcemapStart, $sourcemapEnd]');
         continue;
       }
       var sourcemapView = Uint8List.view(
@@ -204,7 +202,7 @@ class TestAssetServer implements AssetReader {
       var metadataStart = metadataOffsets[0];
       var metadataEnd = metadataOffsets[1];
       if (metadataStart < 0 || metadataEnd > metadataBytes.lengthInBytes) {
-        _printTrace('Invalid byte index: [$metadataStart, $metadataEnd]');
+        _logger.severe('Invalid byte index: [$metadataStart, $metadataEnd]');
         continue;
       }
       var metadataView = Uint8List.view(

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 
 import 'package:dwds/dwds.dart';
 import 'package:file/file.dart';
+import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
@@ -21,6 +22,8 @@ import 'frontend_server_client.dart';
 import 'utilities.dart';
 
 final String dartWebSdkPath = p.join(dartSdkPath, 'lib', 'dev_compiler');
+
+Logger _logger = Logger('WebDevFs');
 
 class WebDevFS {
   WebDevFS({
@@ -184,7 +187,7 @@ Future<void> writeBundle(
     try {
       bundleDir.deleteSync(recursive: true);
     } on FileSystemException catch (err) {
-      printError('Failed to clean up asset directory ${bundleDir.path}: $err\n'
+      _logger.warning('Failed to clean up asset directory ${bundleDir.path}: $err\n'
           'To clean build artifacts, use the command "flutter clean".');
     }
   }

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -186,9 +186,10 @@ Future<void> writeBundle(
   if (bundleDir.existsSync()) {
     try {
       bundleDir.deleteSync(recursive: true);
-    } on FileSystemException catch (err) {
-      _logger.warning('Failed to clean up asset directory ${bundleDir.path}: $err\n'
-          'To clean build artifacts, use the command "flutter clean".');
+    } on FileSystemException catch (e, s) {
+      _logger.warning(
+          'Failed to clean up asset directory ${bundleDir.path}.\n'
+          'To clean build artifacts, use the command "flutter clean".', e, s);
     }
   }
   bundleDir.createSync(recursive: true);

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -189,7 +189,9 @@ Future<void> writeBundle(
     } on FileSystemException catch (e, s) {
       _logger.warning(
           'Failed to clean up asset directory ${bundleDir.path}.\n'
-          'To clean build artifacts, use the command "flutter clean".', e, s);
+          'To clean build artifacts, use the command "flutter clean".',
+          e,
+          s);
     }
   }
   bundleDir.createSync(recursive: true);

--- a/frontend_server_common/lib/src/devfs_content.dart
+++ b/frontend_server_common/lib/src/devfs_content.dart
@@ -10,8 +10,11 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:file/file.dart';
+import 'package:logging/logging.dart';
 
 import 'utilities.dart';
+
+Logger _logger = Logger('DevFsContent');
 
 /// Common superclass for content copied to the device.
 abstract class DevFSContent {
@@ -79,7 +82,7 @@ class DevFSFileContent extends DevFSContent {
       }
     }
     if (_fileStat == null) {
-      printError(
+      _logger.severe(
           'Unable to get status of file "${file.path}": file not found.');
     }
   }

--- a/frontend_server_common/lib/src/frontend_server_client.dart
+++ b/frontend_server_common/lib/src/frontend_server_client.dart
@@ -25,8 +25,8 @@ Logger _serverLogger = Logger('FrontendServer');
 
 void defaultConsumer(String message, {StackTrace stackTrace}) =>
     stackTrace == null
-      ? _serverLogger.info(message)
-      : _serverLogger.severe(message, null, stackTrace);
+        ? _serverLogger.info(message)
+        : _serverLogger.severe(message, null, stackTrace);
 
 String get frontendServerExecutable =>
     p.join(dartSdkPath, 'bin', 'snapshots', 'frontend_server.dart.snapshot');

--- a/frontend_server_common/lib/src/frontend_server_client.dart
+++ b/frontend_server_common/lib/src/frontend_server_client.dart
@@ -20,6 +20,14 @@ import 'package:usage/uuid/uuid.dart';
 
 import 'utilities.dart';
 
+Logger _logger = Logger('FrontendServerClient');
+Logger _serverLogger = Logger('FrontendServer');
+
+void defaultConsumer(String message, {StackTrace stackTrace}) =>
+    stackTrace == null
+      ? _serverLogger.info(message)
+      : _serverLogger.severe(message, null, stackTrace);
+
 String get frontendServerExecutable =>
     p.join(dartSdkPath, 'bin', 'snapshots', 'frontend_server.dart.snapshot');
 
@@ -38,11 +46,7 @@ enum StdoutState { collectDiagnostic, collectDependencies }
 
 /// Handles stdin/stdout communication with the frontend server.
 class StdoutHandler {
-  void _printTrace(String message) {
-    Logger.root.info(message);
-  }
-
-  StdoutHandler({this.consumer = printError}) {
+  StdoutHandler({@required this.consumer}) {
     reset();
   }
 
@@ -137,7 +141,7 @@ class StdoutHandler {
           sources.remove(Uri.parse(message.substring(1)));
           break;
         default:
-          _printTrace('Unexpected prefix for $message uri - ignoring');
+          _logger.warning('Unexpected prefix for $message uri - ignoring');
       }
     }
   }
@@ -389,7 +393,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     this.fileSystemScheme,
     this.platformDill,
     this.verbose,
-    CompilerMessageConsumer compilerMessageConsumer = printError,
+    CompilerMessageConsumer compilerMessageConsumer = defaultConsumer,
   })  : assert(sdkRoot != null),
         _stdoutHandler = StdoutHandler(consumer: compilerMessageConsumer),
         // This is a URI, not a file path, so the forward slash is correct even on Windows.
@@ -400,10 +404,6 @@ class DefaultResidentCompiler implements ResidentCompiler {
   final String fileSystemScheme;
   final String platformDill;
   final bool verbose;
-
-  void _printTrace(String message) {
-    Logger.root.info(message);
-  }
 
   @override
   void addFileSystemRoot(String root) {
@@ -461,14 +461,14 @@ class DefaultResidentCompiler implements ResidentCompiler {
         ? '${_mapFilename(request.mainPath, packageUriMapper)} '
         : '';
     _server.stdin.writeln('recompile $mainUri$inputKey');
-    _printTrace('<- recompile $mainUri$inputKey');
+    _logger.info('<- recompile $mainUri$inputKey');
     for (var fileUri in request.invalidatedFiles) {
       var message = _mapFileUri(fileUri.toString(), packageUriMapper);
       _server.stdin.writeln(message);
-      _printTrace(message);
+      _logger.info(message);
     }
     _server.stdin.writeln(inputKey);
-    _printTrace('<- $inputKey');
+    _logger.info('<- $inputKey');
 
     return _stdoutHandler.compilerOutput.future;
   }
@@ -527,7 +527,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
       if (verbose) '--verbose'
     ];
 
-    _printTrace(args.join(' '));
+    _logger.info(args.join(' '));
     _server = await Process.start(Platform.resolvedExecutable, args,
         workingDirectory: packagesPath);
     _server.stdout
@@ -545,7 +545,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     _server.stderr
         .transform<String>(utf8.decoder)
         .transform<String>(const LineSplitter())
-        .listen(printError);
+        .listen(_logger.info);
 
     unawaited(_server.exitCode.then((int code) {
       if (code != 0) {
@@ -554,7 +554,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     }));
 
     _server.stdin.writeln('compile $scriptUri');
-    _printTrace('<- compile $scriptUri');
+    _logger.info('<- compile $scriptUri');
 
     return _stdoutHandler.compilerOutput.future;
   }
@@ -655,7 +655,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
   void accept() {
     if (_compileRequestNeedsConfirmation) {
       _server.stdin.writeln('accept');
-      _printTrace('<- accept');
+      _logger.info('<- accept');
     }
     _compileRequestNeedsConfirmation = false;
   }
@@ -677,7 +677,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     }
     _stdoutHandler.reset(expectSources: false);
     _server.stdin.writeln('reject');
-    _printTrace('<- reject');
+    _logger.info('<- reject');
     _compileRequestNeedsConfirmation = false;
     return _stdoutHandler.compilerOutput.future;
   }
@@ -685,12 +685,12 @@ class DefaultResidentCompiler implements ResidentCompiler {
   @override
   void reset() {
     _server?.stdin?.writeln('reset');
-    _printTrace('<- reset');
+    _logger.info('<- reset');
   }
 
   Future<int> quit() async {
     _server.stdin.writeln('quit');
-    _printTrace('<- quit');
+    _logger.info('<- quit');
     return _server.exitCode;
   }
 
@@ -749,7 +749,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
       return 0;
     }
 
-    _printTrace('killing pid ${_server.pid}');
+    _logger.info('killing pid ${_server.pid}');
     _server.kill();
     return _server.exitCode;
   }

--- a/frontend_server_common/lib/src/resident_runner.dart
+++ b/frontend_server_common/lib/src/resident_runner.dart
@@ -10,6 +10,7 @@
 import 'dart:async';
 
 import 'package:dwds/dwds.dart';
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
 import 'asset.dart';
@@ -20,6 +21,8 @@ import 'utilities.dart';
 
 final Uri platformDill =
     Uri.file(p.join(dartSdkPath, 'lib', '_internal', 'ddc_sdk.dill'));
+
+Logger _logger = Logger('ResidentWebRunner');
 
 class ResidentWebRunner {
   ResidentWebRunner(
@@ -73,7 +76,7 @@ class ResidentWebRunner {
 
     var report = await _updateDevFS();
     if (!report.success) {
-      printError('Failed to compile application.');
+      _logger.severe('Failed to compile application.');
       return 1;
     }
 

--- a/frontend_server_common/lib/src/utilities.dart
+++ b/frontend_server_common/lib/src/utilities.dart
@@ -27,4 +27,3 @@ final String pubPath =
     p.join(_sdkDir, 'bin', Platform.isWindows ? 'pub.bat' : 'pub');
 
 const fs.FileSystem fileSystem = LocalFileSystem();
-

--- a/frontend_server_common/lib/src/utilities.dart
+++ b/frontend_server_common/lib/src/utilities.dart
@@ -28,9 +28,3 @@ final String pubPath =
 
 const fs.FileSystem fileSystem = LocalFileSystem();
 
-void printError(String message, {StackTrace stackTrace}) {
-  if (stackTrace != null) {
-    print('$message: $stackTrace');
-  }
-  print(message);
-}


### PR DESCRIPTION
- Log http requests to asset server in tests, log request exceptions
- Make setting up logger more convenient by providing default loggers
- Log exceptions and stack traces in default loggers
- Change frontend_server_common to use the same logging mechanism 
  as the rest of the code
- Log build messages and frontend_server messages by default
- Do not log expression_compiler_worker messages by default yet
   since it runs in an isolate and we cannot redirect stdout/stderr to logs.
   Postpone redirecting output until expression_compiler_worker moves to
   a process.