### PR TITLE
Remove dead code for reading events from console

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Show an alert in the Dart Debug Extension for a multi-app scenario.
 - Fix a bug where `dartEmitDebugEvents` was set as a `String` instead of `bool`
   in the injected client.
+- Remove dead code for reading `'dart.developer.registerExtension'` and
+  `'dart.developer.postEvent'` events from the chrome console. These messages
+  haven't been written to the console since dwds v11.1.0 and Dart SDK v2.14.0.
 
 **Breaking changes:**
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -876,32 +876,9 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
       if (isolateRef.id != isolate.id) return;
 
       var firstArgValue = event.args[0].value as String;
-      // TODO(grouma) - Remove when the min SDK has updated to migrate users
-      // over to the injected client communication approach.
+      // TODO(nshahan) - Migrate 'inspect' and 'log' events to the injected
+      // client communication approach as well?
       switch (firstArgValue) {
-        case 'dart.developer.registerExtension':
-          var service = event.args[1].value as String;
-          isolate.extensionRPCs.add(service);
-          _streamNotify(
-              EventStreams.kIsolate,
-              Event(
-                  kind: EventKind.kServiceExtensionAdded,
-                  timestamp: DateTime.now().millisecondsSinceEpoch,
-                  isolate: isolateRef)
-                ..extensionRPC = service);
-          break;
-        case 'dart.developer.postEvent':
-          _streamNotify(
-              EventStreams.kExtension,
-              Event(
-                  kind: EventKind.kExtension,
-                  timestamp: DateTime.now().millisecondsSinceEpoch,
-                  isolate: isolateRef)
-                ..extensionKind = event.args[1].value as String
-                ..extensionData = ExtensionData.parse(
-                    jsonDecode(event.args[2].value as String)
-                        as Map<String, dynamic>));
-          break;
         case 'dart.developer.inspect':
           // All inspected objects should be real objects.
           if (event.args[1].type != 'object') break;


### PR DESCRIPTION
The `'dart.developer.registerExtension'` and `'dart.developer.postEvent'`
events from the chrome console. These messages haven't been written to the
console since dwds v11.1.0 and Dart SDK v2.14.0.

Fixes: https://github.com/dart-lang/webdev/issues/1342