### PR TITLE
Fix test break due to changed compiler error, do not use pub directly

### DIFF
--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -503,10 +503,8 @@ void main() async {
 
               expect(
                   error,
-                  isA<ErrorRef>().having(
-                      (instance) => instance.message,
-                      'message',
-                      matches('CompilationError: Getter not found:.*typo')));
+                  isA<ErrorRef>().having((instance) => instance.message,
+                      'message', contains('CompilationError:')));
             });
           });
 

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -31,7 +31,6 @@ import 'logging.dart';
 import 'server.dart';
 import 'utilities.dart';
 
-final _batExt = Platform.isWindows ? '.bat' : '';
 final _exeExt = Platform.isWindows ? '.exe' : '';
 
 const isRPCError = TypeMatcher<RPCError>();
@@ -171,7 +170,7 @@ class TestContext {
             'Could not start ChromeDriver. Is it installed?\nError: $e');
       }
 
-      await Process.run('pub$_batExt', ['upgrade'],
+      await Process.run(dartPath, ['pub', 'upgrade'],
           workingDirectory: workingDirectory);
 
       ExpressionCompiler expressionCompiler;

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -410,7 +410,7 @@ void main() async {
               const TypeMatcher<ErrorRef>().having(
                   (instance) => instance.message,
                   'message',
-                  'CompilationError: Getter not found: \'typo\'.\ntypo\n^^^^'));
+                  contains('CompilationError:')));
         });
       });
     });


### PR DESCRIPTION
- Fix test break due to changed compiler error 
  Make sure the test does not break due to such changes in the future.
-  Do not use pub directly in tests as it is deprecated.