### PR TITLE
Reliably find unused port to start extension backend http service on

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -12,6 +12,7 @@
   flutter tools and webdev.
 
 - Fix chrome detection in iPhone emulation mode in chrome or edge browsers.
+- Reliably find unused port for extension backend http service.
 
 ## 11.4.0
 

--- a/dwds/lib/src/servers/extension_backend.dart
+++ b/dwds/lib/src/servers/extension_backend.dart
@@ -8,7 +8,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:async/async.dart';
-import 'package:http_multi_server/http_multi_server.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 
@@ -54,7 +53,7 @@ class ExtensionBackend {
       }
       return Response.notFound('');
     }).add(_socketHandler.handler);
-    var server = await HttpMultiServer.bind(hostname, 0);
+    var server = await startHttpServer(hostname);
     serveHttpRequests(server, cascade.handler, (e, s) {
       _logger.warning('Error serving requests', e);
       emitEvent(DwdsEvent.httpRequestException('ExtensionBackend', '$e:$s'));


### PR DESCRIPTION
We start extension backend http server with port 0, which creates flakes
in flutter web tests. Find an unused port instead.

Closes: https://github.com/dart-lang/webdev/issues/1450