### PR TITLE
Replaced pedantic by lints

### DIFF
--- a/dwds/debug_extension/pubspec.yaml
+++ b/dwds/debug_extension/pubspec.yaml
@@ -1,7 +1,6 @@
 name: extension
 publish_to: none
 version: 1.23.0
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-
   A chrome extension for Dart debugging.

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -9,7 +9,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';

--- a/dwds/lib/src/handlers/socket_connections.dart
+++ b/dwds/lib/src/handlers/socket_connections.dart
@@ -7,7 +7,6 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:sse/server/sse_handler.dart';

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -9,7 +9,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart' hide LogRecord;
-import 'package:pedantic/pedantic.dart';
 import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -12,7 +12,6 @@ import 'dart:typed_data';
 
 import 'package:dds/dds.dart';
 import 'package:logging/logging.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf.dart' hide Response;
 import 'package:shelf_web_socket/shelf_web_socket.dart';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   meta: ^1.1.7
   package_config: ^2.0.0
   path: ^1.6.0
-  pedantic: ^1.5.0
   pool: ^1.4.0
   pub_semver: ^2.0.0
   shelf: '>=0.7.0 <2.0.0'
@@ -36,6 +35,7 @@ dependencies:
   vm_service: 7.3.0
   web_socket_channel: ^2.0.0
   webkit_inspection_protocol: ^1.0.0
+  lints: ^1.0.1
 
 dev_dependencies:
   args: ^2.0.0

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -15,7 +15,6 @@ import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
-import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';

--- a/dwds/test/extension_debugger_test.dart
+++ b/dwds/test/extension_debugger_test.dart
@@ -12,7 +12,6 @@ import 'package:dwds/data/devtools_request.dart';
 import 'package:dwds/data/extension_request.dart';
 import 'package:dwds/data/serializers.dart';
 import 'package:dwds/src/servers/extension_debugger.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import 'fixtures/debugger_data.dart';

--- a/dwds/test/run_request_test.dart
+++ b/dwds/test/run_request_test.dart
@@ -10,7 +10,6 @@ import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/services/chrome_proxy_service.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 

--- a/frontend_server_common/lib/src/frontend_server_client.dart
+++ b/frontend_server_common/lib/src/frontend_server_client.dart
@@ -15,7 +15,6 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
-import 'package:pedantic/pedantic.dart';
 import 'package:usage/uuid/uuid.dart';
 
 import 'utilities.dart';

--- a/frontend_server_common/pubspec.yaml
+++ b/frontend_server_common/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
   shelf: ^1.1.4
   package_config: ^2.0.0
   path: ^1.8.0
-  pedantic: ^1.11.0
   usage: ^4.0.0
+  lints: ^1.0.1

--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -10,7 +10,6 @@ import 'dart:io';
 
 import 'package:dwds/data/build_result.dart';
 import 'package:dwds/dwds.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../serve/server_manager.dart';

--- a/webdev/lib/src/serve/handlers/favicon_handler.dart
+++ b/webdev/lib/src/serve/handlers/favicon_handler.dart
@@ -4,10 +4,10 @@
 
 // @dart = 2.9
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:pedantic/pedantic.dart';
 import 'package:shelf/shelf.dart';
 
 Handler interceptFavicon(Handler handler) {

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   http_multi_server: ^3.0.0
   io: ^1.0.0
   logging: ^1.0.0
-  pedantic: ^1.5.0
   meta: ^1.1.2
   path: ^1.5.1
   pool: ^1.4.0
@@ -40,6 +39,7 @@ dependencies:
   # devtools_server indirectly depends on devtools so keep this around.
   devtools: ^2.0.0
   devtools_server: ^2.0.0
+  lints: ^1.0.1
 
 dev_dependencies:
   build: ^2.0.0


### PR DESCRIPTION
Pedantic is deprecated, so in this commit I replaced pedantic by lints which is new recommended linter.