### PR TITLE
Fix flakes in tests due to race condition on finding a free port

### DIFF
--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -11,7 +11,6 @@ import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/events.dart';
 import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:dwds/src/utilities/shared.dart';
-import 'package:http_multi_server/http_multi_server.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webdriver/async_core.dart';
@@ -33,7 +32,7 @@ void main() {
 
     setUp(() async {
       setCurrentLogWriter();
-      server = await HttpMultiServer.bind('localhost', 0);
+      server = await startHttpServer('localhost', port: 0);
     });
 
     tearDown(() async {

--- a/dwds/test/fixtures/server.dart
+++ b/dwds/test/fixtures/server.dart
@@ -11,7 +11,6 @@ import 'package:dds/devtools_server.dart';
 import 'package:dwds/data/build_result.dart';
 import 'package:dwds/dwds.dart';
 import 'package:dwds/src/utilities/shared.dart';
-import 'package:http_multi_server/http_multi_server.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
@@ -123,7 +122,7 @@ class TestServer {
               }
             : null);
 
-    var server = await HttpMultiServer.bind('localhost', port);
+    var server = await startHttpServer('localhost', port: port);
     var cascade = Cascade();
 
     cascade = cascade.add(dwds.handler).add(assetHandler);


### PR DESCRIPTION
Retry starting HttpServer in tests a few times to recover from a rare race condition.

Closes: https://github.com/dart-lang/webdev/issues/1514