### PR TITLE
Fix breakpoints not hitting after changing a base in index.html.

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Update error message on expression evaluation using unloaded libraries.
 - Add `screen` field to the `DebuggerReady` event.
 - Report `DebuggerReady` events for DevTools embedded into Chrome Devtools.
+- Fix breakpoints not hitting after changing a base in index.html.
 
 **Breaking changes:**
 - `Dwds.start` and `ExpressionCompilerService` now take

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `Dwds.start` and `ExpressionCompilerService` now take
   `sdkConfigurationProvider` argument instead of separate SDK-related file
   paths.
+- Add `basePath` parameter to `FrontendServerRequireStrategy`.
 
 ## 12.1.0
 - Update _fe_analyzer_shared to version ^34.0.0.

--- a/dwds/lib/src/loaders/frontend_server_require.dart
+++ b/dwds/lib/src/loaders/frontend_server_require.dart
@@ -19,8 +19,8 @@ class FrontendServerRequireStrategyProvider {
   RequireStrategy _requireStrategy;
 
   FrontendServerRequireStrategyProvider(this._configuration, this._assetReader,
-      this._digestsProvider, String root)
-      : _basePath = basePathForServerUri(root);
+      this._digestsProvider, String basePath)
+      : _basePath = basePathForServerUri(basePath);
 
   RequireStrategy get strategy => _requireStrategy ??= RequireStrategy(
         _configuration,

--- a/dwds/lib/src/loaders/require.dart
+++ b/dwds/lib/src/loaders/require.dart
@@ -11,8 +11,19 @@ import 'package:shelf/shelf.dart';
 
 import '../../dwds.dart';
 
+String basePathForServerUri(String url) {
+  var uri = Uri.parse(url);
+  var base = uri.path.endsWith('.html') ? p.dirname(uri.path) : uri.path;
+  if (base.isNotEmpty) {
+    base = makeAbsolutePath(base);
+  }
+  return base;
+}
+
 String relativizePath(String path) =>
     path.startsWith('/') ? path.substring(1) : path;
+
+String makeAbsolutePath(String path) => path.startsWith('/') ? path : '/$path';
 
 String removeJsExtension(String path) =>
     path.endsWith('.js') ? p.withoutExtension(path) : path;

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -119,6 +119,7 @@ class ChromeProxyService implements VmServiceInterface {
       uri,
     );
     _debuggerCompleter.complete(debugger);
+    _logger.info('Created chrome proxy service for $uri');
   }
 
   static Future<ChromeProxyService> create(

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -270,7 +270,8 @@ class TestContext {
             assetHandler = webRunner.devFS.assetServer.handleRequest;
 
             requireStrategy = FrontendServerRequireStrategyProvider(
-                reloadConfiguration, assetReader, () async => {}).strategy;
+                    reloadConfiguration, assetReader, () async => {}, '')
+                .strategy;
 
             buildResults = const Stream<BuildResults>.empty();
           }


### PR DESCRIPTION
Fix breakpoints not hitting after changing a base in index.html.

- Add `basePath` parameter to `FrontendServerRequireStrategy`, adjust the server paths to contain `basePath`.
- Unify code for adding/removing base path to `require.dart`
- Adjust server paths in `DartUri` accordingly.