### PR TITLE
DWDS only sends events if it has stats

### DIFF
--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -154,12 +154,16 @@ void _processSendEvent(Map<String, dynamic> event,
         var action = payload == null ? null : payload['action'];
         if (screen == 'debugger' && action == 'pageReady') {
           if (dwdsStats.isFirstDebuggerReady()) {
-            emitEvent(DwdsEvent.devToolsLoad(DateTime.now()
-                .difference(dwdsStats.devToolsStart)
-                .inMilliseconds));
-            emitEvent(DwdsEvent.debuggerReady(DateTime.now()
-                .difference(dwdsStats.debuggerStart)
-                .inMilliseconds));
+            if (dwdsStats.devToolsStart != null) {
+              emitEvent(DwdsEvent.devToolsLoad(DateTime.now()
+                  .difference(dwdsStats.devToolsStart)
+                  .inMilliseconds));
+            }
+            if (dwdsStats.debuggerStart != null) {
+              emitEvent(DwdsEvent.debuggerReady(DateTime.now()
+                  .difference(dwdsStats.debuggerStart)
+                  .inMilliseconds));
+            }
           } else {
             _logger.warning('Ignoring already received event: $event');
           }


### PR DESCRIPTION
Will hopefully fix https://github.com/dart-lang/webdev/issues/1468. It's hard to reproduce in a dev environment. 

It looks like `devToolsStart` is being set in two places:
* https://github.com/dart-lang/webdev/blob/95b3fd8e6e705a0eaad9ddd06a6dbd235b8b59e4/dwds/lib/src/handlers/dev_handler.dart#L367
* https://github.com/dart-lang/webdev/blob/95b3fd8e6e705a0eaad9ddd06a6dbd235b8b59e4/dwds/lib/src/handlers/dev_handler.dart#L515

Both of which happen right before `_launchDevTools` is called. I believe this means `devToolsStart` is set when DevTools is launched programmatically (eg, by clicking on the Dart Debug Extension), but not when a user copy-pastes the link from their terminal. 

