### PR TITLE
Modify JS object check for static interop

### DIFF
--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -652,12 +652,16 @@ class Debugger extends Domain {
   }
 }
 
-bool isNativeJsObject(InstanceRef instanceRef) =>
-    // New type representation of JS objects reifies them to JavaScriptObject.
-    (instanceRef?.classRef?.name == 'JavaScriptObject' &&
-        instanceRef?.classRef?.library?.uri == 'dart:_interceptors') ||
-    // Old type representation still needed to support older SDK versions.
-    instanceRef?.classRef?.name == 'NativeJavaScriptObject';
+bool isNativeJsObject(InstanceRef instanceRef) {
+  // New type representation of JS objects reifies them to a type suffixed with
+  // JavaScriptObject.
+  var className = instanceRef?.classRef?.name;
+  return (className != null &&
+          className.endsWith('JavaScriptObject') &&
+          instanceRef?.classRef?.library?.uri == 'dart:_interceptors') ||
+      // Old type representation still needed to support older SDK versions.
+      className == 'NativeJavaScriptObject';
+}
 
 /// Returns the Dart line number for the provided breakpoint.
 int _lineNumberFor(Breakpoint breakpoint) =>


### PR DESCRIPTION
Static interop changes reorganize the type hierarchy such that interop objects are now reified as "LegacyJavaScriptObject". For more context, see this stack of changes that's in the pipeline: https://dart-review.googlesource.com/c/sdk/+/215949 (the relevant bits are in `sdk/lib/_internal/js_dev_runtime/private/interceptors.dart`).