### PR TITLE
Fix issues in DevTools load time reporting

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,14 +1,16 @@
 ## 13.0.0-dev
 - Change wording of paused overlay from "Paused in Dart DevTools" to "Paused"
-- Allow sending back the Dart DevTools URL from DWDS instead of launching 
+- Allow sending back the Dart DevTools URL from DWDS instead of launching
   Dart DevTools, to support embedding Dart DevTools in Chrome DevTools.
 - Temporarily disable the paused in debugger overlay.
 - Add `SdkConfiguration` and `SdkConfigurationProvider` classes to allow
   for lazily created SDK configurations.
+- Fix an issue in reporting DevTools stats where the DevTools load time was
+  not always recorded.
 
 **Breaking changes:**
-- `Dwds.start` and `ExpressionCompilerService` now take 
-  `sdkConfigurationProvider` argument instead of separate SDK-related file 
+- `Dwds.start` and `ExpressionCompilerService` now take
+  `sdkConfigurationProvider` argument instead of separate SDK-related file
   paths.
 
 ## 12.1.0

--- a/dwds/lib/dwds.dart
+++ b/dwds/lib/dwds.dart
@@ -89,9 +89,7 @@ class Dwds {
 
   Future<DebugConnection> debugConnection(AppConnection appConnection) async {
     if (!_enableDebugging) throw StateError('Debugging is not enabled.');
-    final dwdsStats = DwdsStats(DateTime.now());
-    var appDebugServices =
-        await _devHandler.loadAppServices(appConnection, dwdsStats);
+    var appDebugServices = await _devHandler.loadAppServices(appConnection);
     await appDebugServices.chromeProxyService.isInitialized;
     return DebugConnection(appDebugServices);
   }

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -150,10 +150,9 @@ void _processSendEvent(Map<String, dynamic> event,
   switch (type) {
     case 'DevtoolsEvent':
       {
-        var screen = payload == null ? null : payload['screen'];
         var action = payload == null ? null : payload['action'];
-        if (screen == 'debugger' && action == 'pageReady') {
-          if (dwdsStats.isFirstDebuggerReady()) {
+        if (action == 'pageReady') {
+          if (dwdsStats.isFirstDebuggerReady) {
             if (dwdsStats.devToolsStart != null) {
               emitEvent(DwdsEvent.devToolsLoad(DateTime.now()
                   .difference(dwdsStats.devToolsStart)
@@ -165,6 +164,7 @@ void _processSendEvent(Map<String, dynamic> event,
                   .inMilliseconds));
             }
           } else {
+            print('Ignoring already received event: $event');
             _logger.warning('Ignoring already received event: $event');
           }
         } else {

--- a/dwds/lib/src/events.dart
+++ b/dwds/lib/src/events.dart
@@ -10,21 +10,27 @@ import 'package:vm_service/vm_service.dart';
 
 class DwdsStats {
   /// The time when the user starts the debugger.
-  final DateTime debuggerStart;
+  DateTime _debuggerStart;
+  DateTime get debuggerStart => _debuggerStart;
 
   /// The time when dwds launches DevTools.
-  DateTime devToolsStart;
+  DateTime _devToolsStart;
+  DateTime get devToolsStart => _devToolsStart;
 
-  var _isDebuggerReady = false;
-
-  /// Records and returns whether the debugger became ready.
-  bool isFirstDebuggerReady() {
-    final wasReady = _isDebuggerReady;
-    _isDebuggerReady = true;
-    return !wasReady;
+  /// Records and returns weither the debugger is ready.
+  bool _isFirstDebuggerReady = true;
+  bool get isFirstDebuggerReady {
+    var wasReady = _isFirstDebuggerReady;
+    _isFirstDebuggerReady = false;
+    return wasReady;
   }
 
-  DwdsStats(this.debuggerStart);
+  void updateLoadTime({DateTime debuggerStart, DateTime devToolsStart}) {
+    _debuggerStart = debuggerStart;
+    _devToolsStart = devToolsStart;
+  }
+
+  DwdsStats();
 }
 
 class DwdsEventKind {

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -545,9 +545,7 @@ class DevHandler {
         ideQueryParam: 'DebugExtension',
       );
       appServices.dwdsStats.updateLoadTime(
-        debuggerStart: debuggerStart,
-        devToolsStart: DateTime.now()
-      );
+          debuggerStart: debuggerStart, devToolsStart: DateTime.now());
       await _launchDevTools(extensionDebugger, devToolsUri);
     });
   }

--- a/dwds/lib/src/services/app_debug_services.dart
+++ b/dwds/lib/src/services/app_debug_services.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 
 import '../dwds_vm_client.dart';
+import '../events.dart';
 import 'chrome_proxy_service.dart' show ChromeProxyService;
 import 'debug_service.dart';
 
@@ -14,6 +15,7 @@ import 'debug_service.dart';
 class AppDebugServices {
   final DebugService debugService;
   final DwdsVmClient dwdsVmClient;
+  final DwdsStats dwdsStats;
 
   ChromeProxyService get chromeProxyService =>
       debugService.chromeProxyService as ChromeProxyService;
@@ -28,7 +30,7 @@ class AppDebugServices {
   /// We only allow a given app to be debugged in a single tab at a time.
   String connectedInstanceId;
 
-  AppDebugServices(this.debugService, this.dwdsVmClient);
+  AppDebugServices(this.debugService, this.dwdsVmClient, this.dwdsStats);
 
   Future<void> close() =>
       _closed ??= Future.wait([debugService.close(), dwdsVmClient.close()]);


### PR DESCRIPTION
- Store dwdsStats on appServices for an app to make sure we are
  updating an reporting the same stats for an app. Previously,
  if the app services already existed, we would use incorrect
  object to report the stats, causing incorrect times and missing
  reports.
- Set the times on dwdsStats when debug request arrives to make
  sure times are recorded only from the time when the user starts
  debugging.
- Process `pageReady` events from any DevTools page, as DevTools
  does not always show the debugger page first.
- Enabled previously skipped tests.

Closes:https://github.com/dart-lang/webdev/issues/1517