### PR TITLE
Support lazily created SDK configurations.

### DIFF
--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -24,7 +24,7 @@ import 'src/readers/asset_reader.dart';
 import 'src/servers/devtools.dart';
 import 'src/servers/extension_backend.dart';
 import 'src/services/expression_compiler.dart';
-import 'src/utilities/dart_uri.dart';
+import 'src/utilities/sdk_configuration.dart';
 
 export 'src/connections/app_connection.dart' show AppConnection;
 export 'src/connections/debug_connection.dart' show DebugConnection;
@@ -50,6 +50,8 @@ export 'src/services/expression_compiler.dart'
     show ExpressionCompilationResult, ExpressionCompiler, ModuleInfo;
 export 'src/services/expression_compiler_service.dart'
     show ExpressionCompilerService;
+export 'src/utilities/sdk_configuration.dart'
+    show SdkConfiguration, SdkConfigurationInterface;
 
 typedef ConnectionProvider = Future<ChromeConnection> Function();
 typedef UrlEncoder = Future<String> Function(String url);
@@ -115,8 +117,7 @@ class Dwds {
     bool enableDevtoolsLaunch,
     DevtoolsLauncher devtoolsLauncher,
     bool launchDevToolsInNewWindow,
-    Uri sdkDir,
-    Uri librariesPath,
+    SdkConfigurationInterface sdkConfiguration,
     bool emitDebugEvents,
   }) async {
     hostname ??= 'localhost';
@@ -131,7 +132,7 @@ class Dwds {
     globalLoadStrategy = loadStrategy;
     emitDebugEvents ??= true;
 
-    await DartUri.initialize(sdkDir: sdkDir, librariesPath: librariesPath);
+    sdkConfiguration ??= SdkConfiguration.standard();
 
     DevTools devTools;
     Future<String> extensionUri;
@@ -188,6 +189,7 @@ class Dwds {
       injected,
       spawnDds,
       launchDevToolsInNewWindow,
+      sdkConfiguration,
     );
 
     return Dwds._(

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -51,7 +51,7 @@ export 'src/services/expression_compiler.dart'
 export 'src/services/expression_compiler_service.dart'
     show ExpressionCompilerService;
 export 'src/utilities/sdk_configuration.dart'
-    show SdkConfiguration, SdkConfigurationInterface;
+    show SdkConfiguration, SdkConfigurationProvider;
 
 typedef ConnectionProvider = Future<ChromeConnection> Function();
 typedef UrlEncoder = Future<String> Function(String url);
@@ -117,7 +117,7 @@ class Dwds {
     bool enableDevtoolsLaunch,
     DevtoolsLauncher devtoolsLauncher,
     bool launchDevToolsInNewWindow,
-    SdkConfigurationInterface sdkConfiguration,
+    SdkConfigurationProvider sdkConfigurationProvider,
     bool emitDebugEvents,
   }) async {
     hostname ??= 'localhost';
@@ -132,7 +132,7 @@ class Dwds {
     globalLoadStrategy = loadStrategy;
     emitDebugEvents ??= true;
 
-    sdkConfiguration ??= SdkConfiguration.standard();
+    sdkConfigurationProvider ??= DefaultSdkConfigurationProvider();
 
     DevTools devTools;
     Future<String> extensionUri;
@@ -189,7 +189,7 @@ class Dwds {
       injected,
       spawnDds,
       launchDevToolsInNewWindow,
-      sdkConfiguration,
+      sdkConfigurationProvider,
     );
 
     return Dwds._(

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -17,6 +17,7 @@ import '../readers/asset_reader.dart';
 import '../utilities/conversions.dart';
 import '../utilities/dart_uri.dart';
 import '../utilities/domain.dart';
+import '../utilities/sdk_configuration.dart';
 import '../utilities/shared.dart';
 import 'classes.dart';
 import 'debugger.dart';
@@ -64,6 +65,7 @@ class AppInspector extends Domain {
 
   /// The root URI from which the application is served.
   final String _root;
+  final SdkConfigurationInterface _sdkConfiguration;
 
   AppInspector._(
     this.appConnection,
@@ -77,6 +79,7 @@ class AppInspector extends Domain {
     this._locations,
     this._root,
     this._executionContext,
+    this._sdkConfiguration,
   )   : isolateRef = _toIsolateRef(isolate),
         super.forInspector();
 
@@ -91,6 +94,7 @@ class AppInspector extends Domain {
 
     var scripts = await scriptRefs;
 
+    await DartUri.initialize(_sdkConfiguration);
     await DartUri.recordAbsoluteUris(libraries.map((lib) => lib.uri));
     await DartUri.recordAbsoluteUris(scripts.map((script) => script.uri));
 
@@ -112,6 +116,7 @@ class AppInspector extends Domain {
     String root,
     Debugger debugger,
     ExecutionContext executionContext,
+    SdkConfigurationInterface sdkConfiguration,
   ) async {
     var id = createId();
     var time = DateTime.now().millisecondsSinceEpoch;
@@ -156,6 +161,7 @@ class AppInspector extends Domain {
       locations,
       root,
       executionContext,
+      sdkConfiguration,
     );
     await appInspector._initialize();
     return appInspector;

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -65,7 +65,7 @@ class AppInspector extends Domain {
 
   /// The root URI from which the application is served.
   final String _root;
-  final SdkConfigurationInterface _sdkConfiguration;
+  final SdkConfiguration _sdkConfiguration;
 
   AppInspector._(
     this.appConnection,
@@ -116,7 +116,7 @@ class AppInspector extends Domain {
     String root,
     Debugger debugger,
     ExecutionContext executionContext,
-    SdkConfigurationInterface sdkConfiguration,
+    SdkConfiguration sdkConfiguration,
   ) async {
     var id = createId();
     var time = DateTime.now().millisecondsSinceEpoch;

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -66,7 +66,7 @@ class DevHandler {
   final bool _launchDevToolsInNewWindow;
   final ExpressionCompiler _expressionCompiler;
   final DwdsInjector _injected;
-  final SdkConfigurationInterface _sdkConfiguration;
+  final SdkConfigurationProvider _sdkConfigurationProvider;
 
   /// Null until [close] is called.
   ///
@@ -91,7 +91,7 @@ class DevHandler {
     this._injected,
     this._spawnDds,
     this._launchDevToolsInNewWindow,
-    this._sdkConfiguration,
+    this._sdkConfigurationProvider,
   ) {
     _subs.add(buildResults.listen(_emitBuildResults));
     _listen();
@@ -213,7 +213,7 @@ class DevHandler {
       useSse: false,
       expressionCompiler: _expressionCompiler,
       spawnDds: _spawnDds,
-      sdkConfiguration: _sdkConfiguration,
+      sdkConfigurationProvider: _sdkConfigurationProvider,
     );
   }
 
@@ -503,7 +503,7 @@ class DevHandler {
           useSse: _useSseForDebugProxy,
           expressionCompiler: _expressionCompiler,
           spawnDds: _spawnDds,
-          sdkConfiguration: _sdkConfiguration,
+          sdkConfigurationProvider: _sdkConfigurationProvider,
         );
         var appServices = await _createAppDebugServices(
           devToolsRequest.appId,

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -66,6 +66,7 @@ class DevHandler {
   final bool _launchDevToolsInNewWindow;
   final ExpressionCompiler _expressionCompiler;
   final DwdsInjector _injected;
+  final SdkConfigurationInterface _sdkConfiguration;
 
   /// Null until [close] is called.
   ///
@@ -75,21 +76,23 @@ class DevHandler {
   Stream<AppConnection> get connectedApps => _connectedApps.stream;
 
   DevHandler(
-      this._chromeConnection,
-      this.buildResults,
-      this._devTools,
-      this._assetReader,
-      this._loadStrategy,
-      this._hostname,
-      this._extensionBackend,
-      this._urlEncoder,
-      this._useSseForDebugProxy,
-      this._useSseForInjectedClient,
-      this._serveDevTools,
-      this._expressionCompiler,
-      this._injected,
-      this._spawnDds,
-      this._launchDevToolsInNewWindow) {
+    this._chromeConnection,
+    this.buildResults,
+    this._devTools,
+    this._assetReader,
+    this._loadStrategy,
+    this._hostname,
+    this._extensionBackend,
+    this._urlEncoder,
+    this._useSseForDebugProxy,
+    this._useSseForInjectedClient,
+    this._serveDevTools,
+    this._expressionCompiler,
+    this._injected,
+    this._spawnDds,
+    this._launchDevToolsInNewWindow,
+    this._sdkConfiguration,
+  ) {
     _subs.add(buildResults.listen(_emitBuildResults));
     _listen();
     if (_extensionBackend != null) {
@@ -210,6 +213,7 @@ class DevHandler {
       useSse: false,
       expressionCompiler: _expressionCompiler,
       spawnDds: _spawnDds,
+      sdkConfiguration: _sdkConfiguration,
     );
   }
 
@@ -499,6 +503,7 @@ class DevHandler {
           useSse: _useSseForDebugProxy,
           expressionCompiler: _expressionCompiler,
           spawnDds: _spawnDds,
+          sdkConfiguration: _sdkConfiguration,
         );
         var appServices = await _createAppDebugServices(
           devToolsRequest.appId,

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -94,7 +94,7 @@ class ChromeProxyService implements VmServiceInterface {
   final ExpressionCompiler _compiler;
   ExpressionEvaluator _expressionEvaluator;
 
-  final SdkConfigurationInterface _sdkConfiguration;
+  final SdkConfigurationProvider _sdkConfigurationProvider;
 
   bool terminatingIsolates = false;
 
@@ -108,7 +108,7 @@ class ChromeProxyService implements VmServiceInterface {
     this._skipLists,
     this.executionContext,
     this._compiler,
-    this._sdkConfiguration,
+    this._sdkConfigurationProvider,
   ) {
     var debugger = Debugger.create(
       remoteDebugger,
@@ -129,7 +129,7 @@ class ChromeProxyService implements VmServiceInterface {
     AppConnection appConnection,
     ExecutionContext executionContext,
     ExpressionCompiler expressionCompiler,
-    SdkConfigurationInterface sdkConfiguration,
+    SdkConfigurationProvider sdkConfigurationProvider,
   ) async {
     final vm = VM(
       name: 'ChromeDebugProxy',
@@ -159,7 +159,7 @@ class ChromeProxyService implements VmServiceInterface {
       skipLists,
       executionContext,
       expressionCompiler,
-      sdkConfiguration,
+      sdkConfigurationProvider,
     );
     unawaited(service.createIsolate(appConnection));
     return service;
@@ -216,6 +216,7 @@ class ChromeProxyService implements VmServiceInterface {
     // Issue: https://github.com/dart-lang/webdev/issues/1282
     var debugger = await _debugger;
     await _initializeEntrypoint(appConnection.request.entrypointPath);
+    var sdkConfiguration = await _sdkConfigurationProvider.configuration;
 
     debugger.notifyPausedAtStart();
     _inspector = await AppInspector.initialize(
@@ -226,7 +227,7 @@ class ChromeProxyService implements VmServiceInterface {
       uri,
       debugger,
       executionContext,
-      _sdkConfiguration,
+      sdkConfiguration,
     );
 
     _expressionEvaluator = _compiler == null

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -94,6 +94,8 @@ class ChromeProxyService implements VmServiceInterface {
   final ExpressionCompiler _compiler;
   ExpressionEvaluator _expressionEvaluator;
 
+  final SdkConfigurationInterface _sdkConfiguration;
+
   bool terminatingIsolates = false;
 
   ChromeProxyService._(
@@ -106,6 +108,7 @@ class ChromeProxyService implements VmServiceInterface {
     this._skipLists,
     this.executionContext,
     this._compiler,
+    this._sdkConfiguration,
   ) {
     var debugger = Debugger.create(
       remoteDebugger,
@@ -126,6 +129,7 @@ class ChromeProxyService implements VmServiceInterface {
     AppConnection appConnection,
     ExecutionContext executionContext,
     ExpressionCompiler expressionCompiler,
+    SdkConfigurationInterface sdkConfiguration,
   ) async {
     final vm = VM(
       name: 'ChromeDebugProxy',
@@ -155,6 +159,7 @@ class ChromeProxyService implements VmServiceInterface {
       skipLists,
       executionContext,
       expressionCompiler,
+      sdkConfiguration,
     );
     unawaited(service.createIsolate(appConnection));
     return service;
@@ -221,6 +226,7 @@ class ChromeProxyService implements VmServiceInterface {
       uri,
       debugger,
       executionContext,
+      _sdkConfiguration,
     );
 
     _expressionEvaluator = _compiler == null
@@ -1033,6 +1039,10 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
   @override
   Future<Breakpoint> setBreakpointState(
           String isolateId, String breakpointId, bool enable) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Success> streamCpuSamplesWithUserTag(List<String> userTags) =>
       throw UnimplementedError();
 
   /// Prevent DWDS from blocking Dart SDK rolls if changes in package:vm_service

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -203,28 +203,32 @@ class DebugService {
   }
 
   static Future<DebugService> start(
-      String hostname,
-      RemoteDebugger remoteDebugger,
-      ExecutionContext executionContext,
-      String tabUrl,
-      AssetReader assetReader,
-      LoadStrategy loadStrategy,
-      AppConnection appConnection,
-      UrlEncoder urlEncoder,
-      {void Function(Map<String, dynamic>) onRequest,
-      void Function(Map<String, dynamic>) onResponse,
-      bool spawnDds = true,
-      bool useSse,
-      ExpressionCompiler expressionCompiler}) async {
+    String hostname,
+    RemoteDebugger remoteDebugger,
+    ExecutionContext executionContext,
+    String tabUrl,
+    AssetReader assetReader,
+    LoadStrategy loadStrategy,
+    AppConnection appConnection,
+    UrlEncoder urlEncoder, {
+    void Function(Map<String, dynamic>) onRequest,
+    void Function(Map<String, dynamic>) onResponse,
+    bool spawnDds = true,
+    bool useSse,
+    ExpressionCompiler expressionCompiler,
+    SdkConfigurationInterface sdkConfiguration,
+  }) async {
     useSse ??= false;
     var chromeProxyService = await ChromeProxyService.create(
-        remoteDebugger,
-        tabUrl,
-        assetReader,
-        loadStrategy,
-        appConnection,
-        executionContext,
-        expressionCompiler);
+      remoteDebugger,
+      tabUrl,
+      assetReader,
+      loadStrategy,
+      appConnection,
+      executionContext,
+      expressionCompiler,
+      sdkConfiguration,
+    );
     var authToken = _makeAuthToken();
     var serviceExtensionRegistry = ServiceExtensionRegistry();
     Handler handler;

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -216,7 +216,7 @@ class DebugService {
     bool spawnDds = true,
     bool useSse,
     ExpressionCompiler expressionCompiler,
-    SdkConfigurationInterface sdkConfiguration,
+    SdkConfigurationProvider sdkConfigurationProvider,
   }) async {
     useSse ??= false;
     var chromeProxyService = await ChromeProxyService.create(
@@ -227,7 +227,7 @@ class DebugService {
       appConnection,
       executionContext,
       expressionCompiler,
-      sdkConfiguration,
+      sdkConfigurationProvider,
     );
     var authToken = _makeAuthToken();
     var serviceExtensionRegistry = ServiceExtensionRegistry();

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -66,16 +66,16 @@ class _Compiler {
     int port,
     String moduleFormat,
     bool soundNullSafety,
-    SdkConfigurationInterface sdkConfiguration,
+    SdkConfiguration sdkConfiguration,
     bool verbose,
   ) async {
-    await sdkConfiguration.validate();
+    sdkConfiguration.validate();
 
-    final librariesUri = await sdkConfiguration.librariesUri;
-    final workerUri = await sdkConfiguration.compilerWorkerUri;
+    final librariesUri = sdkConfiguration.librariesUri;
+    final workerUri = sdkConfiguration.compilerWorkerUri;
     final sdkSummaryUri = soundNullSafety
-        ? await sdkConfiguration.soundSdkSummaryUri
-        : await sdkConfiguration.unsoundSdkSummaryUri;
+        ? sdkConfiguration.soundSdkSummaryUri
+        : sdkConfiguration.unsoundSdkSummaryUri;
 
     final args = [
       '--experimental-expression-compiler',
@@ -223,9 +223,9 @@ class _Compiler {
 /// Uses [_address] and [_port] to communicate and [_assetHandler] to
 /// redirect asset requests to the asset server.
 ///
-/// [_sdkConfiguration] describes the locations of SDK files used in
-/// expression compilation (summaries, libraries spec, compiler worker
-/// snapshot).
+/// Configuration created by [_sdkConfigurationProvider] describes the
+/// locations of SDK files used in expression compilation (summaries,
+/// libraries spec, compiler worker snapshot).
 ///
 /// Users need to stop the service by calling [stop].
 class ExpressionCompilerService implements ExpressionCompiler {
@@ -235,16 +235,17 @@ class ExpressionCompilerService implements ExpressionCompiler {
   final Handler _assetHandler;
   final bool _verbose;
 
-  final SdkConfigurationInterface _sdkConfiguration;
+  final SdkConfigurationProvider _sdkConfigurationProvider;
 
   ExpressionCompilerService(
     this._address,
     this._port,
     this._assetHandler, {
     bool verbose = false,
-    SdkConfigurationInterface sdkConfiguration,
+    SdkConfigurationProvider sdkConfigurationProvider,
   })  : _verbose = verbose,
-        _sdkConfiguration = sdkConfiguration ?? SdkConfiguration.standard();
+        _sdkConfigurationProvider =
+            sdkConfigurationProvider ?? DefaultSdkConfigurationProvider();
 
   @override
   Future<ExpressionCompilationResult> compileExpressionToJs(
@@ -269,7 +270,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
       await _port,
       moduleFormat,
       soundNullSafety,
-      _sdkConfiguration,
+      await _sdkConfigurationProvider.configuration,
       _verbose,
     );
 

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -74,15 +74,15 @@ class _Compiler {
     final librariesUri = await sdkConfiguration.librariesUri;
     final workerUri = await sdkConfiguration.compilerWorkerUri;
     final sdkSummaryUri = soundNullSafety
-        ? await sdkConfiguration.soundSdkSummaryPath
-        : await sdkConfiguration.unsoundSdkSummaryPath;
+        ? await sdkConfiguration.soundSdkSummaryUri
+        : await sdkConfiguration.unsoundSdkSummaryUri;
 
     final args = [
       '--experimental-expression-compiler',
       '--libraries-file',
       '$librariesUri',
       '--dart-sdk-summary',
-      sdkSummaryUri,
+      '$sdkSummaryUri',
       '--asset-server-address',
       address,
       '--asset-server-port',

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -5,15 +5,14 @@
 // @dart = 2.9
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:isolate';
 
 import 'package:async/async.dart';
 import 'package:logging/logging.dart';
-import 'package:path/path.dart' as p;
 import 'package:shelf/shelf.dart';
 
 import '../utilities/dart_uri.dart';
+import '../utilities/sdk_configuration.dart';
 import 'expression_compiler.dart';
 
 final _logger = Logger('ExpressionCompilerService');
@@ -50,10 +49,9 @@ class _Compiler {
   /// Starts expression compiler worker in an isolate and creates the
   /// expression compilation service that communicates to the worker.
   ///
-  /// [workerPath] is the path for the expression compiler worker,
-  /// [sdkSummaryPath] is the path to the sdk summary dill file
-  /// [librariesPath] is the path to libraries definitions file
-  /// libraries.json.
+  /// [sdkConfiguration] describes the locations of SDK files used in
+  /// expression compilation (summaries, libraries spec, compiler worker
+  /// snapshot).
   ///
   /// [soundNullSafety] indiciates if the compioler should support sound null
   /// safety.
@@ -66,35 +64,25 @@ class _Compiler {
   static Future<_Compiler> start(
     String address,
     int port,
-    String workerPath,
-    String sdkSummaryPath,
-    String librariesPath,
     String moduleFormat,
-    bool verbose,
     bool soundNullSafety,
+    SdkConfigurationInterface sdkConfiguration,
+    bool verbose,
   ) async {
-    final workerUri = p.toUri(p.absolute(workerPath));
-    if (!File.fromUri(workerUri).existsSync()) {
-      _logger.severe('Worker path $workerPath does not exist');
-    }
+    await sdkConfiguration.validate();
 
-    if (!File(sdkSummaryPath).existsSync()) {
-      _logger.severe('SDK summary path $sdkSummaryPath does not exist');
-    }
-
-    if (!File(librariesPath).existsSync()) {
-      _logger.severe('Libraries path $librariesPath does not exist');
-    }
-
-    final sdkSummaryUri = Uri.file(sdkSummaryPath);
-    final librariesUri = Uri.file(librariesPath);
+    final librariesUri = await sdkConfiguration.librariesUri;
+    final workerUri = await sdkConfiguration.compilerWorkerUri;
+    final sdkSummaryUri = soundNullSafety
+        ? await sdkConfiguration.soundSdkSummaryPath
+        : await sdkConfiguration.unsoundSdkSummaryPath;
 
     final args = [
       '--experimental-expression-compiler',
       '--libraries-file',
       '$librariesUri',
       '--dart-sdk-summary',
-      '$sdkSummaryUri',
+      sdkSummaryUri,
       '--asset-server-address',
       address,
       '--asset-server-port',
@@ -235,9 +223,9 @@ class _Compiler {
 /// Uses [_address] and [_port] to communicate and [_assetHandler] to
 /// redirect asset requests to the asset server.
 ///
-/// [_sdkDir] is the path to the SDK installation directory.
-/// [_workerPath] is the path to the DDC worker snapshot.
-/// [_librariesPath] is the path to the libraries.json spec.
+/// [_sdkConfiguration] describes the locations of SDK files used in
+/// expression compilation (summaries, libraries spec, compiler worker
+/// snapshot).
 ///
 /// Users need to stop the service by calling [stop].
 class ExpressionCompilerService implements ExpressionCompiler {
@@ -247,16 +235,16 @@ class ExpressionCompilerService implements ExpressionCompiler {
   final Handler _assetHandler;
   final bool _verbose;
 
-  final String _sdkDir;
-  final String _workerPath;
-  final String _librariesPath;
+  final SdkConfigurationInterface _sdkConfiguration;
 
   ExpressionCompilerService(
-      this._address, this._port, this._assetHandler, this._verbose,
-      {String sdkDir, String workerPath, String librariesPath})
-      : _sdkDir = sdkDir,
-        _workerPath = workerPath,
-        _librariesPath = librariesPath;
+    this._address,
+    this._port,
+    this._assetHandler, {
+    bool verbose = false,
+    SdkConfigurationInterface sdkConfiguration,
+  })  : _verbose = verbose,
+        _sdkConfiguration = sdkConfiguration ?? SdkConfiguration.standard();
 
   @override
   Future<ExpressionCompilationResult> compileExpressionToJs(
@@ -276,20 +264,14 @@ class ExpressionCompilerService implements ExpressionCompiler {
     if (_compiler.isCompleted) return;
     soundNullSafety ??= false;
 
-    final binDir = p.dirname(Platform.resolvedExecutable);
-    var sdkDir = _sdkDir ?? p.dirname(binDir);
-
-    var sdkSummaryRoot = p.join(sdkDir, 'lib', '_internal');
-    var sdkSummaryPath = soundNullSafety
-        ? p.join(sdkSummaryRoot, 'ddc_outline_sound.dill')
-        : p.join(sdkSummaryRoot, 'ddc_sdk.dill');
-    var librariesPath =
-        _librariesPath ?? p.join(sdkDir, 'lib', 'libraries.json');
-    var workerPath =
-        _workerPath ?? p.join(binDir, 'snapshots', 'dartdevc.dart.snapshot');
-
-    var compiler = await _Compiler.start(_address, await _port, workerPath,
-        sdkSummaryPath, librariesPath, moduleFormat, _verbose, soundNullSafety);
+    var compiler = await _Compiler.start(
+      _address,
+      await _port,
+      moduleFormat,
+      soundNullSafety,
+      _sdkConfiguration,
+      _verbose,
+    );
 
     _compiler.complete(compiler);
   }

--- a/dwds/lib/src/utilities/dart_uri.dart
+++ b/dwds/lib/src/utilities/dart_uri.dart
@@ -156,12 +156,19 @@ class DartUri {
 
   /// Record library and script uris to enable resolving library and script paths.
   static Future<void> initialize(SdkConfiguration sdkConfiguration) async {
-    sdkConfiguration.validateSdkDir();
     _sdkConfiguration = sdkConfiguration;
     var packagesUri = p.toUri(p.join(currentDirectory, '.packages'));
 
     clear();
-    await _loadLibrariesConfig(_sdkConfiguration.librariesUri);
+
+    // Allow for tests can supplying empty configurations.
+    if (_sdkConfiguration.sdkDirectory != null) {
+      _sdkConfiguration.validateSdkDir();
+    }
+    if (_sdkConfiguration.librariesUri != null) {
+      await _loadLibrariesConfig(_sdkConfiguration.librariesUri);
+    }
+
     await _loadPackageConfig(packagesUri);
   }
 

--- a/dwds/lib/src/utilities/sdk_configuration.dart
+++ b/dwds/lib/src/utilities/sdk_configuration.dart
@@ -1,0 +1,145 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart=2.9
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+class InvalidSdkConfigurationException implements Exception {
+  final String message;
+
+  InvalidSdkConfigurationException([this.message]);
+
+  @override
+  String toString() {
+    var message = this.message;
+    if (message == null) return 'Invalid SDK configuration';
+    return 'Invalid SDK configuration: $message';
+  }
+}
+
+/// Interface describing the SDK layout.
+///
+/// Note: Supports lazily populated configurations.
+/// Call [validate] method to make sure the files in the
+/// configuration layout exist before reading the files.
+abstract class SdkConfigurationInterface {
+  Future<String> get sdkDirectory;
+  Future<String> get unsoundSdkSummaryPath;
+  Future<String> get soundSdkSummaryPath;
+  Future<String> get librariesPath;
+  Future<String> get compilerWorkerPath;
+
+  Future<Uri> get sdkDirectoryUri =>
+      sdkDirectory.then((value) => value == null ? null : Uri.parse(value));
+
+  Future<Uri> get librariesUri =>
+      librariesPath.then((value) => value == null ? null : Uri.parse(value));
+
+  /// Note: has to be ///file: Uri to run in an isolate.
+  Future<Uri> get compilerWorkerUri => compilerWorkerPath
+      .then((value) => value == null ? null : p.toUri(p.absolute(value)));
+
+  /// Throws [InvalidSdkConfigurationException] if configuration does not
+  /// exist on disk.
+  Future<void> validate() async {
+    await validateSdkDir();
+
+    var libraries = await librariesPath;
+    if (libraries == null || !File(libraries).existsSync()) {
+      throw InvalidSdkConfigurationException(
+          'Libraries spec $libraries does not exist');
+    }
+
+    var unsoundSdkSummary = await unsoundSdkSummaryPath;
+    if (unsoundSdkSummary == null || !File(unsoundSdkSummary).existsSync()) {
+      throw InvalidSdkConfigurationException(
+          'Sdk summary $unsoundSdkSummary does not exist');
+    }
+
+    var soundSdkSummary = await soundSdkSummaryPath;
+    if (soundSdkSummary == null || !File(soundSdkSummary).existsSync()) {
+      throw InvalidSdkConfigurationException(
+          'Sdk summary $soundSdkSummary does not exist');
+    }
+
+    var compilerWorker = await compilerWorkerPath;
+    if (compilerWorker == null || !File(compilerWorker).existsSync()) {
+      throw InvalidSdkConfigurationException(
+          'Compiler worker $compilerWorker does not exist');
+    }
+  }
+
+  /// Throws [InvalidSdkConfigurationException] if SDK root does not
+  /// exist on the disk.
+  Future<void> validateSdkDir() async {
+    var sdkDir = await sdkDirectory;
+    if (sdkDir == null || !Directory(sdkDir).existsSync()) {
+      throw InvalidSdkConfigurationException(
+          'Sdk directory $sdkDir does not exist');
+    }
+  }
+}
+
+/// Implementation for the default SDK configuration layout.
+class SdkConfiguration extends SdkConfigurationInterface {
+  final String _sdkDirectory;
+  final String _unsoundSdkSummaryPath;
+  final String _soundSdkSummaryPath;
+  final String _librariesPath;
+  final String _compilerWorkerPath;
+
+  SdkConfiguration({
+    String sdkDirectory,
+    String unsoundSdkSummaryPath,
+    String soundSdkSummaryPath,
+    String librariesPath,
+    String compilerWorkerPath,
+  })  : _sdkDirectory = sdkDirectory,
+        _unsoundSdkSummaryPath = unsoundSdkSummaryPath,
+        _soundSdkSummaryPath = soundSdkSummaryPath,
+        _librariesPath = librariesPath,
+        _compilerWorkerPath = compilerWorkerPath;
+
+  @override
+  Future<String> get sdkDirectory async => _sdkDirectory;
+
+  @override
+  Future<String> get unsoundSdkSummaryPath async => _unsoundSdkSummaryPath;
+
+  @override
+  Future<String> get soundSdkSummaryPath async => _soundSdkSummaryPath;
+
+  @override
+  Future<String> get librariesPath async => _librariesPath;
+
+  @override
+  Future<String> get compilerWorkerPath async => _compilerWorkerPath;
+
+  /// Create and validate configuration matching the default SDK layout.
+  factory SdkConfiguration.standard() {
+    final binDir = p.dirname(Platform.resolvedExecutable);
+    final sdkDir = p.dirname(binDir);
+
+    if (sdkDir == null || !Directory(sdkDir).existsSync()) {
+      throw InvalidSdkConfigurationException(
+          'Could not detect default SDK configuration. '
+          'Directory $sdkDir does not exist.');
+    }
+
+    var configuration = SdkConfiguration(
+      sdkDirectory: sdkDir,
+      unsoundSdkSummaryPath: p.join(sdkDir, 'lib', '_internal', 'ddc_sdk.dill'),
+      soundSdkSummaryPath:
+          p.join(sdkDir, 'lib', '_internal', 'ddc_outline_sound.dill'),
+      librariesPath: p.join(sdkDir, 'lib', 'libraries.json'),
+      compilerWorkerPath: p.join(binDir, 'snapshots', 'dartdevc.dart.snapshot'),
+    );
+
+    configuration.validate();
+    return configuration;
+  }
+}

--- a/dwds/lib/src/utilities/sdk_configuration.dart
+++ b/dwds/lib/src/utilities/sdk_configuration.dart
@@ -34,16 +34,16 @@ abstract class SdkConfigurationInterface {
   Future<String> get compilerWorkerPath;
 
   Future<Uri> get sdkDirectoryUri =>
-      sdkDirectory.then((value) => value == null ? null : Uri.parse(value));
+      sdkDirectory.then((value) => value == null ? null : p.toUri(value));
 
   Future<Uri> get soundSdkSummaryUri => soundSdkSummaryPath
-      .then((value) => value == null ? null : Uri.file(value));
+      .then((value) => value == null ? null : p.toUri(value));
 
   Future<Uri> get unsoundSdkSummaryUri => unsoundSdkSummaryPath
-      .then((value) => value == null ? null : Uri.file(value));
+      .then((value) => value == null ? null : p.toUri(value));
 
   Future<Uri> get librariesUri =>
-      librariesPath.then((value) => value == null ? null : Uri.file(value));
+      librariesPath.then((value) => value == null ? null : p.toUri(value));
 
   /// Note: has to be ///file: Uri to run in an isolate.
   Future<Uri> get compilerWorkerUri => compilerWorkerPath

--- a/dwds/lib/src/utilities/sdk_configuration.dart
+++ b/dwds/lib/src/utilities/sdk_configuration.dart
@@ -4,12 +4,6 @@
 
 // @dart=2.9
 
-// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
-// @dart=2.9
-
 import 'dart:io';
 
 import 'package:file/file.dart';
@@ -29,15 +23,20 @@ class InvalidSdkConfigurationException implements Exception {
   }
 }
 
+/// SDK configuration provider interface.
+///
+/// Supports lazily populated configurations by allowing to create
+/// configuration asyncronously.
 abstract class SdkConfigurationProvider {
   Future<SdkConfiguration> get configuration;
 }
 
 /// Data class describing the SDK layout.
 ///
-/// Note: Supports lazily populated configurations.
-/// Call [validate] method to make sure the files in the
-/// configuration layout exist before reading the files.
+/// Provides helpers to convert paths to uris that work on all platforms.
+///
+/// Call [validate] method to make sure the files in the configuration
+/// layout exist before reading the files.
 class SdkConfiguration {
   String sdkDirectory;
   String unsoundSdkSummaryPath;

--- a/dwds/lib/src/utilities/sdk_configuration.dart
+++ b/dwds/lib/src/utilities/sdk_configuration.dart
@@ -36,8 +36,14 @@ abstract class SdkConfigurationInterface {
   Future<Uri> get sdkDirectoryUri =>
       sdkDirectory.then((value) => value == null ? null : Uri.parse(value));
 
+  Future<Uri> get soundSdkSummaryUri => soundSdkSummaryPath
+      .then((value) => value == null ? null : Uri.file(value));
+
+  Future<Uri> get unsoundSdkSummaryUri => unsoundSdkSummaryPath
+      .then((value) => value == null ? null : Uri.file(value));
+
   Future<Uri> get librariesUri =>
-      librariesPath.then((value) => value == null ? null : Uri.parse(value));
+      librariesPath.then((value) => value == null ? null : Uri.file(value));
 
   /// Note: has to be ///file: Uri to run in an isolate.
   Future<Uri> get compilerWorkerUri => compilerWorkerPath

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   built_value: '>=6.7.0 <9.0.0'
   crypto: '>=2.0.6 <4.0.0'
   dds: ^2.2.0
+  file: ^6.1.2
   http: '>=0.12.0 <0.14.0'
   http_multi_server: ^3.0.0
   logging: '>=0.11.3 <2.0.0'

--- a/dwds/test/dart_uri_test.dart
+++ b/dwds/test/dart_uri_test.dart
@@ -7,9 +7,9 @@
 @TestOn('vm')
 import 'dart:io';
 
-import 'package:dwds/dwds.dart';
 import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
+import 'package:dwds/src/utilities/sdk_configuration.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -55,7 +55,9 @@ void main() {
 
     group('initialized with current SDK directory', () {
       setUpAll(() async {
-        await DartUri.initialize(SdkConfiguration.standard());
+        var sdkConfiguration =
+            await DefaultSdkConfigurationProvider().configuration;
+        await DartUri.initialize(sdkConfiguration);
         await DartUri.recordAbsoluteUris(['dart:io', 'dart:html']);
       });
 

--- a/dwds/test/dart_uri_test.dart
+++ b/dwds/test/dart_uri_test.dart
@@ -53,6 +53,21 @@ void main() {
       expect(uri.serverPath, 'web/main.dart');
     });
 
+    group('initialized with empty configuration', () {
+      setUpAll(() async {
+        var sdkConfiguration =
+            await FakeSdkConfigurationProvider().configuration;
+        await DartUri.initialize(sdkConfiguration);
+        await DartUri.recordAbsoluteUris(['dart:io', 'dart:html']);
+      });
+
+      tearDownAll(DartUri.clear);
+      test('cannot resolve uris', () async {
+        var resolved = DartUri.toResolvedUri('dart:io');
+        expect(resolved, isNull);
+      });
+    });
+
     group('initialized with current SDK directory', () {
       setUpAll(() async {
         var sdkConfiguration =
@@ -173,4 +188,9 @@ void main() {
       });
     });
   });
+}
+
+class FakeSdkConfigurationProvider extends SdkConfigurationProvider {
+  @override
+  Future<SdkConfiguration> get configuration async => SdkConfiguration();
 }

--- a/dwds/test/dart_uri_test.dart
+++ b/dwds/test/dart_uri_test.dart
@@ -7,6 +7,7 @@
 @TestOn('vm')
 import 'dart:io';
 
+import 'package:dwds/dwds.dart';
 import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:path/path.dart' as p;
@@ -54,7 +55,7 @@ void main() {
 
     group('initialized with current SDK directory', () {
       setUpAll(() async {
-        await DartUri.initialize();
+        await DartUri.initialize(SdkConfiguration.standard());
         await DartUri.recordAbsoluteUris(['dart:io', 'dart:html']);
       });
 
@@ -90,7 +91,11 @@ void main() {
         Directory(fakeLibrariesDir).createSync();
         File(librariesPath).copySync(fakeLibrariesPath);
 
-        await DartUri.initialize(sdkDir: Uri.file(fakeSdkDir));
+        var sdkConfiguration = SdkConfiguration(
+          sdkDirectory: fakeSdkDir,
+          librariesPath: fakeLibrariesPath,
+        );
+        await DartUri.initialize(sdkConfiguration);
         await DartUri.recordAbsoluteUris(['dart:io', 'dart:html']);
       });
 
@@ -133,9 +138,11 @@ void main() {
         var fakeLibrariesDir = p.join(fakeSdkDir, 'lib');
         var fakeLibrariesPath = p.join(fakeLibrariesDir, 'libraries.json');
 
-        await DartUri.initialize(
-            sdkDir: Uri.file(fakeSdkDir),
-            librariesPath: Uri.file(fakeLibrariesPath));
+        var sdkConfiguration = SdkConfiguration(
+          sdkDirectory: fakeSdkDir,
+          librariesPath: fakeLibrariesPath,
+        );
+        await DartUri.initialize(sdkConfiguration);
         await DartUri.recordAbsoluteUris(['dart:io', 'dart:html']);
 
         expect(

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -81,7 +81,7 @@ void main() async {
           await context.webDriver.driver.switchTo.window(windows.last);
           expect(await context.webDriver.title, 'Dart DevTools');
         });
-      }, skip: 'https://github.com/dart-lang/webdev/issues/1512');
+      });
 
       group('With a sharded Dart app', () {
         setUp(() async {

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -80,7 +80,7 @@ void main() async {
           var windows = await context.webDriver.windows.toList();
           await context.webDriver.driver.switchTo.window(windows.last);
           expect(await context.webDriver.title, 'Dart DevTools');
-        });
+        }, skip: 'https://github.com/dart-lang/webdev/issues/1512');
       });
 
       group('With a sharded Dart app', () {
@@ -158,7 +158,7 @@ void main() async {
           var windows = await context.webDriver.windows.toList();
           await context.webDriver.driver.switchTo.window(windows.last);
           expect(await context.webDriver.title, 'Dart DevTools');
-        });
+        }, skip: 'https://github.com/dart-lang/webdev/issues/1512');
       });
     });
   }

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -75,7 +75,7 @@ void main() async {
           await context.webDriver.driver.switchTo.window(windows.last);
           expect(await context.webDriver.title, 'Dart DevTools');
         });
-      });
+      }, skip: 'https://github.com/dart-lang/webdev/issues/1512');
 
       group('With a sharded Dart app', () {
         setUp(() async {

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -61,8 +61,8 @@ void main() async {
       // start expression compilation service
       Response assetHandler(request) =>
           Response(200, body: File.fromUri(kernel).readAsBytesSync());
-      service =
-          ExpressionCompilerService('localhost', port, assetHandler, false);
+      service = ExpressionCompilerService('localhost', port, assetHandler,
+          verbose: false);
 
       await service.initialize(moduleFormat: 'amd');
 

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -105,21 +105,23 @@ class TestContext {
     _entryContents = _entryFile.readAsStringSync();
   }
 
-  Future<void> setUp(
-      {ReloadConfiguration reloadConfiguration,
-      bool serveDevTools,
-      bool enableDebugExtension,
-      bool autoRun,
-      bool enableDebugging,
-      bool useSse,
-      bool spawnDds,
-      String hostname,
-      bool waitToDebug,
-      UrlEncoder urlEncoder,
-      bool restoreBreakpoints,
-      CompilationMode compilationMode,
-      bool enableExpressionEvaluation,
-      bool verboseCompiler}) async {
+  Future<void> setUp({
+    ReloadConfiguration reloadConfiguration,
+    bool serveDevTools,
+    bool enableDebugExtension,
+    bool autoRun,
+    bool enableDebugging,
+    bool useSse,
+    bool spawnDds,
+    String hostname,
+    bool waitToDebug,
+    UrlEncoder urlEncoder,
+    bool restoreBreakpoints,
+    CompilationMode compilationMode,
+    bool enableExpressionEvaluation,
+    bool verboseCompiler,
+    SdkConfigurationInterface sdkConfiguration,
+  }) async {
     reloadConfiguration ??= ReloadConfiguration.none;
     serveDevTools ??= false;
     enableDebugExtension ??= false;
@@ -130,6 +132,7 @@ class TestContext {
     enableExpressionEvaluation ??= false;
     spawnDds ??= true;
     verboseCompiler ??= false;
+    sdkConfiguration ??= SdkConfiguration.standard();
 
     try {
       configureLogWriter();
@@ -219,7 +222,8 @@ class TestContext {
                 'localhost',
                 port,
                 assetHandler,
-                verboseCompiler,
+                verbose: verboseCompiler,
+                sdkConfiguration: sdkConfiguration,
               );
               expressionCompiler = ddcService;
             }

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -14,6 +14,7 @@ import 'package:build_daemon/data/build_target.dart';
 import 'package:dwds/dwds.dart';
 import 'package:dwds/src/debugging/webkit_debugger.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
+import 'package:dwds/src/utilities/sdk_configuration.dart';
 import 'package:dwds/src/utilities/shared.dart';
 import 'package:frontend_server_common/src/resident_runner.dart';
 import 'package:http/http.dart';
@@ -120,7 +121,7 @@ class TestContext {
     CompilationMode compilationMode,
     bool enableExpressionEvaluation,
     bool verboseCompiler,
-    SdkConfigurationInterface sdkConfiguration,
+    SdkConfigurationProvider sdkConfigurationProvider,
   }) async {
     reloadConfiguration ??= ReloadConfiguration.none;
     serveDevTools ??= false;
@@ -132,7 +133,7 @@ class TestContext {
     enableExpressionEvaluation ??= false;
     spawnDds ??= true;
     verboseCompiler ??= false;
-    sdkConfiguration ??= SdkConfiguration.standard();
+    sdkConfigurationProvider ??= DefaultSdkConfigurationProvider();
 
     try {
       configureLogWriter();
@@ -223,7 +224,7 @@ class TestContext {
                 port,
                 assetHandler,
                 verbose: verboseCompiler,
-                sdkConfiguration: sdkConfiguration,
+                sdkConfigurationProvider: sdkConfigurationProvider,
               );
               expressionCompiler = ddcService;
             }

--- a/dwds/test/sdk_configuration_test.dart
+++ b/dwds/test/sdk_configuration_test.dart
@@ -18,17 +18,17 @@ var _throwsDoesNotExistException = throwsA(
 void main() {
   group('Basic configuration', () {
     test('Can validate default configuration layout', () async {
-      var defaultConfiguration = SdkConfiguration.standard();
-      await defaultConfiguration.validateSdkDir();
-      await defaultConfiguration.validate();
+      var defaultConfiguration =
+          await DefaultSdkConfigurationProvider().configuration;
+      defaultConfiguration.validateSdkDir();
+      defaultConfiguration.validate();
     });
 
     test('Cannot validate an empty configuration layout', () async {
       var emptyConfiguration = SdkConfiguration();
-      await expectLater(
-          emptyConfiguration.validateSdkDir(), _throwsDoesNotExistException);
-      await expectLater(
-          emptyConfiguration.validate(), _throwsDoesNotExistException);
+      expect(() => emptyConfiguration.validateSdkDir(),
+          _throwsDoesNotExistException);
+      expect(() => emptyConfiguration.validate(), _throwsDoesNotExistException);
     });
   });
 
@@ -45,30 +45,31 @@ void main() {
     });
 
     test('Can validate existing configuration layout', () async {
-      var defaultSdkConfiguration = SdkConfiguration.standard();
+      var defaultSdkConfiguration =
+          await DefaultSdkConfigurationProvider().configuration;
 
       var sdkDirectory = outputDir.path;
       var librariesDir = p.join(sdkDirectory, 'specs');
       var librariesPath = p.join(librariesDir, 'libraries.json');
 
       Directory(librariesDir).createSync(recursive: true);
-      File(await defaultSdkConfiguration.librariesPath).copySync(librariesPath);
+      File(defaultSdkConfiguration.librariesPath).copySync(librariesPath);
 
       var summariesDir = p.join(sdkDirectory, 'summaries');
       var unsoundSdkSummaryPath = p.join(summariesDir, 'ddc_sdk.dill');
       var soundSdkSummaryPath = p.join(summariesDir, 'ddc_outline_sound.dill');
 
       Directory(summariesDir).createSync(recursive: true);
-      File(await defaultSdkConfiguration.unsoundSdkSummaryPath)
+      File(defaultSdkConfiguration.unsoundSdkSummaryPath)
           .copySync(unsoundSdkSummaryPath);
-      File(await defaultSdkConfiguration.soundSdkSummaryPath)
+      File(defaultSdkConfiguration.soundSdkSummaryPath)
           .copySync(soundSdkSummaryPath);
 
       var workerDir = p.join(sdkDirectory, 'snapshots');
       var compilerWorkerPath = p.join(workerDir, 'dartdevc.dart.snapshot');
 
       Directory(workerDir).createSync(recursive: true);
-      File(await defaultSdkConfiguration.compilerWorkerPath)
+      File(defaultSdkConfiguration.compilerWorkerPath)
           .copySync(compilerWorkerPath);
 
       var sdkConfiguration = SdkConfiguration(
@@ -79,17 +80,15 @@ void main() {
         compilerWorkerPath: compilerWorkerPath,
       );
 
-      expect(await sdkConfiguration.sdkDirectory, equals(sdkDirectory));
-      expect(await sdkConfiguration.unsoundSdkSummaryPath,
+      expect(sdkConfiguration.sdkDirectory, equals(sdkDirectory));
+      expect(sdkConfiguration.unsoundSdkSummaryPath,
           equals(unsoundSdkSummaryPath));
-      expect(await sdkConfiguration.soundSdkSummaryPath,
-          equals(soundSdkSummaryPath));
-      expect(await sdkConfiguration.librariesPath, equals(librariesPath));
-      expect(await sdkConfiguration.compilerWorkerPath,
-          equals(compilerWorkerPath));
+      expect(sdkConfiguration.soundSdkSummaryPath, equals(soundSdkSummaryPath));
+      expect(sdkConfiguration.librariesPath, equals(librariesPath));
+      expect(sdkConfiguration.compilerWorkerPath, equals(compilerWorkerPath));
 
-      await expectLater(sdkConfiguration.validateSdkDir(), completes);
-      await expectLater(sdkConfiguration.validate(), completes);
+      sdkConfiguration.validateSdkDir();
+      sdkConfiguration.validate();
     });
 
     test('Cannot validate non-existing configuration layout', () async {
@@ -110,9 +109,8 @@ void main() {
         compilerWorkerPath: compilerWorkerPath,
       );
 
-      await expectLater(sdkConfiguration.validateSdkDir(), completes);
-      await expectLater(
-          sdkConfiguration.validate(), _throwsDoesNotExistException);
+      sdkConfiguration.validateSdkDir();
+      expect(() => sdkConfiguration.validate(), _throwsDoesNotExistException);
     });
   });
 }

--- a/dwds/test/sdk_configuration_test.dart
+++ b/dwds/test/sdk_configuration_test.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart = 2.9
+
+@TestOn('vm')
+import 'dart:io';
+
+import 'package:dwds/src/utilities/sdk_configuration.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+var _throwsDoesNotExistException = throwsA(
+    isA<InvalidSdkConfigurationException>()
+        .having((e) => '$e', 'message', contains('does not exist')));
+
+void main() {
+  group('Basic configuration', () {
+    test('Can validate default configuration layout', () async {
+      var defaultConfiguration = SdkConfiguration.standard();
+      await defaultConfiguration.validateSdkDir();
+      await defaultConfiguration.validate();
+    });
+
+    test('Cannot validate an empty configuration layout', () async {
+      var emptyConfiguration = SdkConfiguration();
+      await expectLater(
+          emptyConfiguration.validateSdkDir(), _throwsDoesNotExistException);
+      await expectLater(
+          emptyConfiguration.validate(), _throwsDoesNotExistException);
+    });
+  });
+
+  group('Non-standard configuration', () {
+    Directory outputDir;
+
+    setUp(() async {
+      var systemTempDir = Directory.systemTemp;
+      outputDir = systemTempDir.createTempSync('foo bar');
+    });
+
+    tearDown(() async {
+      await outputDir?.delete(recursive: true);
+    });
+
+    test('Can validate existing configuration layout', () async {
+      var defaultSdkConfiguration = SdkConfiguration.standard();
+
+      var sdkDirectory = outputDir.path;
+      var librariesDir = p.join(sdkDirectory, 'specs');
+      var librariesPath = p.join(librariesDir, 'libraries.json');
+
+      Directory(librariesDir).createSync(recursive: true);
+      File(await defaultSdkConfiguration.librariesPath).copySync(librariesPath);
+
+      var summariesDir = p.join(sdkDirectory, 'summaries');
+      var unsoundSdkSummaryPath = p.join(summariesDir, 'ddc_sdk.dill');
+      var soundSdkSummaryPath = p.join(summariesDir, 'ddc_outline_sound.dill');
+
+      Directory(summariesDir).createSync(recursive: true);
+      File(await defaultSdkConfiguration.unsoundSdkSummaryPath)
+          .copySync(unsoundSdkSummaryPath);
+      File(await defaultSdkConfiguration.soundSdkSummaryPath)
+          .copySync(soundSdkSummaryPath);
+
+      var workerDir = p.join(sdkDirectory, 'snapshots');
+      var compilerWorkerPath = p.join(workerDir, 'dartdevc.dart.snapshot');
+
+      Directory(workerDir).createSync(recursive: true);
+      File(await defaultSdkConfiguration.compilerWorkerPath)
+          .copySync(compilerWorkerPath);
+
+      var sdkConfiguration = SdkConfiguration(
+        sdkDirectory: sdkDirectory,
+        soundSdkSummaryPath: soundSdkSummaryPath,
+        unsoundSdkSummaryPath: unsoundSdkSummaryPath,
+        librariesPath: librariesPath,
+        compilerWorkerPath: compilerWorkerPath,
+      );
+
+      expect(await sdkConfiguration.sdkDirectory, equals(sdkDirectory));
+      expect(await sdkConfiguration.unsoundSdkSummaryPath,
+          equals(unsoundSdkSummaryPath));
+      expect(await sdkConfiguration.soundSdkSummaryPath,
+          equals(soundSdkSummaryPath));
+      expect(await sdkConfiguration.librariesPath, equals(librariesPath));
+      expect(await sdkConfiguration.compilerWorkerPath,
+          equals(compilerWorkerPath));
+
+      await expectLater(sdkConfiguration.validateSdkDir(), completes);
+      await expectLater(sdkConfiguration.validate(), completes);
+    });
+
+    test('Cannot validate non-existing configuration layout', () async {
+      var sdkDir = outputDir.path;
+      var librariesDir = p.join(sdkDir, 'fakespecs');
+      var librariesPath = p.join(librariesDir, 'libraries.json');
+      var summariesDir = p.join(sdkDir, 'fakesummaries');
+      var unsoundSdkSummaryPath = p.join(summariesDir, 'ddc_sdk.dill');
+      var soundSdkSummaryPath = p.join(summariesDir, 'ddc_outline_sound.dill');
+      var workerDir = p.join(sdkDir, 'fakesnapshots');
+      var compilerWorkerPath = p.join(workerDir, 'dartdevc.dart.snapshot');
+
+      var sdkConfiguration = SdkConfiguration(
+        sdkDirectory: sdkDir,
+        soundSdkSummaryPath: soundSdkSummaryPath,
+        unsoundSdkSummaryPath: unsoundSdkSummaryPath,
+        librariesPath: librariesPath,
+        compilerWorkerPath: compilerWorkerPath,
+      );
+
+      await expectLater(sdkConfiguration.validateSdkDir(), completes);
+      await expectLater(
+          sdkConfiguration.validate(), _throwsDoesNotExistException);
+    });
+  });
+}


### PR DESCRIPTION
- Add SdkConfigurationInterface and a default implementation.
- Pass SdkConfiguration to dwds and ExpressionCompilerService.
- Add tests.

Note: this change will enable us to add debugging for scenarios where SDK files are generated and copied during the build.