### PR TITLE
Update dependencies for the Dart Debug Extension

### DIFF
--- a/dwds/debug_extension/pubspec.yaml
+++ b/dwds/debug_extension/pubspec.yaml
@@ -18,8 +18,8 @@ dependencies:
 
 dev_dependencies:
   build: ^2.0.0
-  build_web_compilers: ">=1.2.0 <3.0.0"
-  build_runner: ">=1.5.0 <2.0.0"
+  build_web_compilers: ^3.0.0
+  build_runner: ^2.0.6
   built_collection: ^5.0.0
   dwds: ^11.0.0
   webdev: ^2.0.0


### PR DESCRIPTION
A couple of the dependencies were out of date, which caused the following error when running `dart pub get`. This PR updates them to match the versions in DWDS.

```
Resolving dependencies... (1.2s)
Because analyzer >=1.0.0 <1.1.0 depends on _fe_analyzer_shared ^16.0.0 and analyzer >=1.1.0 <1.2.0 depends on
  _fe_analyzer_shared ^17.0.0, analyzer >=1.0.0 <1.2.0 requires _fe_analyzer_shared ^16.0.0 or ^17.0.0.
And because analyzer >=1.2.0 <1.3.0 depends on _fe_analyzer_shared ^18.0.0, analyzer >=1.0.0 <1.3.0 requires
  _fe_analyzer_shared ^16.0.0 or ^17.0.0 or ^18.0.0.
Because analyzer >=1.4.0 <1.5.0 depends on _fe_analyzer_shared ^20.0.0 and analyzer >=1.3.0 <1.4.0 depends on
  _fe_analyzer_shared ^19.0.0, analyzer >=1.3.0 <1.5.0 requires _fe_analyzer_shared ^19.0.0 or ^20.0.0.
Thus, analyzer >=1.0.0 <1.5.0 requires _fe_analyzer_shared ^16.0.0 or ^17.0.0 or ^18.0.0 or ^19.0.0 or ^20.0.0.
Because analyzer ^1.6.0 depends on _fe_analyzer_shared ^22.0.0 and analyzer >=1.5.0 <1.6.0 depends on _fe_analyzer_shared
  ^21.0.0, analyzer ^1.5.0 requires _fe_analyzer_shared ^21.0.0 or ^22.0.0.
Thus, analyzer ^1.0.0 requires _fe_analyzer_shared ^16.0.0 or ^17.0.0 or ^18.0.0 or ^19.0.0 or ^20.0.0 or ^21.0.0 or
  ^22.0.0.
And because every version of dwds from path depends on _fe_analyzer_shared ^31.0.0, dwds from path is incompatible with
  analyzer ^1.0.0.
And because build_web_compilers >=2.16.4 <3.2.0 depends on analyzer ^1.0.0 and build_web_compilers >=0.4.1 <2.16.4
  depends on glob ^1.1.0, if dwds from path and build_web_compilers >=0.4.1 <3.2.0 then glob ^1.1.0.
And because build_runner >=1.11.2 depends on glob ^2.0.0 and build_runner >=0.10.1 <1.12.0 depends on web_socket_channel
  ^1.0.9, if dwds from path and build_web_compilers >=0.4.1 <3.2.0 and build_runner >=0.10.1 then web_socket_channel
  ^1.0.9.
And because extension depends on both web_socket_channel ^2.0.0 and build_web_compilers >=1.2.0 <3.0.0, dwds from path is
  incompatible with build_runner >=0.10.1.
So, because extension depends on both build_runner ^1.5.0 and dwds from path, version solving failed.
```