### PR TITLE
Option to better serve single-page applications

### DIFF
--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -37,6 +37,7 @@ const nullSafetySound = 'sound';
 const nullSafetyUnsound = 'unsound';
 const nullSafetyAuto = 'auto';
 const disableDdsFlag = 'disable-dds';
+const singlePageFlag = 'spa';
 
 ReloadConfiguration _parseReloadConfiguration(ArgResults argResults) {
   var auto = argResults.options.contains(autoOption)
@@ -105,6 +106,7 @@ class Configuration {
   final bool _verbose;
   final bool _disableDds;
   final String _nullSafety;
+  final String singlePageApplicationEntrypoint;
 
   Configuration({
     bool autoRun,
@@ -129,6 +131,7 @@ class Configuration {
     bool verbose,
     bool disableDds,
     String nullSafety,
+    this.singlePageApplicationEntrypoint,
   })  : _autoRun = autoRun,
         _chromeDebugPort = chromeDebugPort,
         _debugExtension = debugExtension,
@@ -410,6 +413,7 @@ class Configuration {
       enableExpressionEvaluation: enableExpressionEvaluation,
       verbose: verbose,
       nullSafety: nullSafety,
+      singlePageApplicationEntrypoint: argResults[singlePageFlag] as String,
     );
   }
 }

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -81,6 +81,14 @@ refresh: Performs a full page refresh.
     ..addOption(tlsCertKeyFlag,
         help: 'The file location to a TLS Key to create an HTTPs server.\n'
             'Must be used with $tlsCertChainFlag.')
+    ..addOption(
+      singlePageFlag,
+      help: 'Serve the given asset in single-page mode. \n'
+          "All requests that don't end in a file extension are forwarded to "
+          'that that `index.html`. Requests with a file extension in their URL '
+          'are resolved as assets relative to the given `index.html`.',
+      valueHelp: 'Index HTML asset id',
+    )
     ..addSeparator('Common:');
 
   ServeCommand() {


### PR DESCRIPTION
Idea to close https://github.com/dart-lang/webdev/issues/1528: This adds an `--spa` option to `webdev serve` that wile serve that asset for everything that doesn't have a file extension.

I'm not sure if this is the behavior we want in the end (or if it's agreed that this should be part of `webdev` in the first place), but it could be helpful for that use-case.