### PR TITLE
Change to recognize pageReady dwds event from devtools

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -10,7 +10,7 @@
     'payload': {
       'screen: '<screen name>',
       'action: '<action name>',
-    }
+    },
   }
   ```
   Currently supported event values:
@@ -18,9 +18,9 @@
   {
     'type: 'DevtoolsEvent',
     'payload': {
-      'screen': 'debugger'
-      'action': 'screenReady'
-    }
+      'screen': 'debugger',
+      'action': 'pageReady',
+    },
   }
   ```
 

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -9,8 +9,8 @@
     'type': '<event type>',
     'payload': {
       'screen: '<screen name>',
-      'action: '<action name>',
-    },
+      'action: '<action name>'
+    }
   }
   ```
   Currently supported event values:
@@ -19,8 +19,8 @@
     'type: 'DevtoolsEvent',
     'payload': {
       'screen': 'debugger',
-      'action': 'pageReady',
-    },
+      'action': 'pageReady'
+    }
   }
   ```
 

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -203,12 +203,14 @@ void _processSendEvent(Map<String, dynamic> event,
       {
         var screen = payload == null ? null : payload['screen'];
         var action = payload == null ? null : payload['action'];
-        if (screen == 'debugger' &&
-            action == 'screenReady' &&
-            dwdsStats.isFirstDebuggerReady()) {
-          emitEvent(DwdsEvent.debuggerReady(DateTime.now()
-              .difference(dwdsStats.debuggerStart)
-              .inMilliseconds));
+        if (screen == 'debugger' && action == 'pageReady') {
+          if (dwdsStats.isFirstDebuggerReady()) {
+            emitEvent(DwdsEvent.debuggerReady(DateTime.now()
+                .difference(dwdsStats.debuggerStart)
+                .inMilliseconds));
+          } else {
+            _logger.warning('Ignoring already received event: $event');
+          }
         } else {
           _logger.warning('Ignoring unknown event: $event');
         }

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -74,10 +74,12 @@ void main() {
 
   test('emits DEBUGGER_READY event', () async {
     await expectEventDuring(
-      matchesEvent(DwdsEventKind.debuggerReady, {}),
+      matchesEvent(DwdsEventKind.debuggerReady, {
+        'elapsedMilliseconds': isNotNull,
+      }),
       () => keyboard.sendChord([Keyboard.alt, 'd']),
     );
-  }, skip: 'https://github.com/dart-lang/webdev/issues/1406');
+  });
 
   test('events can be listened to multiple times', () async {
     events.listen((_) {});
@@ -90,18 +92,6 @@ void main() {
         () => vmService.callServiceExtension('ext.dwds.emitEvent', args: {
               'type': 'foo-event',
               'payload': {'data': 1234},
-            }));
-    expect(response.type, 'Success');
-  });
-
-  test('can receive DevtoolsEvent and emit DEBUGGER_READY event', () async {
-    final response = await expectEventDuring(
-        matchesEvent(DwdsEventKind.debuggerReady, {
-          'elapsedMilliseconds': isNotNull,
-        }),
-        () => vmService.callServiceExtension('ext.dwds.sendEvent', args: {
-              'type': 'DevtoolsEvent',
-              'payload': {'screen': 'debugger', 'action': 'screenReady'},
             }));
     expect(response.type, 'Success');
   });
@@ -275,7 +265,7 @@ void main() {
 
     test('emits GET_SCRIPTS events', () async {
       await expectEventDuring(
-          matchesEvent(DwdsEventKind.getSourceReport, {
+          matchesEvent(DwdsEventKind.getScripts, {
             'elapsedMilliseconds': isNotNull,
           }),
           () => service.getScripts(isolateId));

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -79,7 +79,9 @@ void main() {
       }),
       () => keyboard.sendChord([Keyboard.alt, 'd']),
     );
-  });
+  },
+      skip: 'Enable after publishing of '
+          'https://github.com/flutter/devtools/pull/3346');
 
   test('events can be listened to multiple times', () async {
     events.listen((_) {});


### PR DESCRIPTION
- Change to recognize pageReady dwds event from devtools
  see: https://github.com/flutter/devtools/pull/3355

- Update tests
Closes: https://github.com/dart-lang/webdev/issues/1406

Note that this change needs https://github.com/flutter/devtools/pull/3346 to actually send devtools IPL events, will be a noop for earlier versions of devtools.