### PR TITLE
Return only scripts included in a library for library object

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Various VM API
   - Hot restart
   - Http request handling exceptions
+- Only return scripts included in the library with Library object.
 - Add `ext.dwds.sendEvent` service extension to dwds so other tools
   can send events to the debugger.
   Event format:

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -235,7 +235,7 @@ class AppInspector extends Domain {
       String isolateId, String targetId, String expression,
       {Map<String, String> scope}) async {
     scope ??= {};
-    var library = await _getLibrary(isolateId, targetId);
+    var library = await getLibrary(isolateId, targetId);
     if (library == null) {
       throw UnsupportedError(
           'Evaluate is only supported when `targetId` is a library.');
@@ -343,11 +343,7 @@ function($argsString) {
     return _jsCallFunction(function, arguments);
   }
 
-  Future<Library> getLibrary(String isolateId, String objectId) {
-    return _getLibrary(isolateId, objectId);
-  }
-
-  Future<Library> _getLibrary(String isolateId, String objectId) async {
+  Future<Library> getLibrary(String isolateId, String objectId) async {
     if (isolateId != isolate.id) return null;
     var libraryRef = await libraryHelper.libraryRefFor(objectId);
     if (libraryRef == null) return null;
@@ -357,7 +353,7 @@ function($argsString) {
   Future<Obj> getObject(String isolateId, String objectId,
       {int offset, int count}) async {
     try {
-      var library = await _getLibrary(isolateId, objectId);
+      var library = await getLibrary(isolateId, objectId);
       if (library != null) {
         return library;
       }

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -118,7 +118,7 @@ class LibraryHelper extends Domain {
         uri: libraryRef.uri,
         debuggable: true,
         dependencies: [],
-        scripts: await inspector.scriptRefs,
+        scripts: await inspector.scriptRefsForLibrary(libraryRef.id),
         variables: [],
         functions: [],
         classes: classRefs,

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -425,12 +425,14 @@ void main() {
         var library =
             await service.getObject(isolate.id, rootLibrary.id) as Library;
         expect(library.scripts, hasLength(2));
-        expect(library.scripts, [
-          predicate((ScriptRef s) =>
-              s.uri == 'org-dartlang-app:///example/hello_world/main.dart'),
-          predicate((ScriptRef s) =>
-              s.uri == 'org-dartlang-app:///example/hello_world/part.dart'),
-        ]);
+        expect(
+            library.scripts,
+            unorderedEquals([
+              predicate((ScriptRef s) =>
+                  s.uri == 'org-dartlang-app:///example/hello_world/main.dart'),
+              predicate((ScriptRef s) =>
+                  s.uri == 'org-dartlang-app:///example/hello_world/part.dart'),
+            ]));
       });
 
       test('Can get the same library in parallel', () async {


### PR DESCRIPTION
We used to return all script refs with a library object. Change that to only include script refs from the same library.

Closes: https://github.com/dart-lang/webdev/issues/1422