### PR TITLE
Disable the "Paused" overlay

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Change wording of paused overlay from "Paused in Dart DevTools" to "Paused"
 - Allow sending back the Dart DevTools URL from DWDS instead of launching 
   Dart DevTools, to support embedding Dart DevTools in Chrome DevTools.
+- Temporarily disable the paused in debugger overlay.
 
 ## 12.1.0
 - Update _fe_analyzer_shared to version ^34.0.0.

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -67,7 +67,10 @@ class Debugger extends Domain {
 
   PauseState _pauseState = PauseState.none;
 
-  bool _pausedOverlayVisible = false;
+  // TODO(elliette): https://github.com/dart-lang/webdev/issues/1501 Re-enable
+  // after checking with Chrome team if there is a way to check if the Chrome
+  // DevTools is showing an overlay. Both cannot be shown at the same time:
+  // bool _pausedOverlayVisible = false;
 
   String get pauseState => _pauseModePauseStates.entries
       .firstWhere((entry) => entry.value == _pauseState)

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -588,7 +588,10 @@ class Debugger extends Domain {
       logger.warning('Error calculating Dart frames', e, s);
     }
 
-    _showPausedOverlay();
+    // TODO(elliette): https://github.com/dart-lang/webdev/issues/1501 Re-enable
+    // after checking with Chrome team if there is a way to check if the Chrome
+    // DevTools is showing an overlay. Both cannot be shown at the same time.
+    // _showPausedOverlay();
     isolate.pauseEvent = event;
     _streamNotify('Debug', event);
   }
@@ -606,7 +609,10 @@ class Debugger extends Domain {
         timestamp: DateTime.now().millisecondsSinceEpoch,
         isolate: inspector.isolateRef);
 
-    _hidePausedOverlay();
+    // TODO(elliette): https://github.com/dart-lang/webdev/issues/1501 Re-enable
+    // after checking with Chrome team if there is a way to check if the Chrome
+    // DevTools is showing an overlay. Both cannot be shown at the same time.
+    // _hidePausedOverlay();
     isolate.pauseEvent = event;
     _streamNotify('Debug', event);
   }

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -394,28 +394,28 @@ class Debugger extends Domain {
     return await inspector.jsCallFunctionOn(receiver, expression, args);
   }
 
+  // TODO(elliette): https://github.com/dart-lang/webdev/issues/1501 Re-enable
+  // after checking with Chrome team if there is a way to check if the Chrome
+  // DevTools is showing an overlay. Both cannot be shown at the same time:
+
   // Renders the paused at breakpoint overlay over the application.
-  // TODO(elliette): Detect whether or not Chrome DevTools is also open, and
-  // if so don't show this overlay. Chrome DevTools also adds an overlay above
-  // this one. Currently we just make sure our overlay message is shorter than
-  // Chrome DevTools message, so that our overlay is hidden.
-  void _showPausedOverlay() async {
-    if (_pausedOverlayVisible) return;
-    handleErrorIfPresent(await _remoteDebugger?.sendCommand('DOM.enable'));
-    handleErrorIfPresent(await _remoteDebugger?.sendCommand('Overlay.enable'));
-    handleErrorIfPresent(await _remoteDebugger
-        ?.sendCommand('Overlay.setPausedInDebuggerMessage', params: {
-      'message': 'Paused',
-    }));
-    _pausedOverlayVisible = true;
-  }
+  // void _showPausedOverlay() async {
+  //   if (_pausedOverlayVisible) return;
+  //   handleErrorIfPresent(await _remoteDebugger?.sendCommand('DOM.enable'));
+  //   handleErrorIfPresent(await _remoteDebugger?.sendCommand('Overlay.enable'));
+  //   handleErrorIfPresent(await _remoteDebugger
+  //       ?.sendCommand('Overlay.setPausedInDebuggerMessage', params: {
+  //     'message': 'Paused',
+  //   }));
+  //   _pausedOverlayVisible = true;
+  // }
 
   // Removes the paused at breakpoint overlay from the application.
-  void _hidePausedOverlay() async {
-    if (!_pausedOverlayVisible) return;
-    handleErrorIfPresent(await _remoteDebugger?.sendCommand('Overlay.disable'));
-    _pausedOverlayVisible = false;
-  }
+  // void _hidePausedOverlay() async {
+  //   if (!_pausedOverlayVisible) return;
+  //   handleErrorIfPresent(await _remoteDebugger?.sendCommand('Overlay.disable'));
+  //   _pausedOverlayVisible = false;
+  // }
 
   /// Calls the Chrome Runtime.getProperties API for the object with [objectId].
   ///


### PR DESCRIPTION
Temporarily disables the "Paused" overlay until we check with Chrome DevTools team if there is a way to conditionally show it based on whether they have added their overlay. 

Currently what happens is (these can happen in any order):
- DWDS adds its overlay
- Chrome DevTools add its overlay

So we have two overlays (R, S are the resume, skip buttons)
`[Paused in Chrome DevTools R S]`
`[Paused R S]`

If a user hits "Resume" in the `[Paused in Chrome DevTools R S]`, it actually triggers the "Skip" below it, so instead of resuming the debugger skips. 