### PR TITLE
Don't fetch range if the object has no length

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Fix chrome detection in iPhone emulation mode in chrome or edge browsers.
 - Reliably find unused port for extension backend http service.
+- Ignore offset / count parameters in getObject if the object has no length
 
 ## 11.4.0
 

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -362,6 +362,8 @@ class Debugger extends Domain {
   /// List/Map and [offset] and [count] should indicate the desired range.
   Future<RemoteObject> _subrange(
       String id, int offset, int count, int length) async {
+    assert(offset != null);
+    assert(length != null);
     // TODO(#809): Sometimes we already know the type of the object, and
     // we could take advantage of that to short-circuit.
     var receiver = remoteObjectFor(id);
@@ -395,12 +397,11 @@ class Debugger extends Domain {
   /// Note that the property names are JS names, e.g.
   /// Symbol(DartClass.actualName) and will need to be converted. For a system
   /// List or Map, [offset] and/or [count] can be provided to indicate a desired
-  /// range of entries. If those are provided, then [length] should also be
-  /// provided to indicate the total length of the List/Map.
+  /// range of entries. They will be ignored if there is no [length].
   Future<List<Property>> getProperties(String objectId,
       {int offset, int count, int length}) async {
     var rangeId = objectId;
-    if (offset != null || count != null) {
+    if (length != null && (offset != null || count != null)) {
       var range = await _subrange(objectId, offset ?? 0, count, length);
       rangeId = range.objectId;
     }

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -478,6 +478,40 @@ void main() {
             ]));
       });
 
+      test('Classes with offset', () async {
+        var testClass = await service.getObject(
+                isolate.id, rootLibrary.classes.first.id, offset: 0, count: 0)
+            as Class;
+        expect(
+            testClass.functions,
+            unorderedEquals([
+              predicate((FuncRef f) => f.name == 'message' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'hello' && !f.isStatic),
+              predicate((FuncRef f) => f.name == '_equals' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'hashCode' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'toString' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic),
+              predicate((FuncRef f) => f.name == 'runtimeType' && !f.isStatic),
+            ]));
+        expect(
+            testClass.fields,
+            unorderedEquals([
+              predicate((FieldRef f) =>
+                  f.name == 'message' &&
+                  f.declaredType != null &&
+                  !f.isStatic &&
+                  !f.isConst &&
+                  f.isFinal),
+              predicate((FieldRef f) =>
+                  f.name == 'notFinal' &&
+                  f.declaredType != null &&
+                  !f.isStatic &&
+                  !f.isConst &&
+                  !f.isFinal),
+            ]));
+      });
+
       test('Runtime classes', () async {
         var testClass = await service.getObject(
             isolate.id, 'classes|dart:_runtime|_Type') as Class;


### PR DESCRIPTION
If a client sets the optional parameters offset / count in getObject, but the object they are requesting has no length, then DWDS should ignore those parameters.

Fixes #1439