### PR TITLE
Adds an IDE query parameter to the Dart DevTools URL

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Temporarily disable the paused in debugger overlay.
 - Add `SdkConfiguration` and `SdkConfigurationProvider` classes to allow
   for lazily created SDK configurations.
+- Add an `ide` query parameter to the Dart DevTools URL for analytics.
 
 **Breaking changes:**
 - `Dwds.start` and `ExpressionCompilerService` now take 

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -375,8 +375,10 @@ class DevHandler {
 
     appServices.connectedInstanceId = appConnection.request.instanceId;
     dwdsStats.devToolsStart = DateTime.now();
-    await _launchDevTools(appServices.chromeProxyService.remoteDebugger,
-        _constructDevToolsUri(appServices.debugService.uri));
+    await _launchDevTools(
+        appServices.chromeProxyService.remoteDebugger,
+        _constructDevToolsUri(appServices.debugService.uri,
+            ideQueryParam: 'Dwds'));
   }
 
   Future<AppConnection> _handleConnectRequest(
@@ -523,16 +525,24 @@ class DevHandler {
         extensionDebugConnections.add(DebugConnection(appServices));
         _servicesByAppId[appId] = appServices;
       }
-      final devToolsUri = _constructDevToolsUri(
-          await _servicesByAppId[appId].debugService.encodedUri);
+      final encodedUri = await _servicesByAppId[appId].debugService.encodedUri;
       dwdsStats.devToolsStart = DateTime.now();
 
-      // If we only want the URI, then return early.
+      // If we only want the URI, this means we are embedding Dart DevTools in
+      // Chrome DevTools. Therefore return early.
       if (devToolsRequest.uriOnly != null && devToolsRequest.uriOnly) {
+        final devToolsUri = _constructDevToolsUri(
+          encodedUri,
+          ideQueryParam: 'ChromeDevTools',
+        );
         extensionDebugger.sendEvent('dwds.devtoolsUri', devToolsUri);
         return;
       }
 
+      final devToolsUri = _constructDevToolsUri(
+        encodedUri,
+        ideQueryParam: 'DebugExtension',
+      );
       await _launchDevTools(extensionDebugger, devToolsUri);
     });
   }
@@ -549,12 +559,16 @@ class DevHandler {
     });
   }
 
-  String _constructDevToolsUri(String debugServiceUri) {
-    return Uri(
+  String _constructDevToolsUri(
+    String debugServiceUri, {
+    String ideQueryParam = '',
+  }) {
+    final uri = Uri(
         scheme: 'http',
         host: _devTools.hostname,
         port: _devTools.port,
         queryParameters: {'uri': debugServiceUri}).toString();
+    return ideQueryParam.isEmpty ? uri : '$uri?ide=$ideQueryParam';
   }
 }
 

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -563,12 +563,14 @@ class DevHandler {
     String debugServiceUri, {
     String ideQueryParam = '',
   }) {
-    final uri = Uri(
+    return Uri(
         scheme: 'http',
         host: _devTools.hostname,
         port: _devTools.port,
-        queryParameters: {'uri': debugServiceUri}).toString();
-    return ideQueryParam.isEmpty ? uri : '$uri?ide=$ideQueryParam';
+        queryParameters: {
+          'uri': debugServiceUri,
+          if (ideQueryParam.isNotEmpty) 'ide': ideQueryParam,
+        }).toString();
   }
 }
 

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -78,6 +78,8 @@ void main() async {
           // TODO(grouma): switch back to `fixture.webdriver.title` when
           // https://github.com/flutter/devtools/issues/2045 is fixed.
           expect(await context.webDriver.pageSource, contains('Flutter'));
+          expect(await context.webDriver.currentUrl,
+              contains('ide=DebugExtension'));
         });
 
         test('can close DevTools and relaunch', () async {

--- a/dwds/test/devtools_test.dart
+++ b/dwds/test/devtools_test.dart
@@ -47,6 +47,7 @@ void main() {
       // TODO(grouma): switch back to `fixture.webdriver.title` when
       // https://github.com/flutter/devtools/issues/2045 is fixed.
       expect(await context.webDriver.pageSource, contains('Flutter'));
+      expect(await context.webDriver.currentUrl, contains('ide=Dwds'));
     });
 
     test(


### PR DESCRIPTION
This query parameter is used in Dart DevTools to track how how it was launched. This should give us metrics on the number of users launching Dart DevTools from the Dart Debug Extension.