### PR TITLE
Split SDK configuration validation into components

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 13.1.1-dev
 - Add column information to breakpoints to allow precise breakpoint placement.
+- Split SDK validation methods to allow validation of separate components.
 
 ## 13.1.0
 - Update _fe_analyzer_shared to version ^38.0.0.

--- a/dwds/lib/src/utilities/sdk_configuration.dart
+++ b/dwds/lib/src/utilities/sdk_configuration.dart
@@ -70,6 +70,24 @@ class SdkConfiguration {
     fileSystem ??= const LocalFileSystem();
 
     validateSdkDir(fileSystem: fileSystem);
+    validateSummaries(fileSystem: fileSystem);
+    validateLibrariesSpec(fileSystem: fileSystem);
+    validateCompilerWorker(fileSystem: fileSystem);
+  }
+
+  /// Throws [InvalidSdkConfigurationException] if SDK root does not
+  /// exist on the disk.
+  void validateSdkDir({FileSystem fileSystem}) {
+    fileSystem ??= const LocalFileSystem();
+    if (sdkDirectory == null ||
+        !fileSystem.directory(sdkDirectory).existsSync()) {
+      throw InvalidSdkConfigurationException(
+          'Sdk directory $sdkDirectory does not exist');
+    }
+  }
+
+  void validateSummaries({FileSystem fileSystem}) {
+    fileSystem ??= const LocalFileSystem();
 
     if (unsoundSdkSummaryPath == null ||
         !fileSystem.file(unsoundSdkSummaryPath).existsSync()) {
@@ -82,27 +100,24 @@ class SdkConfiguration {
       throw InvalidSdkConfigurationException(
           'Sdk summary $soundSdkSummaryPath does not exist');
     }
+  }
+
+  void validateLibrariesSpec({FileSystem fileSystem}) {
+    fileSystem ??= const LocalFileSystem();
 
     if (librariesPath == null || !fileSystem.file(librariesPath).existsSync()) {
       throw InvalidSdkConfigurationException(
           'Libraries spec $librariesPath does not exist');
     }
+  }
+
+  void validateCompilerWorker({FileSystem fileSystem}) {
+    fileSystem ??= const LocalFileSystem();
 
     if (compilerWorkerPath == null ||
         !fileSystem.file(compilerWorkerPath).existsSync()) {
       throw InvalidSdkConfigurationException(
           'Compiler worker $compilerWorkerPath does not exist');
-    }
-  }
-
-  /// Throws [InvalidSdkConfigurationException] if SDK root does not
-  /// exist on the disk.
-  void validateSdkDir({FileSystem fileSystem}) {
-    fileSystem ??= const LocalFileSystem();
-    if (sdkDirectory == null ||
-        !fileSystem.directory(sdkDirectory).existsSync()) {
-      throw InvalidSdkConfigurationException(
-          'Sdk directory $sdkDirectory does not exist');
     }
   }
 }


### PR DESCRIPTION
Split SDK configuration validation into components to allow for scenarios that do not use all the components, for example,
 flutter tools, which does not use the expression compiler service.

Helps: https://github.com/flutter/flutter/issues/101639