### PR TITLE
Prep to publish dwds

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 11.2.2
+
+- Depend on `dds` version `2.1.1`.
+- Depend on `vm_service` vesrion `7.2.0`.
+
 ## 11.2.1
 
 - Recover from used port errors when starting debug service.

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -160,7 +160,10 @@ class ClassHelper extends Domain {
           name: name,
           owner: classRef,
           isConst: descriptor['isConst'] as bool,
-          isStatic: descriptor['isStatic'] as bool));
+          isStatic: descriptor['isStatic'] as bool,
+          // TODO(annagrin): get information about getters and setters from symbols.
+          // https://github.com/dart-lang/sdk/issues/46723
+          implicit: false));
     });
     var fieldRefs = <FieldRef>[];
     var fieldDescriptors = classDescriptor['fields'] as Map<String, dynamic>;

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -414,7 +414,10 @@ class InstanceHelper extends Domain {
               // TODO(alanknight): The right ClassRef
               owner: classRefForUnknown,
               isConst: false,
-              isStatic: false)
+              isStatic: false,
+              // TODO(annagrin): get information about getters and setters from symbols.
+              // https://github.com/dart-lang/sdk/issues/46723
+              implicit: false)
           ..closureContext = (ContextRef(length: 0, id: createId()));
       default:
         // Return null for an unsupported type. This is likely a JS construct.

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '11.2.1';
+const packageVersion = '11.2.2';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 11.2.1
+version: 11.2.2
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM
@@ -14,7 +14,7 @@ dependencies:
   built_collection: ^5.0.0
   built_value: '>=6.7.0 <9.0.0'
   crypto: '>=2.0.6 <4.0.0'
-  dds: ^2.0.0
+  dds: ^2.1.1
   http: '>=0.12.0 <0.14.0'
   http_multi_server: ^3.0.0
   logging: '>=0.11.3 <2.0.0'
@@ -32,7 +32,7 @@ dependencies:
   source_maps: ^0.10.0
   sse: ^4.1.0
   # We pin the version because we implement the interface.
-  vm_service: 7.1.1
+  vm_service: 7.2.0
   web_socket_channel: ^2.0.0
   webkit_inspection_protocol: ^1.0.0
 

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -7,7 +7,11 @@ description: >-
   service protocol.
 
 environment:
+<<<<<<< HEAD
   sdk: ">=2.13.0 <3.0.0"
+=======
+  sdk: ">=2.13.4 <3.0.0"
+>>>>>>> 7c6a989 (Update versions and build)
 
 dependencies:
   async: ^2.3.0

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -7,11 +7,7 @@ description: >-
   service protocol.
 
 environment:
-<<<<<<< HEAD
   sdk: ">=2.13.0 <3.0.0"
-=======
-  sdk: ">=2.13.4 <3.0.0"
->>>>>>> 7c6a989 (Update versions and build)
 
 dependencies:
   async: ^2.3.0


### PR DESCRIPTION
- Depend on `dds` version `2.1.1`.
- Depend on `vm_service` vesrion `7.2.0`.
- Prep to publish dwds.

Needed for: https://github.com/flutter/flutter/issues/86361