### PR TITLE
Fix crash on missing libraries.json

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Show an alert in the Dart Debug Extension for a multi-app scenario.
 - Fix a bug where `dartEmitDebugEvents` was set as a `String` instead of `bool`
   in the injected client.
+- Emit a warning instead of crashing on missing `libraries.json`.
 
 **Breaking changes:**
 

--- a/dwds/lib/src/utilities/dart_uri.dart
+++ b/dwds/lib/src/utilities/dart_uri.dart
@@ -160,6 +160,7 @@ class DartUri {
 
     librariesPath ??=
         p.toUri(p.join(_sdkDir.toFilePath(), 'lib', 'libraries.json'));
+
     var packagesUri = p.toUri(p.join(currentDirectory, '.packages'));
 
     clear();
@@ -169,6 +170,8 @@ class DartUri {
 
   /// Clear the uri resolution tables.
   static void clear() {
+    _librariesSpec = null;
+    _packageConfig = null;
     _resolvedUriToUri.clear();
     _uriToResolvedUri.clear();
   }
@@ -198,8 +201,10 @@ class DartUri {
       var json = File.fromUri(uri).readAsStringSync();
       _librariesSpec =
           LibrariesSpecification.parse(uri, json).specificationFor('dartdevc');
-    } on LibrariesSpecificationException catch (e, s) {
-      _logger.warning('Cannot read libraries spec: $uri', e, s);
+    } on LibrariesSpecificationException catch (e) {
+      _logger.warning('Cannot parse libraries spec: $uri', e);
+    } on Exception catch (e) {
+      _logger.warning('Cannot read libraries spec: $uri', e);
     }
   }
 

--- a/dwds/lib/src/utilities/dart_uri.dart
+++ b/dwds/lib/src/utilities/dart_uri.dart
@@ -203,7 +203,7 @@ class DartUri {
           LibrariesSpecification.parse(uri, json).specificationFor('dartdevc');
     } on LibrariesSpecificationException catch (e) {
       _logger.warning('Cannot parse libraries spec: $uri', e);
-    } on Exception catch (e) {
+    } on FileSystemException catch (e) {
       _logger.warning('Cannot read libraries spec: $uri', e);
     }
   }


### PR DESCRIPTION
Emit a warning instead of crashing on missing libraries spec (libraries.json), add tests.