### PR TITLE
Fixed issues discovered in integration

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -5,12 +5,16 @@
 - Make `ExpressionCompilerService` infer location of `libraries.json` from
   `sdkDir` parameter.
 - Show an alert in the Dart Debug Extension for a multi-app scenario.
+- Fix a bug where `dartEmitDebugEvents` was set as a `String` instead of `bool`
+  in the injected client.
 
 **Breaking changes:**
 
-- Add `sdkDir` argument to `Dwds.start` to help file resolution for sdk uris.
+- Add `sdkDir` and `librariesPath` arguments to `Dwds.start` to help file
+  resolution for sdk uris.
 - Add `emitDebugEvents` argument to `Dwds.start` to suppress emitting debug
   events from the injected client.
+- Replace `sdkRoot` parameter by `sdkDir` in `ExpressionCompilerService`.
 
 ## 11.5.1
 

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -113,6 +113,7 @@ class Dwds {
     bool enableDevtoolsLaunch,
     DevtoolsLauncher devtoolsLauncher,
     Uri sdkDir,
+    Uri librariesPath,
     bool emitDebugEvents,
   }) async {
     hostname ??= 'localhost';
@@ -126,7 +127,7 @@ class Dwds {
     globalLoadStrategy = loadStrategy;
     emitDebugEvents ??= true;
 
-    await DartUri.initialize(sdkDir: sdkDir);
+    await DartUri.initialize(sdkDir: sdkDir, librariesPath: librariesPath);
 
     DevTools devTools;
     Future<String> extensionUri;

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -205,7 +205,7 @@ String _injectedClientSnippet(
       'window.\$dwdsDevHandlerPath = "$devHandlerPath";\n'
       'window.\$dwdsEnableDevtoolsLaunch = $enableDevtoolsLaunch;\n'
       'window.\$dartEntrypointPath = "$entrypointPath";\n'
-      'window.\$dartEmitDebugEvents = "$emitDebugEvents";\n'
+      'window.\$dartEmitDebugEvents = $emitDebugEvents;\n'
       '${loadStrategy.loadClientSnippet(_clientScript)}';
   if (extensionUri != null) {
     injectedBody += 'window.\$dartExtensionUri = "$extensionUri";\n';

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -237,6 +237,7 @@ class _Compiler {
 ///
 /// [_sdkDir] is the path to the SDK installation directory.
 /// [_workerPath] is the path to the DDC worker snapshot.
+/// [_librariesPath] is the path to the libraries.json spec.
 ///
 /// Users need to stop the service by calling [stop].
 class ExpressionCompilerService implements ExpressionCompiler {
@@ -248,12 +249,14 @@ class ExpressionCompilerService implements ExpressionCompiler {
 
   final String _sdkDir;
   final String _workerPath;
+  final String _librariesPath;
 
   ExpressionCompilerService(
       this._address, this._port, this._assetHandler, this._verbose,
-      {String sdkDir, String workerPath})
+      {String sdkDir, String workerPath, String librariesPath})
       : _sdkDir = sdkDir,
-        _workerPath = workerPath;
+        _workerPath = workerPath,
+        _librariesPath = librariesPath;
 
   @override
   Future<ExpressionCompilationResult> compileExpressionToJs(
@@ -280,7 +283,8 @@ class ExpressionCompilerService implements ExpressionCompiler {
     var sdkSummaryPath = soundNullSafety
         ? p.join(sdkSummaryRoot, 'ddc_outline_sound.dill')
         : p.join(sdkSummaryRoot, 'ddc_sdk.dill');
-    var librariesPath = p.join(sdkDir, 'lib', 'libraries.json');
+    var librariesPath =
+        _librariesPath ?? p.join(sdkDir, 'lib', 'libraries.json');
     var workerPath =
         _workerPath ?? p.join(binDir, 'snapshots', 'dartdevc.dart.snapshot');
 

--- a/dwds/lib/src/utilities/dart_uri.dart
+++ b/dwds/lib/src/utilities/dart_uri.dart
@@ -154,11 +154,11 @@ class DartUri {
   static String currentDirectoryUri = '${p.toUri(currentDirectory)}';
 
   /// Record library and script uris to enable resolving library and script paths.
-  static Future<void> initialize({Uri sdkDir}) async {
+  static Future<void> initialize({Uri sdkDir, Uri librariesPath}) async {
     _sdkDir =
         sdkDir ?? p.toUri(p.dirname(p.dirname(Platform.resolvedExecutable)));
 
-    var librariesPath =
+    librariesPath ??=
         p.toUri(p.join(_sdkDir.toFilePath(), 'lib', 'libraries.json'));
     var packagesUri = p.toUri(p.join(currentDirectory, '.packages'));
 


### PR DESCRIPTION
- Some scenarios require libraries.json to be a different path from the
  SDK installation directory, update `DartUri` and `ExpressionCompilerService`
  to allow for that.
- Fix a bug where `dartEmitDebugEvents` was set as a `String` instead of
  `bool` in the injected client.