### PR TITLE
Avoid OOM errors when event traffic is high

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -847,15 +847,15 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   Future<void> parseDebugEvent(DebugEvent debugEvent) async {
     if (terminatingIsolates) return;
 
-    var isolate = _inspector?.isolate;
-    if (isolate == null) return;
+    var isolateRef = _inspector?.isolateRef;
+    if (isolateRef == null) return;
 
     _streamNotify(
         EventStreams.kExtension,
         Event(
             kind: EventKind.kExtension,
             timestamp: DateTime.now().millisecondsSinceEpoch,
-            isolate: isolate)
+            isolate: isolateRef)
           ..extensionKind = debugEvent.kind
           ..extensionData = ExtensionData.parse(
               jsonDecode(debugEvent.eventData) as Map<String, dynamic>));
@@ -868,15 +868,17 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
     var isolate = _inspector?.isolate;
     if (isolate == null) return;
-
     var service = registerEvent.eventData;
     isolate.extensionRPCs.add(service);
+
+    var isolateRef = _inspector?.isolateRef;
+    if (isolateRef == null) return;
     _streamNotify(
         EventStreams.kIsolate,
         Event(
             kind: EventKind.kServiceExtensionAdded,
             timestamp: DateTime.now().millisecondsSinceEpoch,
-            isolate: isolate)
+            isolate: isolateRef)
           ..extensionRPC = service);
   }
 


### PR DESCRIPTION
Revert to attaching the IsolateRef instead of the Isolate to the postEvent
and registerExtension events. The Isolate is much larger and was causing
systems to run out of memory when event traffic is high like in Flutter
where they are sent on every animation frame.

See: https://github.com/flutter/flutter/issues/87100