### PR TITLE
Add option to launch DevTools in the same Chrome window

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Show an alert in the Dart Debug Extension for a multi-app scenario.
 - Fix a bug where `dartEmitDebugEvents` was set as a `String` instead of `bool`
   in the injected client.
+  - Add option to launch Dart DevTools in the same window as the connected Dart app.
 
 **Breaking changes:**
 

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Remove dead code for reading `'dart.developer.registerExtension'` and
   `'dart.developer.postEvent'` events from the chrome console. These messages
   haven't been written to the console since dwds v11.1.0 and Dart SDK v2.14.0.
-  - Add an option to launch Dart DevTools in the same window as the connected Dart app.
 
 **Breaking changes:**
 
@@ -20,6 +19,8 @@
 - Add `emitDebugEvents` argument to `Dwds.start` to suppress emitting debug
   events from the injected client.
 - Replace `sdkRoot` parameter by `sdkDir` in `ExpressionCompilerService`.
+- Adds an additional parameter to launch Dart DevTools in the same window as
+  the connected Dart app.
 
 ## 11.5.1
 

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -110,8 +110,11 @@ class Dwds {
     bool useSseForInjectedClient,
     UrlEncoder urlEncoder,
     bool spawnDds,
+    // TODO(elliette): DevTools is inconsistently capitalized throughout this
+    // file. Change all occurances of devtools/Devtools to devTools/DevTools.
     bool enableDevtoolsLaunch,
     DevtoolsLauncher devtoolsLauncher,
+    bool launchDevToolsInNewWindow,
     Uri sdkDir,
     Uri librariesPath,
     bool emitDebugEvents,
@@ -123,6 +126,7 @@ class Dwds {
     useSseForDebugBackend ??= true;
     useSseForInjectedClient ??= true;
     enableDevtoolsLaunch ??= true;
+    launchDevToolsInNewWindow ??= true;
     spawnDds ??= true;
     globalLoadStrategy = loadStrategy;
     emitDebugEvents ??= true;
@@ -183,6 +187,7 @@ class Dwds {
       expressionCompiler,
       injected,
       spawnDds,
+      launchDevToolsInNewWindow,
     );
 
     return Dwds._(

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -63,6 +63,7 @@ class DevHandler {
   final bool _useSseForInjectedClient;
   final bool _serveDevTools;
   final bool _spawnDds;
+  final bool _launchDevToolsInNewWindow;
   final ExpressionCompiler _expressionCompiler;
   final DwdsInjector _injected;
 
@@ -87,7 +88,8 @@ class DevHandler {
       this._serveDevTools,
       this._expressionCompiler,
       this._injected,
-      this._spawnDds) {
+      this._spawnDds,
+      this._launchDevToolsInNewWindow) {
     _subs.add(buildResults.listen(_emitBuildResults));
     _listen();
     if (_extensionBackend != null) {
@@ -525,7 +527,7 @@ class DevHandler {
     if (!_serveDevTools) return;
     emitEvent(DwdsEvent.devtoolsLaunch());
     await remoteDebugger.sendCommand('Target.createTarget', params: {
-      'newWindow': true,
+      'newWindow': _launchDevToolsInNewWindow,
       'url': Uri(
           scheme: 'http',
           host: _devTools.hostname,


### PR DESCRIPTION
A few customers requested the ability to launch Dart DevTools in the same Chrome window as their Dart application. Currently we only launch Dart DevTools from a different Chrome window, this adds the ability to launch it from the same window.