### PR TITLE
Fix error message on expression evaluation  for module load error

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -12,7 +12,7 @@
   restart.
 - Remove verbose printing on receiving DevTools events.
 - Update `vm_service` version to `^8.2.0`.
-
+- Update error message on expression evaluation using unloaded libraries.
 
 **Breaking changes:**
 - `Dwds.start` and `ExpressionCompilerService` now take

--- a/dwds/debug_extension/pubspec.yaml
+++ b/dwds/debug_extension/pubspec.yaml
@@ -1,7 +1,6 @@
 name: extension
 publish_to: none
 version: 1.27.0
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/webdev
 description: >-
   A chrome extension for Dart debugging.

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -215,7 +215,8 @@ class ChromeProxyService implements VmServiceInterface {
     // the expression compiler service will fail to start.
     // Issue: https://github.com/dart-lang/webdev/issues/1282
     var debugger = await _debugger;
-    await _initializeEntrypoint(appConnection.request.entrypointPath);
+    var entrypoint = appConnection.request.entrypointPath;
+    await _initializeEntrypoint(entrypoint);
     var sdkConfiguration = await _sdkConfigurationProvider.configuration;
 
     debugger.notifyPausedAtStart();
@@ -232,7 +233,13 @@ class ChromeProxyService implements VmServiceInterface {
 
     _expressionEvaluator = _compiler == null
         ? null
-        : ExpressionEvaluator(_inspector, _locations, _modules, _compiler);
+        : ExpressionEvaluator(
+            entrypoint,
+            _inspector,
+            _locations,
+            _modules,
+            _compiler,
+          );
 
     await debugger.reestablishBreakpoints(
         _previousBreakpoints, _disabledBreakpoints);

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -493,7 +493,7 @@ void main() async {
             });
           });
 
-          test('error', () async {
+          test('compilation error', () async {
             await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
               var event = await stream.firstWhere(
                   (event) => event.kind == EventKind.kPauseBreakpoint);
@@ -507,6 +507,21 @@ void main() async {
                       'message', contains('CompilationError:')));
             });
           });
+
+          test('module load error', () async {
+            await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
+              var event = await stream.firstWhere(
+                  (event) => event.kind == EventKind.kPauseBreakpoint);
+
+              var error = await setup.service.evaluateInFrame(
+                  isolate.id, event.topFrame.index, 'd.deferredPrintLocal()');
+
+              expect(
+                  error,
+                  isA<ErrorRef>().having((instance) => instance.message,
+                      'message', contains('LoadModuleError:')));
+            });
+          }, skip: 'https://github.com/dart-lang/sdk/issues/48587');
 
           test('cannot evaluate in unsupported isolate', () async {
             await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -413,6 +413,21 @@ void main() async {
                   contains('CompilationError:')));
         });
       });
+
+      test('module load error', () async {
+        await onBreakPoint(isolate.id, mainScript, 'printLocal', () async {
+          var event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
+
+          var error = await setup.service.evaluateInFrame(
+              isolate.id, event.topFrame.index, 'd.deferredPrintLocal()');
+
+          expect(
+              error,
+              isA<ErrorRef>().having((instance) => instance.message, 'message',
+                  contains('LoadModuleError:')));
+        });
+      }, skip: 'https://github.com/dart-lang/sdk/issues/48587');
     });
 
     group('evaluate', () {

--- a/fixtures/_test/lib/deferred_library.dart
+++ b/fixtures/_test/lib/deferred_library.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A library that we can import.
+library test_deferred_library;
+
+void deferredPrintLocal() {
+  print('hello from deferred library'); // Breakpoint: DeferredPrintLocal
+}

--- a/fixtures/_testPackage/web/main.dart
+++ b/fixtures/_testPackage/web/main.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:core';
 import 'dart:html';
 
+import 'package:_test/deferred_library.dart' deferred as d;
 import 'package:_test/library.dart';
 import 'package:_test_package/test_library.dart';
 
@@ -92,6 +93,10 @@ void printLoopVariable() {
   for (var item in list) {
     print(item); // Breakpoint: printLoopVariable
   }
+}
+
+Future<void> printDeferred() async {
+  d.deferredPrintLocal();
 }
 
 class MainClass {

--- a/fixtures/_testPackageSound/web/main.dart
+++ b/fixtures/_testPackageSound/web/main.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:core';
 import 'dart:html';
 
+import 'package:_test/deferred_library.dart' deferred as d;
 import 'package:_test/library.dart';
 import 'package:_test_package/test_library.dart';
 
@@ -101,6 +102,10 @@ void printLoopVariable() {
   for (var item in list) {
     print(item); // Breakpoint: printLoopVariable
   }
+}
+
+Future<void> printDeferred() async {
+  d.deferredPrintLocal();
 }
 
 class MainClass {

--- a/fixtures/_testSound/lib/deferred_library.dart
+++ b/fixtures/_testSound/lib/deferred_library.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A library that we can import.
+library test_deferred_library;
+
+void deferredPrintLocal() {
+  print('hello from deferred library'); // Breakpoint: DeferredPrintLocal
+}

--- a/webdev/test/chrome_test.dart
+++ b/webdev/test/chrome_test.dart
@@ -18,9 +18,11 @@ void main() {
   }
 
   tearDown(() async {
-    var tabs = await chrome.chromeConnection.getTabs();
-    for (var tab in tabs) {
-      await chrome.chromeConnection.getUrl('/json/close/${tab.id}');
+    var tabs = await chrome?.chromeConnection?.getTabs();
+    if (tabs != null) {
+      for (var tab in tabs) {
+        await chrome.chromeConnection.getUrl('/json/close/${tab.id}');
+      }
     }
     await chrome?.close();
     chrome = null;


### PR DESCRIPTION
Change error message on expression evaluation using deferred libraries from `NetworkError` to `LoadModuleError` with more readable details about the module name and path.

Closes: https://github.com/dart-lang/webdev/issues/1541