### PR TITLE
Update the Dart min SDK to `2.16.0` and prepare webdev and DWDS for release

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 12.0.0-dev
+## 12.0.0
 
 - Implement `lookupResolvedPackageUris` and `lookupPackageUris` vm service API.
 - Update `vm_service` version to `^8.1.0`.
@@ -13,6 +13,7 @@
   haven't been written to the console since dwds v11.1.0 and Dart SDK v2.14.0.
 - Batch debug events sent from injected client to dwds to relieve network load. 
 - Update `_fe_analyzer_shared` version to `33.0.0`
+- Update the Dart minimum SDK to `>=2.16.0`.
 
 **Breaking changes:**
 

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -7,7 +7,7 @@ description: >-
   service protocol.
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
   _fe_analyzer_shared: ^33.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: A web app example for webdev CLI.
 publish_to: none
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/fixtures/_webdevSmoke/pubspec.yaml
+++ b/fixtures/_webdevSmoke/pubspec.yaml
@@ -7,7 +7,7 @@ description: A test fixture for webdev testing.
 # and build_web_compilers constraint should match those defined
 # in pubspec.dart.
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 dev_dependencies:
   build_runner: '>=1.6.2 <3.0.0'

--- a/fixtures/_webdevSoundSmoke/pubspec.yaml
+++ b/fixtures/_webdevSoundSmoke/pubspec.yaml
@@ -2,7 +2,7 @@ name: _webdev_smoke
 description: A test fixture for webdev testing with sound support.
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 dev_dependencies:
   build_runner: '>=1.6.2 <3.0.0'

--- a/frontend_server_common/pubspec.yaml
+++ b/frontend_server_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: >-
   Frontend server integration code to use for dwds tests. Mimicks flutter code.
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
   dwds:

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 2.7.8-dev
+## 2.7.8
 
 - Update `vm_service` to `^8.1.0`.
 - Enable expression evaluation by default.
+- Update the Dart minimum SDK to `>=2.16.0`.
 
 ## 2.7.7
 

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
   features for users and tools to build and deploy web applications with Dart.
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
   args: ^2.0.0


### PR DESCRIPTION
The min SDK check is blocking https://github.com/dart-lang/webdev/pull/1494