### PR TITLE
Add more tests for native JS types in variable windows

### DIFF
--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -173,7 +173,7 @@ void main() {
 
       var variableNames = variables.keys.toList()..sort();
       // Note: '$this' should change to 'this', and 'return' should
-      //disappear after debug symbols are available.
+      // disappear after debug symbols are available.
       // https://github.com/dart-lang/webdev/issues/1371
       expect(variableNames, ['\$this', 'ret', 'return']);
     });

--- a/example/web/scopes_main.dart
+++ b/example/web/scopes_main.dart
@@ -59,6 +59,8 @@ void main() async {
     localList.add('abc');
     var f = testClass.methodWithVariables();
     print(f('parameter'));
+    var num = '1234'.someExtensionMethod();
+    print('$num');
   });
 
   print(_libraryPrivateFinal);
@@ -153,4 +155,11 @@ class NotReallyAList extends ListBase<Object?> {
 
   @override
   set length(x) => _internal.length = x;
+}
+
+extension NumberParsing on String {
+  int someExtensionMethod() {
+    var ret = int.parse(this);
+    return ret; // Breakpoint: extension
+  }
 }


### PR DESCRIPTION
Tests to prevent regressions, for example, the following one caused by an update in SDK:

Related: https://github.com/dart-lang/webdev/issues/1372