### PR TITLE
Do not use pub.dart.snapshot

### DIFF
--- a/dwds/test/fixtures/utilities.dart
+++ b/dwds/test/fixtures/utilities.dart
@@ -20,8 +20,8 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
         // the process will start in a disjoint cmd without access to
         // STDIO. We also want to ensure the version of pub is consistent with
         // the SDK that was used to launch webdev.
-        [dartPath, pubSnapshot]
-          ..addAll(['run', 'build_runner', 'daemon'])
+        [dartPath, dartdevSnapshot]
+          ..addAll(['pub', 'run', 'build_runner', 'daemon'])
           ..addAll(options),
         logHandler: logHandler);
 
@@ -36,8 +36,8 @@ final String _sdkDir = (() {
 
 final String dartSdkPath = _sdkDir;
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
-final String pubSnapshot =
-    p.join(_sdkDir, 'bin', 'snapshots', 'pub.dart.snapshot');
+final String dartdevSnapshot =
+    p.join(_sdkDir, 'bin', 'snapshots', 'dartdev.dart.snapshot');
 final String pubPath =
     p.join(_sdkDir, 'bin', Platform.isWindows ? 'pub.bat' : 'pub');
 

--- a/dwds/test/fixtures/utilities.dart
+++ b/dwds/test/fixtures/utilities.dart
@@ -20,8 +20,8 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
         // the process will start in a disjoint cmd without access to
         // STDIO. We also want to ensure the version of pub is consistent with
         // the SDK that was used to launch webdev.
-        [dartPath, dartdevSnapshot]
-          ..addAll(['pub', 'run', 'build_runner', 'daemon'])
+        [dartPath]
+          ..addAll(['run', 'build_runner', 'daemon'])
           ..addAll(options),
         logHandler: logHandler);
 
@@ -36,8 +36,6 @@ final String _sdkDir = (() {
 
 final String dartSdkPath = _sdkDir;
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
-final String dartdevSnapshot =
-    p.join(_sdkDir, 'bin', 'snapshots', 'dartdev.dart.snapshot');
 
 /// Returns the port of the daemon asset server.
 int daemonPort(String workingDirectory) {

--- a/dwds/test/fixtures/utilities.dart
+++ b/dwds/test/fixtures/utilities.dart
@@ -16,10 +16,6 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
         List<String> options, Function(ServerLog) logHandler) =>
     BuildDaemonClient.connect(
         workingDirectory,
-        // On Windows we need to call the snapshot directly otherwise
-        // the process will start in a disjoint cmd without access to
-        // STDIO. We also want to ensure the version of pub is consistent with
-        // the SDK that was used to launch webdev.
         [dartPath]
           ..addAll(['run', 'build_runner', 'daemon'])
           ..addAll(options),

--- a/dwds/test/fixtures/utilities.dart
+++ b/dwds/test/fixtures/utilities.dart
@@ -16,7 +16,11 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
         List<String> options, Function(ServerLog) logHandler) =>
     BuildDaemonClient.connect(
         workingDirectory,
-        [dartPath]
+        // On Windows we need to call the snapshot directly otherwise
+        // the process will start in a disjoint cmd without access to
+        // STDIO. We also want to ensure the version of pub is consistent with
+        // the SDK that was used to launch webdev.
+        [dartPath, dartdevSnapshot]
           ..addAll(['pub', 'run', 'build_runner', 'daemon'])
           ..addAll(options),
         logHandler: logHandler);
@@ -32,6 +36,8 @@ final String _sdkDir = (() {
 
 final String dartSdkPath = _sdkDir;
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
+final String dartdevSnapshot =
+    p.join(_sdkDir, 'bin', 'snapshots', 'dartdev.dart.snapshot');
 
 /// Returns the port of the daemon asset server.
 int daemonPort(String workingDirectory) {

--- a/dwds/test/fixtures/utilities.dart
+++ b/dwds/test/fixtures/utilities.dart
@@ -16,11 +16,7 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
         List<String> options, Function(ServerLog) logHandler) =>
     BuildDaemonClient.connect(
         workingDirectory,
-        // On Windows we need to call the snapshot directly otherwise
-        // the process will start in a disjoint cmd without access to
-        // STDIO. We also want to ensure the version of pub is consistent with
-        // the SDK that was used to launch webdev.
-        [dartPath, dartdevSnapshot]
+        [dartPath]
           ..addAll(['pub', 'run', 'build_runner', 'daemon'])
           ..addAll(options),
         logHandler: logHandler);
@@ -36,10 +32,6 @@ final String _sdkDir = (() {
 
 final String dartSdkPath = _sdkDir;
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
-final String dartdevSnapshot =
-    p.join(_sdkDir, 'bin', 'snapshots', 'dartdev.dart.snapshot');
-final String pubPath =
-    p.join(_sdkDir, 'bin', Platform.isWindows ? 'pub.bat' : 'pub');
 
 /// Returns the port of the daemon asset server.
 int daemonPort(String workingDirectory) {

--- a/frontend_server_common/lib/src/utilities.dart
+++ b/frontend_server_common/lib/src/utilities.dart
@@ -23,6 +23,8 @@ final String dartSdkPath = _sdkDir;
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
 final String pubSnapshot =
     p.join(_sdkDir, 'bin', 'snapshots', 'pub.dart.snapshot');
+final String dartdevSnapshot =
+    p.join(_sdkDir, 'bin', 'snapshots', 'dartdev.dart.snapshot');
 final String pubPath =
     p.join(_sdkDir, 'bin', Platform.isWindows ? 'pub.bat' : 'pub');
 

--- a/frontend_server_common/lib/src/utilities.dart
+++ b/frontend_server_common/lib/src/utilities.dart
@@ -21,11 +21,5 @@ final String _sdkDir = (() {
 
 final String dartSdkPath = _sdkDir;
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
-final String pubSnapshot =
-    p.join(_sdkDir, 'bin', 'snapshots', 'pub.dart.snapshot');
-final String dartdevSnapshot =
-    p.join(_sdkDir, 'bin', 'snapshots', 'dartdev.dart.snapshot');
-final String pubPath =
-    p.join(_sdkDir, 'bin', Platform.isWindows ? 'pub.bat' : 'pub');
 
 const fs.FileSystem fileSystem = LocalFileSystem();

--- a/webdev/lib/src/daemon_client.dart
+++ b/webdev/lib/src/daemon_client.dart
@@ -22,8 +22,8 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
         // the process will start in a disjoint cmd without access to
         // STDIO. We also want to ensure the version of pub is consistent with
         // the SDK that was used to launch webdev.
-        [dartPath, dartdevSnapshot]
-          ..addAll(['pub', 'run', 'build_runner', 'daemon'])
+        [dartPath]
+          ..addAll(['run', 'build_runner', 'daemon'])
           ..addAll(options),
         logHandler: logHandler);
 

--- a/webdev/lib/src/daemon_client.dart
+++ b/webdev/lib/src/daemon_client.dart
@@ -22,8 +22,8 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
         // the process will start in a disjoint cmd without access to
         // STDIO. We also want to ensure the version of pub is consistent with
         // the SDK that was used to launch webdev.
-        [dartPath, pubSnapshot]
-          ..addAll(['run', 'build_runner', 'daemon'])
+        [dartPath, dartdevSnapshot]
+          ..addAll(['pub', 'run', 'build_runner', 'daemon'])
           ..addAll(options),
         logHandler: logHandler);
 

--- a/webdev/lib/src/daemon_client.dart
+++ b/webdev/lib/src/daemon_client.dart
@@ -22,7 +22,7 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
         // the process will start in a disjoint cmd without access to
         // STDIO. We also want to ensure the version of pub is consistent with
         // the SDK that was used to launch webdev.
-        [dartPath, dartdevSnapshot]
+        [dartPath]
           ..addAll(['pub', 'run', 'build_runner', 'daemon'])
           ..addAll(options),
         logHandler: logHandler);

--- a/webdev/lib/src/daemon_client.dart
+++ b/webdev/lib/src/daemon_client.dart
@@ -18,10 +18,6 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
         List<String> options, Function(ServerLog) logHandler) =>
     BuildDaemonClient.connect(
         workingDirectory,
-        // On Windows we need to call the snapshot directly otherwise
-        // the process will start in a disjoint cmd without access to
-        // STDIO. We also want to ensure the version of pub is consistent with
-        // the SDK that was used to launch webdev.
         [dartPath]
           ..addAll(['run', 'build_runner', 'daemon'])
           ..addAll(options),

--- a/webdev/lib/src/daemon_client.dart
+++ b/webdev/lib/src/daemon_client.dart
@@ -22,7 +22,7 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
         // the process will start in a disjoint cmd without access to
         // STDIO. We also want to ensure the version of pub is consistent with
         // the SDK that was used to launch webdev.
-        [dartPath]
+        [dartPath, dartdevSnapshot]
           ..addAll(['pub', 'run', 'build_runner', 'daemon'])
           ..addAll(options),
         logHandler: logHandler);

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -55,7 +55,7 @@ dev_dependencies:
 }
 
 Future _runPubDeps() async {
-  var result = Process.runSync(pubPath, ['deps']);
+  var result = Process.runSync(dartPath, ['pub', 'deps']);
 
   if (result.exitCode == 65 || result.exitCode == 66) {
     throw PackageException(
@@ -64,8 +64,8 @@ Future _runPubDeps() async {
 
   if (result.exitCode != 0) {
     throw ProcessException(
-        pubPath,
-        ['deps'],
+        dartPath,
+        ['pub', 'deps'],
         '***OUT***\n${result.stdout}\n***ERR***\n${result.stderr}\n***',
         exitCode);
   }

--- a/webdev/lib/src/util.dart
+++ b/webdev/lib/src/util.dart
@@ -20,3 +20,5 @@ final String _sdkDir = (() {
 })();
 
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
+final String dartdevSnapshot =
+    p.join(_sdkDir, 'bin', 'snapshots', 'dartdev.dart.snapshot');

--- a/webdev/lib/src/util.dart
+++ b/webdev/lib/src/util.dart
@@ -20,7 +20,3 @@ final String _sdkDir = (() {
 })();
 
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
-final String dartdevSnapshot =
-    p.join(_sdkDir, 'bin', 'snapshots', 'dartdev.dart.snapshot');
-final String pubPath =
-    p.join(_sdkDir, 'bin', Platform.isWindows ? 'pub.bat' : 'pub');

--- a/webdev/lib/src/util.dart
+++ b/webdev/lib/src/util.dart
@@ -20,5 +20,3 @@ final String _sdkDir = (() {
 })();
 
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
-final String dartdevSnapshot =
-    p.join(_sdkDir, 'bin', 'snapshots', 'dartdev.dart.snapshot');

--- a/webdev/lib/src/util.dart
+++ b/webdev/lib/src/util.dart
@@ -20,7 +20,7 @@ final String _sdkDir = (() {
 })();
 
 final String dartPath = p.join(_sdkDir, 'bin', 'dart');
-final String pubSnapshot =
-    p.join(_sdkDir, 'bin', 'snapshots', 'pub.dart.snapshot');
+final String dartdevSnapshot =
+    p.join(_sdkDir, 'bin', 'snapshots', 'dartdev.dart.snapshot');
 final String pubPath =
     p.join(_sdkDir, 'bin', Platform.isWindows ? 'pub.bat' : 'pub');

--- a/webdev/test/daemon/utils.dart
+++ b/webdev/test/daemon/utils.dart
@@ -43,7 +43,7 @@ Future<String> prepareWorkspace() async {
   var exampleDirectory =
       p.absolute(p.join(p.current, '..', 'fixtures', '_webdevSmoke'));
 
-  var process = await TestProcess.start(pubPath, ['upgrade'],
+  var process = await TestProcess.start(dartPath, ['pub', 'upgrade'],
       workingDirectory: exampleDirectory, environment: getPubEnvironment());
 
   await process.shouldExit(0);

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -42,12 +42,12 @@ void main() {
     soundExampleDirectory =
         p.absolute(p.join(p.current, '..', 'fixtures', '_webdevSoundSmoke'));
 
-    var process = await TestProcess.start(pubPath, ['upgrade'],
+    var process = await TestProcess.start(dartPath, ['pub', 'upgrade'],
         workingDirectory: exampleDirectory, environment: getPubEnvironment());
 
     await process.shouldExit(0);
 
-    process = await TestProcess.start(pubPath, ['upgrade'],
+    process = await TestProcess.start(dartPath, ['pub', 'upgrade'],
         workingDirectory: soundExampleDirectory,
         environment: getPubEnvironment());
 


### PR DESCRIPTION
- `pub.dart.shapshot` was removed starting from 2.15.0-49.0.dev
- replace it by `dartdev.dart.snapshot pub` in webdev and tests
  - all versions 2.13.0 and higher contain this snapshot so
    no need to check for sdk version as it is guaranteed to be
    2.13.0 or higher by our min sdk constraints.

SDK commit: https://github.com/dart-lang/sdk/commit/ae81cd5dabe63f6b6dd2edc34a8583d2e772e7d6