### PR TITLE
Webdev serve: add an option to pass user data directory to chrome

### DIFF
--- a/webdev/README.md
+++ b/webdev/README.md
@@ -72,6 +72,11 @@ Advanced:
                                            specify a specific port to attach to
                                            an already running chrome instance
                                            instead.
+    --user-data-dir                        Use with launch-in-chrome to specify
+                                           user data directory to pass to
+                                           chrome. Will start chrome window
+                                           logged into default profile with
+                                           enabled extensions.
     --log-requests                         Enables logging for each request to
                                            the server.
     --tls-cert-chain                       The file location to a TLS

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -23,6 +23,7 @@ const hotReloadFlag = 'hot-reload';
 const hotRestartFlag = 'hot-restart';
 const launchAppOption = 'launch-app';
 const launchInChromeFlag = 'launch-in-chrome';
+const userDataDirFlag = 'user-data-dir';
 const liveReloadFlag = 'live-reload';
 const logRequestsFlag = 'log-requests';
 const outputFlag = 'output';
@@ -92,6 +93,7 @@ class Configuration {
   final String _tlsCertKey;
   final List<String> _launchApps;
   final bool _launchInChrome;
+  final String _userDataDir;
   final bool _logRequests;
   final String _output;
   final String outputInput;
@@ -115,6 +117,7 @@ class Configuration {
     String tlsCertKey,
     List<String> launchApps,
     bool launchInChrome,
+    String userDataDir,
     bool logRequests,
     String output,
     this.outputInput,
@@ -136,6 +139,7 @@ class Configuration {
         _tlsCertKey = tlsCertKey,
         _launchApps = launchApps,
         _launchInChrome = launchInChrome,
+        _userDataDir = userDataDir,
         _logRequests = logRequests,
         _output = output,
         _release = release,
@@ -185,6 +189,11 @@ class Configuration {
       throw InvalidConfiguration(
           '--$launchAppOption can only be used with --$launchInChromeFlag');
     }
+
+    if (userDataDir != null && !launchInChrome) {
+      throw InvalidConfiguration(
+          '--$userDataDir can only be used with --$launchInChromeFlag');
+    }
   }
 
   /// Creates a new [Configuration] with all non-null fields from
@@ -201,6 +210,7 @@ class Configuration {
       tlsCertKey: other._tlsCertKey ?? _tlsCertKey,
       launchApps: other._launchApps ?? _launchApps,
       launchInChrome: other._launchInChrome ?? _launchInChrome,
+      userDataDir: other._userDataDir ?? _userDataDir,
       logRequests: other._logRequests ?? _logRequests,
       output: other._output ?? _output,
       release: other._release ?? _release,
@@ -238,6 +248,8 @@ class Configuration {
   List<String> get launchApps => _launchApps ?? [];
 
   bool get launchInChrome => _launchInChrome ?? false;
+
+  String get userDataDir => _userDataDir;
 
   bool get logRequests => _logRequests ?? false;
 
@@ -320,6 +332,10 @@ class Configuration {
             ? true
             : defaultConfiguration.launchInChrome;
 
+    var userDataDir = argResults.options.contains(userDataDirFlag)
+        ? argResults[userDataDirFlag] as String
+        : defaultConfiguration.userDataDir;
+
     var logRequests = argResults.options.contains(logRequestsFlag)
         ? argResults[logRequestsFlag] as bool
         : defaultConfiguration.logRequests;
@@ -382,6 +398,7 @@ class Configuration {
       tlsCertKey: tlsCertKey,
       launchApps: launchApps,
       launchInChrome: launchInChrome,
+      userDataDir: userDataDir,
       logRequests: logRequests,
       output: output,
       outputInput: outputInput,

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -59,6 +59,10 @@ refresh: Performs a full page refresh.
         help: 'Automatically launches your application in Chrome with the '
             'debug port open. Use $chromeDebugPortFlag to specify a specific '
             'port to attach to an already running chrome instance instead.')
+    ..addOption(userDataDirFlag,
+        help: 'Use with $launchInChromeFlag to specify user data directory '
+            'to pass to chrome. Will start chrome window logged into default '
+            'profile with enabled extensions.')
     ..addFlag(liveReloadFlag,
         negatable: false,
         help: 'Automatically refreshes the page after each successful build.\n'

--- a/webdev/lib/src/serve/chrome.dart
+++ b/webdev/lib/src/serve/chrome.dart
@@ -8,9 +8,14 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:browser_launcher/browser_launcher.dart' as browser_launcher;
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
+import '../command/configuration.dart';
+import 'utils.dart';
+
+var _logger = Logger('ChromeLauncher');
 var _currentCompleter = Completer<Chrome>();
 
 /// A class for managing an instance of Chrome.
@@ -38,17 +43,58 @@ class Chrome {
   /// Starts Chrome with the remote debug port enabled.
   ///
   /// Each url in [urls] will be loaded in a separate tab.
-  static Future<Chrome> start(List<String> urls, {int port}) async {
+  /// Enables chrome devtools with port [port] if specified.
+  /// Uses a copy of [userDataDir] to sign into the default
+  /// user profile, or starts a new session without sign in,
+  /// if not specified.
+  static Future<Chrome> start(List<String> urls,
+      {int port, String userDataDir}) async {
+    var signIn = false;
     String dir;
     // Re-using the directory causes flakiness on Windows, so on that platform
     // pass null to have it create a directory.
     if (!Platform.isWindows) {
-      dir = path.join(Directory.current.absolute.path, '.dart_tool', 'webdev',
-          'chrome_user_data');
-      Directory(dir).createSync(recursive: true);
+      var userDataTemp = path.join(Directory.current.absolute.path,
+          '.dart_tool', 'webdev', 'chrome_user_data');
+      var userDataCopy = path.join(Directory.current.absolute.path,
+          '.dart_tool', 'webdev', 'chrome_user_data_copy');
+
+      if (userDataDir != null) {
+        signIn = true;
+        dir = userDataCopy;
+        var stopwatch = Stopwatch()..start();
+        try {
+          _logger.info('Copying user data directory...');
+          _logger.warning(
+              'Copying user data directory might take >12s on the first '
+              'use of --$userDataDirFlag, and ~2-3s on subsequent runs. '
+              'Run without --$userDataDirFlag to improve performance.');
+
+          Directory(dir).createSync(recursive: true);
+          await updatePath(
+              path.join(userDataDir, 'Default'), path.join(dir, 'Default'));
+
+          _logger.info(
+              'Copied user data directory in ${stopwatch.elapsedMilliseconds} ms');
+        } catch (e, s) {
+          dir = userDataTemp;
+          signIn = false;
+          Directory(dir).deleteSync(recursive: true);
+          _logger.severe('Failed to copy user data directory', e, s);
+          _logger.severe('Launching with temp profile instead.');
+          rethrow;
+        }
+      }
+
+      if (!signIn) {
+        dir = userDataTemp;
+        Directory(dir).createSync(recursive: true);
+      }
     }
+
+    _logger.info('Starting chrome with user data directory: $dir');
     var chrome = await browser_launcher.Chrome.startWithDebugPort(urls,
-        debugPort: port, userDataDir: dir);
+        debugPort: port, userDataDir: dir, signIn: signIn);
     return _connect(Chrome._(chrome.debugPort, chrome));
   }
 

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -72,7 +72,9 @@ Future<Chrome> _startChrome(
   ];
   try {
     if (configuration.launchInChrome) {
-      return await Chrome.start(uris, port: configuration.chromeDebugPort);
+      var userDataDir = configuration.userDataDir;
+      return await Chrome.start(uris,
+          port: configuration.chromeDebugPort, userDataDir: userDataDir);
     } else if (configuration.chromeDebugPort != 0) {
       return await Chrome.fromExisting(configuration.chromeDebugPort);
     }

--- a/webdev/lib/src/serve/utils.dart
+++ b/webdev/lib/src/serve/utils.dart
@@ -7,6 +7,8 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+
 /// Returns a port that is probably, but not definitely, not in use.
 ///
 /// This has a built-in race condition: another process may bind this port at
@@ -22,4 +24,62 @@ Future<int> findUnusedPort() async {
   port = socket.port;
   await socket.close();
   return port;
+}
+
+/// Copy directory [from] to [to].
+///
+/// Updates contents of [to] if already exists.
+Future<void> updatePath(String from, String to) async {
+  await _removeDeleted(from, to);
+  await _copyUpdated(from, to);
+}
+
+// Update modified files.
+Future<void> _copyUpdated(String from, String to) async {
+  if (!Directory(from).existsSync()) return;
+  await Directory(to).create(recursive: true);
+
+  await for (final file in Directory(from).list()) {
+    final copyTo = p.join(to, p.relative(file.path, from: from));
+    if (file is Directory) {
+      await _copyUpdated(file.path, copyTo);
+    } else if (file is File) {
+      var copyToFile = File(copyTo);
+      if (!copyToFile.existsSync() ||
+          copyToFile.statSync().modified.compareTo(file.statSync().modified) <
+              0) {
+        await File(file.path).copy(copyTo);
+      }
+    } else if (file is Link) {
+      await Link(copyTo).create(await file.target(), recursive: true);
+    }
+  }
+}
+
+// Remove deleted files.
+Future<void> _removeDeleted(String from, String to) async {
+  if (!Directory(from).existsSync()) {
+    if (Directory(to).existsSync()) {
+      await Directory(to).delete(recursive: true);
+    }
+    return;
+  }
+
+  await for (final file in Directory(to).list()) {
+    final copyFrom = p.join(from, p.relative(file.path, from: to));
+    if (file is File) {
+      var copyFromFile = File(copyFrom);
+      if (!copyFromFile.existsSync()) {
+        await File(file.path).delete();
+      }
+    } else if (file is Directory) {
+      var copyFromDir = Directory(copyFrom);
+      await _removeDeleted(copyFromDir.path, file.path);
+    } else if (file is Link) {
+      var copyFromDir = Link(copyFrom);
+      if (!copyFromDir.existsSync()) {
+        await Link(file.path).delete();
+      }
+    }
+  }
 }

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -51,9 +51,11 @@ dev_dependencies:
   webdriver: ^3.0.0
 
 # Uncomment for development versions
-# dependency_overrides:
-#   dwds:
-#     path: ../dwds
+dependency_overrides:
+  dwds:
+    path: ../dwds
+  browser_launcher:
+    path: ../../browser_launcher
 
 executables:
   webdev:

--- a/webdev/test/chrome_test.dart
+++ b/webdev/test/chrome_test.dart
@@ -5,45 +5,153 @@
 // @dart = 2.9
 
 import 'dart:async';
+import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
+import 'package:webdev/src/logging.dart';
 import 'package:webdev/src/serve/chrome.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 void main() {
   Chrome chrome;
 
-  Future<void> launchChrome({int port}) async {
-    chrome = await Chrome.start([_googleUrl], port: port ?? 0);
+  Future<void> launchChrome({int port, String userDataDir}) async {
+    chrome = await Chrome.start([_googleUrl],
+        port: port ?? 0, userDataDir: userDataDir);
   }
 
-  tearDown(() async {
-    var tabs = await chrome.chromeConnection.getTabs();
-    for (var tab in tabs) {
-      await chrome.chromeConnection.getUrl('/json/close/${tab.id}');
-    }
-    await chrome?.close();
-    chrome = null;
+  Future<void> openTab(String url) =>
+      chrome.chromeConnection.getUrl(_openTabUrl(url));
+
+  Future<void> closeTab(ChromeTab tab) =>
+      chrome.chromeConnection.getUrl(_closeTabUrl(tab.id));
+
+  Future<WipConnection> connectToTab(String url) async {
+    var tab = await chrome.chromeConnection.getTab((t) => t.url.contains(url));
+    expect(tab, isNotNull);
+    return tab.connect();
+  }
+
+  group('chrome with temp data dir', () {
+    tearDown(() async {
+      var tabs = await chrome.chromeConnection.getTabs();
+      for (var tab in tabs) {
+        await closeTab(tab);
+      }
+      await chrome?.close();
+      chrome = null;
+    });
+
+    test('can launch chrome', () async {
+      await launchChrome();
+      expect(chrome, isNotNull);
+    });
+
+    test('has a working debugger', () async {
+      await launchChrome();
+      var tabs = await chrome.chromeConnection.getTabs();
+      expect(
+          tabs,
+          contains(const TypeMatcher<ChromeTab>()
+              .having((t) => t.url, 'url', _googleUrl)));
+    });
+
+    test('uses open debug port if provided port is 0', () async {
+      await launchChrome(port: 0);
+      expect(chrome.debugPort, isNot(equals(0)));
+    });
+
+    test('has correct profile path', () async {
+      await launchChrome();
+      await openTab(_chromeVersionUrl);
+
+      var wipConnection = await connectToTab(_chromeVersionUrl);
+      var result = await _evaluateExpression(wipConnection.page,
+          "document.getElementById('profile_path').textContent");
+
+      expect(result, contains('chrome_user_data'));
+    });
   });
 
-  test('can launch chrome', () async {
-    await launchChrome();
-    expect(chrome, isNotNull);
-  });
+  group('chrome with user data dir', () {
+    Directory dataDir;
+    StreamController<String> logController;
+    Stream<String> logStream;
 
-  test('debugger is working', () async {
-    await launchChrome();
-    var tabs = await chrome.chromeConnection.getTabs();
-    expect(
-        tabs,
-        contains(const TypeMatcher<ChromeTab>()
-            .having((t) => t.url, 'url', _googleUrl)));
-  });
+    setUp(() {
+      logController = StreamController<String>();
+      logStream = logController.stream.asBroadcastStream();
 
-  test('uses open debug port if provided port is 0', () async {
-    await launchChrome(port: 0);
-    expect(chrome.debugPort, isNot(equals(0)));
+      void _logWriter(Level level, String message,
+          {String error, String loggerName, String stackTrace}) {
+        if (level >= Level.SEVERE) {
+          logController.add('[$level] $loggerName: $message');
+        }
+      }
+
+      logStream.listen(print);
+
+      configureLogWriter(true, customLogWriter: _logWriter);
+      dataDir = Directory.systemTemp.createTempSync(_userDataDirName);
+    });
+
+    tearDown(() async {
+      var tabs = await chrome.chromeConnection.getTabs();
+      for (var tab in tabs) {
+        await closeTab(tab);
+      }
+      await chrome.close();
+      chrome = null;
+
+      await logController.close();
+      dataDir?.deleteSync(recursive: true);
+    });
+
+    test('works with debug port', () async {
+      await launchChrome(userDataDir: dataDir.path);
+      expect(chrome, isNotNull);
+    });
+
+    test('has a working debugger', () async {
+      await launchChrome(userDataDir: dataDir.path);
+
+      var tabs = await chrome.chromeConnection.getTabs();
+      expect(
+          tabs,
+          contains(const TypeMatcher<ChromeTab>()
+              .having((t) => t.url, 'url', _googleUrl)));
+    });
+
+    test('has correct profile path', () async {
+      await launchChrome(userDataDir: dataDir.path);
+      await openTab(_chromeVersionUrl);
+
+      var wipConnection = await connectToTab(_chromeVersionUrl);
+      var result = await _evaluateExpression(wipConnection.page,
+          "document.getElementById('profile_path').textContent");
+
+      expect(result, contains('chrome_user_data_copy'));
+    });
   });
 }
 
-const _googleUrl = 'http://www.google.com/';
+String _openTabUrl(String url) => '/json/new?$url';
+String _closeTabUrl(String id) => '/json/close/$id';
+
+Future<String> _evaluateExpression(WipPage page, String expression) async {
+  var result = '';
+  while (result.isEmpty) {
+    await Future.delayed(const Duration(milliseconds: 100));
+    var wipResponse = await page.sendCommand(
+      'Runtime.evaluate',
+      params: {'expression': expression},
+    );
+    result = wipResponse.json['result']['result']['value'] as String;
+  }
+  return result;
+}
+
+const _googleUrl = 'https://www.google.com/';
+const _chromeVersionUrl = 'chrome://version/';
+const _userDataDirName = 'data dir';

--- a/webdev/test/configuration_test.dart
+++ b/webdev/test/configuration_test.dart
@@ -13,7 +13,8 @@ void main() {
   setUp(() {
     argParser = ArgParser()
       ..addFlag('release')
-      ..addOption(nullSafetyFlag, defaultsTo: nullSafetyAuto);
+      ..addOption(nullSafetyFlag, defaultsTo: nullSafetyAuto)
+      ..addOption(userDataDirFlag, defaultsTo: null);
   });
 
   test('default configuration is correctly applied', () {
@@ -38,6 +39,30 @@ void main() {
 
   test('must provide a debug port when launchInChrome is false ', () {
     expect(() => Configuration(debug: true, launchInChrome: false),
+        throwsA(isA<InvalidConfiguration>()));
+  });
+
+  test('user data directory defaults to null ', () {
+    var argResults = argParser.parse(['']);
+    var defaultConfiguration = Configuration.fromArgs(argResults);
+    expect(defaultConfiguration.userDataDir, isNull);
+  });
+
+  test('can read user data dir from args ', () {
+    var argResults =
+        argParser.parse(['--launch-in-chrome --user-data-dir=tempdir']);
+    var configuration = Configuration.fromArgs(argResults);
+    expect(configuration.userDataDir, equals('tempdir'));
+  });
+
+  test('can set user data directory with launchInChrome ', () {
+    var configuration =
+        Configuration(launchInChrome: true, userDataDir: 'temp');
+    expect(configuration.userDataDir, equals('temp'));
+  });
+
+  test('must set launchInChrome is to true if using user data directory ', () {
+    expect(() => Configuration(launchInChrome: false, userDataDir: 'temp'),
         throwsA(isA<InvalidConfiguration>()));
   });
 

--- a/webdev/test/utils_test.dart
+++ b/webdev/test/utils_test.dart
@@ -1,0 +1,147 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart = 2.9
+
+@Retry(0)
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:webdev/src/serve/utils.dart';
+
+void main() {
+  Directory from;
+  Directory to;
+
+  setUp(() {
+    from = Directory.systemTemp.createTempSync('from');
+    to = Directory.systemTemp.createTempSync('to');
+  });
+
+  tearDown(() {
+    from?.deleteSync(recursive: true);
+    to?.deleteSync(recursive: true);
+  });
+
+  test('updatePath does nothing for non-existing directories', () async {
+    var subDirFrom = Directory(p.join(from.path, '1'));
+    var subDirTo = Directory(p.join(to.path, '2'));
+
+    expect(subDirFrom.existsSync(), isFalse);
+    expect(subDirTo.existsSync(), isFalse);
+
+    await updatePath(subDirFrom.path, subDirTo.path);
+
+    expect(subDirFrom.existsSync(), isFalse);
+    expect(subDirTo.existsSync(), isFalse);
+  });
+
+  test('updatePath removes stale directories', () async {
+    var subDirFrom = Directory(p.join(from.path, '1'));
+    var subDirTo = Directory(p.join(to.path, '2'));
+
+    subDirTo.createSync();
+
+    expect(subDirFrom.existsSync(), isFalse);
+    expect(subDirTo.existsSync(), isTrue);
+
+    await updatePath(from.path, to.path);
+
+    expect(subDirFrom.existsSync(), isFalse);
+    expect(subDirTo.existsSync(), isFalse);
+  });
+
+  test('updatePath updates directories', () async {
+    var subDirFrom = Directory(p.join(from.path, '1'));
+    var subDirTo = Directory(p.join(to.path, '2'));
+
+    subDirFrom.createSync();
+    subDirTo.createSync();
+
+    var listFrom =
+        from.listSync().map((e) => p.relative(e.path, from: from.path));
+    await updatePath(from.path, to.path);
+
+    var listTo = to.listSync().map((e) => p.relative(e.path, from: to.path));
+    expect(listFrom, listTo);
+  });
+
+  test('updatePath updates files', () async {
+    var fileFrom = File(p.join(from.path, '1'));
+    var fileTo = File(p.join(to.path, '2'));
+
+    fileFrom.createSync();
+    fileTo.createSync();
+
+    var listFrom =
+        from.listSync().map((e) => p.relative(e.path, from: from.path));
+    await updatePath(from.path, to.path);
+
+    var listTo = to.listSync().map((e) => p.relative(e.path, from: to.path));
+    expect(listFrom, listTo);
+  });
+
+  test('updatePath updates files and directories', () async {
+    var subDirFrom = Directory(p.join(from.path, '1'));
+    var subDirTo1 = Directory(p.join(to.path, '1'));
+    var subDirTo2 = Directory(p.join(to.path, '2'));
+
+    subDirFrom.createSync();
+    subDirTo1.createSync();
+    subDirTo2.createSync();
+
+    var fileFrom = File(p.join(subDirFrom.path, 'a'));
+    var fileTo1 = File(p.join(subDirTo1.path, 'b'));
+    var fileTo2 = File(p.join(subDirTo2.path, 'b'));
+
+    fileFrom.createSync();
+    fileTo1.createSync();
+    fileTo2.createSync();
+
+    var listFrom = from
+        .listSync(recursive: true)
+        .map((e) => p.relative(e.path, from: from.path));
+    await updatePath(from.path, to.path);
+
+    var listTo = to
+        .listSync(recursive: true)
+        .map((e) => p.relative(e.path, from: to.path));
+    expect(listFrom, listTo);
+  });
+
+  test('updatePath updates stale files', () async {
+    var fileFrom = File(p.join(from.path, '1'));
+    var fileTo = File(p.join(to.path, '1'));
+
+    fileTo.writeAsStringSync('contentsTo');
+    await Future.delayed(const Duration(milliseconds: 10));
+    fileFrom.writeAsStringSync('contentsFrom');
+
+    var stats = fileFrom.statSync();
+    expect(fileTo.statSync().modified, isNot(equals(stats.modified)));
+
+    await updatePath(from.path, to.path);
+    expect(fileTo.statSync().modified, equals(stats.modified));
+    expect(fileTo.readAsStringSync(), equals('contentsFrom'));
+  });
+
+  test('updatePath does not update newer files', () async {
+    var fileFrom = File(p.join(from.path, '1'));
+    var fileTo = File(p.join(to.path, '1'));
+
+    fileFrom.writeAsStringSync('contentsFrom');
+    await Future.delayed(const Duration(milliseconds: 10));
+    fileTo.writeAsStringSync('contentsTo');
+
+    var stats = fileFrom.statSync();
+    expect(fileTo.statSync().modified, isNot(equals(stats.modified)));
+
+    await updatePath(from.path, to.path);
+    expect(fileTo.statSync().modified, isNot(equals(stats.modified)));
+    expect(fileTo.readAsStringSync(), equals('contentsTo'));
+  });
+}


### PR DESCRIPTION
Webdev launches chrome using temp profile by default, so the users
cannot use their extensions while debugging. Allow launching chrome
in a window that is signed in as the user's default profile.

Notes:

  There seems to be a limitation in chrome that only uses the existing
session with --user-data-dir. The existing session cannot open a debug
port that dwds needs.

  To work around this issue, we copy the default profile to a temporary
directory, and pass it to chrome. That seems to work, but takes time
to copy the profile. Issue a performance warning in that case.

  Note that subsequent updates will only update modified files, so the
performance hit becomes smaller over time.

Closes: https://github.com/dart-lang/webdev/issues/1490