### PR TITLE
Add metrics for devtools IPL

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Update SDK constraint to `>=2.14.0 <3.0.0`
 - Depend on `vm_service` version `7.3.0`.
+- Add metrics for API on the critical path for DevTools IPL.
+- Add metrics for total DevTools IPL.
 
 ## 11.2.3
 

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,8 +1,33 @@
+## 11.3.1-dev
+
+- Add metrics measuring DevTools Initial Page Load time.
+- Add `ext.dwds.sendEvent` service extension to dwds so other tools
+  can send events to the debugger.
+  Event format:
+  ```
+  {
+    'type': '<event type>',
+    'payload': {
+      'screen: '<screen name>',
+      'action: '<action name>',
+    }
+  }
+  ```
+  Currently supported event values:
+  ```
+  {
+    'type: 'DevtoolsEvent',
+    'payload': {
+      'screen': 'debugger'
+      'action': 'screenReady'
+    }
+  }
+  ```
+
 ## 11.3.0
 
 - Update SDK constraint to `>=2.14.0 <3.0.0`
 - Depend on `vm_service` version `7.3.0`.
-- Add metrics measuring DevTools Initial Page Load time.
 
 ## 11.2.3
 

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 - Update SDK constraint to `>=2.14.0 <3.0.0`
 - Depend on `vm_service` version `7.3.0`.
-- Add metrics for API on the critical path for DevTools IPL.
-- Add metrics for total DevTools IPL.
+- Add metrics measuring DevTools Initial Page Load time.
 
 ## 11.2.3
 

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -157,12 +157,16 @@ class DwdsVmClient {
 
     client.registerServiceCallback('ext.dwds.sendEvent', (event) async {
       var type = event['type'] as String;
+      var payload = event['payload'] as Map<String, dynamic>;
       switch (type) {
-        case 'DevtoolsReady':
+        case 'DevtoolsEvent':
           {
-            emitEvent(DwdsEvent.debuggerReady(DateTime.now()
-                .difference(dwdsStats.debuggerStart)
-                .inMilliseconds));
+            var screen = payload == null ? null : payload['screen'];
+            if (screen == 'debugger' && dwdsStats.isFirstDebuggerReady()) {
+              emitEvent(DwdsEvent.debuggerReady(DateTime.now()
+                  .difference(dwdsStats.debuggerStart)
+                  .inMilliseconds));
+            }
           }
       }
       return {'result': Success().toJson()};

--- a/dwds/lib/src/events.dart
+++ b/dwds/lib/src/events.dart
@@ -6,6 +6,30 @@
 
 import 'dart:async';
 
+class DwdsStats {
+  final DateTime debuggerStart;
+  DateTime _debuggerReady;
+
+  DateTime get debuggerReady {
+    return _debuggerReady;
+  }
+
+  set debuggerReady(DateTime value) {
+    if (_debuggerReady != null) return;
+    _debuggerReady = value;
+  }
+
+  int get debuggerReadyElapsed {
+    if (_debuggerReady == null) {
+      throw StateError('debuggerReady is not set in DwdsStats');
+    }
+    return _debuggerReady.millisecondsSinceEpoch -
+        debuggerStart.millisecondsSinceEpoch;
+  }
+
+  DwdsStats(this.debuggerStart);
+}
+
 class DwdsEvent {
   final String type;
   final Map<String, dynamic> payload;

--- a/dwds/lib/src/events.dart
+++ b/dwds/lib/src/events.dart
@@ -7,19 +7,21 @@
 import 'dart:async';
 
 class DwdsStats {
+  /// Timestamp for the point when the user starts the debugger
+  /// by either clicking the debugger extension button or
+  /// starting debugging in the UI.
   final DateTime debuggerStart;
+
+  /// Timestamp for the point when the debugger becomes
+  /// available and fuctional for the user.
   DateTime _debuggerReady;
-
-  DateTime get debuggerReady {
-    return _debuggerReady;
-  }
-
-  set debuggerReady(DateTime value) {
-    if (_debuggerReady != null) return;
-    _debuggerReady = value;
-  }
+  DateTime get debuggerReady => _debuggerReady;
+  set debuggerReady(DateTime value) => _debuggerReady ??= value;
 
   int get debuggerReadyElapsed {
+    if (debuggerStart == null) {
+      throw StateError('debuggerStart is not set in DwdsStats');
+    }
     if (_debuggerReady == null) {
       throw StateError('debuggerReady is not set in DwdsStats');
     }

--- a/dwds/lib/src/events.dart
+++ b/dwds/lib/src/events.dart
@@ -7,26 +7,16 @@
 import 'dart:async';
 
 class DwdsStats {
-  /// Timestamp for the point when the user starts the debugger
-  /// by either clicking the debugger extension button or
-  /// starting debugging in the UI.
+  /// The time when the user starts the debugger.
   final DateTime debuggerStart;
 
-  /// Timestamp for the point when the debugger becomes
-  /// available and fuctional for the user.
-  DateTime _debuggerReady;
-  DateTime get debuggerReady => _debuggerReady;
-  set debuggerReady(DateTime value) => _debuggerReady ??= value;
+  var _isDebuggerReady = false;
 
-  int get debuggerReadyElapsed {
-    if (debuggerStart == null) {
-      throw StateError('debuggerStart is not set in DwdsStats');
-    }
-    if (_debuggerReady == null) {
-      throw StateError('debuggerReady is not set in DwdsStats');
-    }
-    return _debuggerReady.millisecondsSinceEpoch -
-        debuggerStart.millisecondsSinceEpoch;
+  /// Records and returns whether the debugger became ready.
+  bool isFirstDebuggerReady() {
+    final wasReady = _isDebuggerReady;
+    _isDebuggerReady = true;
+    return !wasReady;
   }
 
   DwdsStats(this.debuggerStart);

--- a/dwds/lib/src/events.dart
+++ b/dwds/lib/src/events.dart
@@ -6,6 +6,8 @@
 
 import 'dart:async';
 
+import 'package:vm_service/vm_service.dart';
+
 class DwdsStats {
   /// The time when the user starts the debugger.
   final DateTime debuggerStart;
@@ -22,11 +24,71 @@ class DwdsStats {
   DwdsStats(this.debuggerStart);
 }
 
+class DwdsEventKind {
+  static const String compilerUpdateDependencies =
+      'COMPILER_UPDATE_DEPENDENCIES';
+  static const String devtoolsLaunch = 'DEVTOOLS_LAUNCH';
+  static const String evaluate = 'EVALUATE';
+  static const String evaluateInFrame = 'EVALUATE_IN_FRAME';
+  static const String getIsolate = 'GET_ISOLATE';
+  static const String getScripts = 'GET_SCRIPTS';
+  static const String getSourceReport = 'GET_SOURCE_REPORT';
+  static const String debuggerReady = 'DEBUGGER_READY';
+  static const String getVM = 'GET_VM';
+  static const String resume = 'RESUME';
+
+  DwdsEventKind._();
+}
+
 class DwdsEvent {
   final String type;
   final Map<String, dynamic> payload;
 
   DwdsEvent(this.type, this.payload);
+
+  DwdsEvent.compilerUpdateDependencies(String entrypoint)
+      : this(DwdsEventKind.compilerUpdateDependencies, {
+          'entrypoint': entrypoint,
+        });
+
+  DwdsEvent.devtoolsLaunch() : this(DwdsEventKind.devtoolsLaunch, {});
+
+  DwdsEvent.evaluate(String expression, Response result)
+      : this(DwdsEventKind.evaluate, {
+          'expression': expression,
+          'success': result != null && result is InstanceRef,
+          if (result != null && result is ErrorRef) 'error': result,
+        });
+
+  DwdsEvent.evaluateInFrame(String expression, Response result)
+      : this(DwdsEventKind.evaluateInFrame, {
+          'expression': expression,
+          'success': result != null && result is InstanceRef,
+          if (result != null && result is ErrorRef) 'error': result,
+        });
+
+  DwdsEvent.getIsolate() : this(DwdsEventKind.getIsolate, {});
+
+  DwdsEvent.getScripts() : this(DwdsEventKind.getScripts, {});
+
+  DwdsEvent.getVM() : this(DwdsEventKind.getVM, {});
+
+  DwdsEvent.resume(String step) : this(DwdsEventKind.resume, {'step': step});
+
+  DwdsEvent.getSourceReport() : this(DwdsEventKind.getSourceReport, {});
+
+  DwdsEvent.debuggerReady(int elapsedMilliseconds)
+      : this(DwdsEventKind.debuggerReady, {
+          'elapsedMilliseconds': elapsedMilliseconds,
+        });
+
+  void addException(dynamic exception) {
+    payload['exception'] = exception;
+  }
+
+  void addElapsedTime(int elapsedMilliseconds) {
+    payload['elapsedMilliseconds'] = elapsedMilliseconds;
+  }
 
   @override
   String toString() {

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -518,7 +518,7 @@ class DevHandler {
     // TODO(grouma) - We may want to log the debugServiceUri if we don't launch
     // DevTools so that users can manually connect.
     if (!_serveDevTools) return;
-    emitEvent(DwdsEvent('DEVTOOLS_LAUNCH', {}));
+    emitEvent(DwdsEvent.devtoolsLaunch());
     await remoteDebugger.sendCommand('Target.createTarget', params: {
       'newWindow': true,
       'url': Uri(

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -209,7 +209,6 @@ class DevHandler {
       useSse: false,
       expressionCompiler: _expressionCompiler,
       spawnDds: _spawnDds,
-      dwdsStats: DwdsStats(DateTime.now()),
     );
   }
 
@@ -223,12 +222,13 @@ class DevHandler {
   }
 
   Future<AppDebugServices> loadAppServices(AppConnection appConnection) async {
+    var dwdsStats = DwdsStats(DateTime.now());
     var appId = appConnection.request.appId;
     if (_servicesByAppId[appId] == null) {
       var debugService = await _startLocalDebugService(
           await _chromeConnection(), appConnection);
       var appServices = await _createAppDebugServices(
-          appConnection.request.appId, debugService);
+          appConnection.request.appId, debugService, dwdsStats);
       unawaited(appServices.chromeProxyService.remoteDebugger.onClose.first
           .whenComplete(() async {
         await appServices.close();
@@ -435,8 +435,8 @@ class DevHandler {
   }
 
   Future<AppDebugServices> _createAppDebugServices(
-      String appId, DebugService debugService) async {
-    var webdevClient = await DwdsVmClient.create(debugService);
+      String appId, DebugService debugService, DwdsStats dwdsStats) async {
+    var webdevClient = await DwdsVmClient.create(debugService, dwdsStats);
     if (_spawnDds) {
       await debugService.startDartDevelopmentService();
     }
@@ -464,6 +464,7 @@ class DevHandler {
     // Waits for a `DevToolsRequest` to be sent from the extension background
     // when the extension is clicked.
     extensionDebugger.devToolsRequestStream.listen((devToolsRequest) async {
+      var dwdsStats = DwdsStats(DateTime.now());
       var connection = _appConnectionByAppId[devToolsRequest.appId];
       if (connection == null) {
         // TODO(grouma) - Ideally we surface this warning to the extension so
@@ -491,10 +492,12 @@ class DevHandler {
           useSse: _useSseForDebugProxy,
           expressionCompiler: _expressionCompiler,
           spawnDds: _spawnDds,
-          dwdsStats: DwdsStats(DateTime.now()),
         );
-        var appServices =
-            await _createAppDebugServices(devToolsRequest.appId, debugService);
+        var appServices = await _createAppDebugServices(
+          devToolsRequest.appId,
+          debugService,
+          dwdsStats,
+        );
         var encodedUri = await debugService.encodedUri;
         extensionDebugger.sendEvent('dwds.encodedUri', encodedUri);
         unawaited(appServices.chromeProxyService.remoteDebugger.onClose.first

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -209,6 +209,7 @@ class DevHandler {
       useSse: false,
       expressionCompiler: _expressionCompiler,
       spawnDds: _spawnDds,
+      dwdsStats: DwdsStats(DateTime.now()),
     );
   }
 
@@ -490,6 +491,7 @@ class DevHandler {
           useSse: _useSseForDebugProxy,
           expressionCompiler: _expressionCompiler,
           spawnDds: _spawnDds,
+          dwdsStats: DwdsStats(DateTime.now()),
         );
         var appServices =
             await _createAppDebugServices(devToolsRequest.appId, debugService);

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -540,14 +540,9 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   @override
   Future<Obj> getObject(String isolateId, String objectId,
       {int offset, int count}) async {
-    return await _withEvent(() async {
-      await isInitialized;
-      return await _inspector?.getObject(isolateId, objectId,
-          offset: offset, count: count);
-    },
-        (result) => DwdsEvent('GET_OBJECT', {
-              if (result != null) 'type': result.type,
-            }));
+    await isInitialized;
+    return _inspector?.getObject(isolateId, objectId,
+        offset: offset, count: count);
   }
 
   @override

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -575,10 +575,15 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
           reportLines: reportLines);
     }, (result) => DwdsEvent('GET_SOURCE_REPORT', {}));
 
-    if (_dwdsStats.debuggerReady == null) {
-      _dwdsStats.debuggerReady = DateTime.now();
+    // This metric is an approximation of the "debugger is ready"
+    // time when using devtools. It currently has flaws:
+    // - it does not make sense for other debugger uses
+    // - is also can be invalidated later.
+    // Issue: https://github.com/dart-lang/webdev/issues/1406
+    if (_dwdsStats.isFirstDebuggerReady()) {
       emitEvent(DwdsEvent('DEBUGGER_READY', {
-        'elapsedMilliseconds': _dwdsStats.debuggerReadyElapsed,
+        'elapsedMilliseconds':
+            DateTime.now().difference(_dwdsStats.debuggerStart).inMilliseconds,
       }));
     }
 

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -23,6 +23,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import '../../dwds.dart';
 import '../debugging/execution_context.dart';
 import '../debugging/remote_debugger.dart';
+import '../events.dart';
 import '../utilities/shared.dart';
 import 'chrome_proxy_service.dart';
 
@@ -213,7 +214,8 @@ class DebugService {
       void Function(Map<String, dynamic>) onResponse,
       bool spawnDds = true,
       bool useSse,
-      ExpressionCompiler expressionCompiler}) async {
+      ExpressionCompiler expressionCompiler,
+      DwdsStats dwdsStats}) async {
     useSse ??= false;
     var chromeProxyService = await ChromeProxyService.create(
         remoteDebugger,
@@ -222,7 +224,8 @@ class DebugService {
         loadStrategy,
         appConnection,
         executionContext,
-        expressionCompiler);
+        expressionCompiler,
+        dwdsStats);
     var authToken = _makeAuthToken();
     var serviceExtensionRegistry = ServiceExtensionRegistry();
     Handler handler;

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -23,7 +23,6 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import '../../dwds.dart';
 import '../debugging/execution_context.dart';
 import '../debugging/remote_debugger.dart';
-import '../events.dart';
 import '../utilities/shared.dart';
 import 'chrome_proxy_service.dart';
 
@@ -214,8 +213,7 @@ class DebugService {
       void Function(Map<String, dynamic>) onResponse,
       bool spawnDds = true,
       bool useSse,
-      ExpressionCompiler expressionCompiler,
-      DwdsStats dwdsStats}) async {
+      ExpressionCompiler expressionCompiler}) async {
     useSse ??= false;
     var chromeProxyService = await ChromeProxyService.create(
         remoteDebugger,
@@ -224,8 +222,7 @@ class DebugService {
         loadStrategy,
         appConnection,
         executionContext,
-        expressionCompiler,
-        dwdsStats);
+        expressionCompiler);
     var authToken = _makeAuthToken();
     var serviceExtensionRegistry = ServiceExtensionRegistry();
     Handler handler;

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '11.3.0';
+const packageVersion = '11.3.1-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `pub run build_runner build`.
-version: 11.3.0
+version: 11.3.1-dev
 homepage: https://github.com/dart-lang/webdev/tree/master/dwds
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -98,7 +98,7 @@ void main() {
     var response = await context.debugConnection.vmService
         .callServiceExtension('ext.dwds.sendEvent', args: {
       'type': 'DevtoolsEvent',
-      'payload': {'screen': 'debugger'},
+      'payload': {'screen': 'debugger', 'action': 'screenReady'},
     });
     expect(response.type, 'Success');
     await events;

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -25,8 +25,14 @@ WipConnection get tabConnection => context.tabConnection;
 final context = TestContext();
 
 void main() {
+  Future initialEvents;
+
   setUpAll(() async {
     setCurrentLogWriter();
+    initialEvents = expectLater(
+        eventStream,
+        emitsThrough(predicate((DwdsEvent event) =>
+            event.type == 'COMPILER_UPDATE_DEPENDENCIES')));
     await context.setUp(
       serveDevTools: true,
       enableExpressionEvaluation: true,
@@ -99,6 +105,10 @@ void main() {
         expression,
       );
       await events;
+    });
+
+    test('emits COMPILER_UPDATE_DEPENDENCIES event', () async {
+      await initialEvents;
     });
 
     test('emits EVALUATE events on evaluation failure', () async {

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -88,9 +88,7 @@ void main() {
     await events;
   });
 
-  test(
-      'can receive DevtoolsReady event and emit DEBUGGER_READY '
-      'event through service extension', () async {
+  test('can receive DevtoolsEvent and emit DEBUGGER_READY event', () async {
     var events = expectLater(
         context.testServer.dwds.events,
         emitsThrough(predicate((DwdsEvent event) =>
@@ -99,8 +97,8 @@ void main() {
 
     var response = await context.debugConnection.vmService
         .callServiceExtension('ext.dwds.sendEvent', args: {
-      'type': 'DevtoolsReady',
-      'payload': {},
+      'type': 'DevtoolsEvent',
+      'payload': {'screen': 'debugger'},
     });
     expect(response.type, 'Success');
     await events;


### PR DESCRIPTION
Add metrics to track DevTools IPL and VM calls on the critical path to loading DevTools app.
In addition, differentiate between errors returning `ErrorRef` and exceptions from `evaluate` and `evaluateInFrame` calls.

Closes: https://github.com/dart-lang/webdev/issues/1403