### PR TITLE
Fix slow stepping into with deferred loaded modules

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -10,9 +10,17 @@
   - Remove clearing all scripts on page load for extension debugger.
 - Fix breakpoints not hitting after changing a base in index.html.
 - Find best locations for call frames, breakpoints, or expression evaluation.
+- Fix issues discovered when using legacy module system, debug extension,
+  and JIT modules:
+  - Improve step-into times by not stepping into library loading code.
+  - Fix incorrect skip lists due to unsorted locations.
+  - Fix memory leak in extension debugger by removing stale script IDs.
+  - Allow mapping JS locations to Dart locations matching other JS lines,
+    to match the behavior of Chrome DevTools.
 
 **Breaking changes:**
 - Add `basePath` parameter to `FrontendServerRequireStrategy`.
+- Add `loadLibrariesModule` getter to `LoadStrategy` interface.
 
 ## 13.1.0
 - Update _fe_analyzer_shared to version ^38.0.0.

--- a/dwds/lib/src/debugging/skip_list.dart
+++ b/dwds/lib/src/debugging/skip_list.dart
@@ -26,11 +26,13 @@ class SkipLists {
   ) async {
     if (_idToList.containsKey(scriptId)) return _idToList[scriptId];
 
+    var sortedLocations = locations.toList()
+      ..sort((a, b) => a.jsLocation.compareTo(b.jsLocation));
+
     var ranges = <Map<String, dynamic>>[];
     var startLine = 0;
     var startColumn = 0;
-    for (var location in locations) {
-      // Account for 1 based.
+    for (var location in sortedLocations) {
       var endLine = location.jsLocation.line;
       var endColumn = location.jsLocation.column;
       // Stop before the known location.
@@ -40,8 +42,10 @@ class SkipLists {
         endColumn = maxValue;
       }
       if (endLine > startLine || endColumn > startColumn) {
-        ranges.add(
-            _rangeFor(scriptId, startLine, startColumn, endLine, endColumn));
+        if (endLine >= startLine) {
+          ranges.add(
+              _rangeFor(scriptId, startLine, startColumn, endLine, endColumn));
+        }
         startLine = location.jsLocation.line;
         startColumn = location.jsLocation.column + 1;
       }

--- a/dwds/lib/src/loaders/legacy.dart
+++ b/dwds/lib/src/loaders/legacy.dart
@@ -80,6 +80,9 @@ class LegacyStrategy extends LoadStrategy {
   String get moduleFormat => 'ddc';
 
   @override
+  String get loadLibrariesModule => 'dart_library.ddk.js';
+
+  @override
   String get loadLibrariesSnippet =>
       'for(let module of dart_library.libraries()) {\n'
       'dart_library.import(module)[module];\n'

--- a/dwds/lib/src/loaders/require.dart
+++ b/dwds/lib/src/loaders/require.dart
@@ -170,6 +170,9 @@ class RequireStrategy extends LoadStrategy {
   String get moduleFormat => 'amd';
 
   @override
+  String get loadLibrariesModule => 'require.js';
+
+  @override
   String get loadLibrariesSnippet =>
       'let libs = $loadModuleSnippet("dart_sdk").dart.getLibraries();\n';
 

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -36,6 +36,11 @@ abstract class LoadStrategy {
   /// expression evaluation.
   String get moduleFormat;
 
+  /// Module containing code for loading libraries.
+  ///
+  /// Used for preventing stepping into the library loading code.
+  String get loadLibrariesModule;
+
   /// Returns a snippet of JS code that loads all Dart libraries into a `libs`
   /// variable.
   String get loadLibrariesSnippet;

--- a/dwds/lib/src/servers/extension_debugger.dart
+++ b/dwds/lib/src/servers/extension_debugger.dart
@@ -64,6 +64,7 @@ class ExtensionDebugger implements RemoteDebugger {
       (WipEvent event) => ExceptionThrownEvent(event.json));
 
   final _scripts = <String, WipScript>{};
+  final _scriptIds = <String, String>{};
 
   ExtensionDebugger(this.sseConnection) {
     sseConnection.stream.listen((data) {
@@ -104,7 +105,13 @@ class ExtensionDebugger implements RemoteDebugger {
       close();
     }, onDone: close);
     onScriptParsed.listen((event) {
+      // Remove stale scripts from cache.
+      if (event.script.url.isNotEmpty &&
+          _scriptIds.containsKey(event.script.url)) {
+        _scripts.remove(_scriptIds[event.script.url]);
+      }
       _scripts[event.script.scriptId] = event.script;
+      _scriptIds[event.script.url] = event.script.scriptId;
     });
     // Listens for a page reload.
     onGlobalObjectCleared.listen((_) {

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -276,6 +276,9 @@ class FakeStrategy implements LoadStrategy {
   String get moduleFormat => 'dummy-format';
 
   @override
+  String get loadLibrariesModule => '';
+
+  @override
   String get loadLibrariesSnippet => '';
 
   @override

--- a/dwds/test/location_test.dart
+++ b/dwds/test/location_test.dart
@@ -1,0 +1,220 @@
+// Copyright 2020 The Dart Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.9
+
+import 'package:dwds/dwds.dart';
+import 'package:dwds/src/debugging/location.dart';
+import 'package:dwds/src/debugging/modules.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/utilities/dart_uri.dart';
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:test/test.dart';
+
+import 'debugger_test.dart';
+
+void main() {
+  globalLoadStrategy = MockLoadStrategy();
+  var assetReader = FakeAssetReader();
+  var modules = MockModules();
+
+  var locations = Locations(assetReader, modules, '');
+
+  group('JS locations |', () {
+    group('location |', () {
+      test('is zero based', () async {
+        var loc = JsLocation.fromZeroBased('module', 0, 0);
+        expect(
+            loc,
+            isA<JsLocation>()
+                .having((l) => l.line, 'line', 0)
+                .having((l) => l.column, 'column', 0));
+      });
+
+      test('can compare to other location', () async {
+        var loc00 = JsLocation.fromZeroBased('module', 0, 0);
+        var loc01 = JsLocation.fromZeroBased('module', 0, 1);
+        var loc10 = JsLocation.fromZeroBased('module', 1, 0);
+        var loc11 = JsLocation.fromZeroBased('module', 1, 1);
+
+        expect(loc00.compareTo(loc01), isNegative);
+        expect(loc00.compareTo(loc10), isNegative);
+        expect(loc00.compareTo(loc10), isNegative);
+        expect(loc00.compareTo(loc11), isNegative);
+
+        expect(loc00.compareTo(loc00), isZero);
+        expect(loc11.compareTo(loc00), isPositive);
+      });
+    });
+
+    group('best location |', () {
+      test('does not return location for setup code', () async {
+        var jsLocation = await locations.locationForJs('module', 0, 0);
+        expect(jsLocation, isNull);
+      });
+
+      test('prefers precise match', () async {
+        var jsLocation = await locations.locationForJs('module', 37, 0);
+        expect(
+            jsLocation,
+            isA<Location>()
+                .having((l) => l.jsLocation.line, 'line', 37)
+                .having((l) => l.jsLocation.column, 'column', 0));
+      });
+
+      test('matches to location after if stopped in the beginning of the line',
+          () async {
+        var jsLocation = await locations.locationForJs('module', 39, 4);
+        expect(
+            jsLocation,
+            isA<Location>()
+                .having((l) => l.jsLocation.line, 'line', 39)
+                .having((l) => l.jsLocation.column, 'column', 6));
+      });
+
+      test('matches to location before if stopped in the middle of the line',
+          () async {
+        var jsLocation = await locations.locationForJs('module', 39, 10);
+        expect(
+            jsLocation,
+            isA<Location>()
+                .having((l) => l.jsLocation.line, 'line', 39)
+                .having((l) => l.jsLocation.column, 'column', 6));
+      });
+    });
+  });
+
+  group('Dart locations |', () {
+    var uri = DartUri('org-dartlang://web/main.dart');
+
+    group('location |', () {
+      test('is one based', () async {
+        var loc = DartLocation.fromZeroBased(uri, 0, 0);
+        expect(
+            loc,
+            isA<DartLocation>()
+                .having((l) => l.line, 'line', 1)
+                .having((l) => l.column, 'column', 1));
+      });
+
+      test('can compare to other locations', () async {
+        var loc00 = DartLocation.fromZeroBased(uri, 0, 0);
+        var loc01 = DartLocation.fromZeroBased(uri, 0, 1);
+        var loc10 = DartLocation.fromZeroBased(uri, 1, 0);
+        var loc11 = DartLocation.fromZeroBased(uri, 1, 1);
+
+        expect(loc00.compareTo(loc01), isNegative);
+        expect(loc00.compareTo(loc10), isNegative);
+        expect(loc00.compareTo(loc10), isNegative);
+        expect(loc00.compareTo(loc11), isNegative);
+
+        expect(loc00.compareTo(loc00), isZero);
+        expect(loc11.compareTo(loc00), isPositive);
+      });
+    });
+
+    group('best location |', () {
+      test('does not return location for dart lines not mapped to JS',
+          () async {
+        var jsLocation = await locations.locationForDart(uri, 0, 0);
+        expect(jsLocation, isNull);
+      });
+
+      test('returns location after on the same line', () async {
+        var jsLocation = await locations.locationForDart(
+            DartUri('org-dartlang://web/main.dart'), 11, 0);
+        expect(
+            jsLocation,
+            isA<Location>()
+                .having((l) => l.dartLocation.line, 'line', 11)
+                .having((l) => l.dartLocation.column, 'column', 3));
+      });
+    });
+  });
+}
+
+class MockLoadStrategy implements LoadStrategy {
+  @override
+  Future<String> bootstrapFor(String entrypoint) async => 'dummy_bootstrap';
+
+  @override
+  shelf.Handler get handler =>
+      (request) => (request.url.path == 'someDummyPath')
+          ? shelf.Response.ok('some dummy response')
+          : null;
+
+  @override
+  String get id => 'dummy-id';
+
+  @override
+  String get moduleFormat => 'dummy-format';
+
+  @override
+  String get loadLibrariesModule => '';
+
+  @override
+  String get loadLibrariesSnippet => '';
+
+  @override
+  String loadLibrarySnippet(String libraryUri) => '';
+
+  @override
+  String get loadModuleSnippet => '';
+
+  @override
+  ReloadConfiguration get reloadConfiguration => ReloadConfiguration.none;
+
+  @override
+  String loadClientSnippet(String clientScript) => 'dummy-load-client-snippet';
+
+  @override
+  Future<String> moduleForServerPath(
+          String entrypoint, String serverPath) async =>
+      'module';
+
+  @override
+  Future<String> serverPathForModule(String entrypoint, String module) async =>
+      'serverPath';
+
+  @override
+  Future<String> sourceMapPathForModule(
+          String entrypoint, String module) async =>
+      'sourceMapPath';
+
+  @override
+  String serverPathForAppUri(String appUri) => 'serverPath';
+
+  @override
+  MetadataProvider metadataProviderFor(String entrypoint) => null;
+
+  @override
+  void trackEntrypoint(String entrypoint) {}
+
+  @override
+  Future<Map<String, ModuleInfo>> moduleInfoForEntrypoint(String entrypoint) =>
+      throw UnimplementedError();
+}
+
+class MockModules implements Modules {
+  @override
+  void initialize(String entrypoint) {}
+
+  @override
+  Future<Uri> libraryForSource(String serverPath) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<String> moduleForSource(String serverPath) async => 'module';
+
+  @override
+  Future<Map<String, String>> modules() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<String> moduleForlibrary(String libraryUri) {
+    throw UnimplementedError();
+  }
+}

--- a/dwds/test/skip_list_test.dart
+++ b/dwds/test/skip_list_test.dart
@@ -29,6 +29,30 @@ void main() {
       _validateRange(skipList.last, 10, 21, maxValue, maxValue);
     });
 
+    test('do not include start of the file', () async {
+      var skipList = await skipLists.compute('123', {
+        Location.from(
+            'foo', TargetLineEntry(0, []), TargetEntry(0, 0, 0, 0), null),
+        Location.from(
+            'foo', TargetLineEntry(10, []), TargetEntry(20, 0, 0, 0), null),
+      });
+      expect(skipList.length, 2);
+      _validateRange(skipList[0], 0, 1, 10, 19);
+      _validateRange(skipList.last, 10, 21, maxValue, maxValue);
+    });
+
+    test('does not depend on order of locations', () async {
+      var skipList = await skipLists.compute('123', {
+        Location.from(
+            'foo', TargetLineEntry(10, []), TargetEntry(20, 0, 0, 0), null),
+        Location.from(
+            'foo', TargetLineEntry(0, []), TargetEntry(0, 0, 0, 0), null),
+      });
+      expect(skipList.length, 2);
+      _validateRange(skipList[0], 0, 1, 10, 19);
+      _validateRange(skipList.last, 10, 21, maxValue, maxValue);
+    });
+
     test('contains the provided id', () async {
       var id = '123';
       var skipList = await skipLists.compute(id, {});


### PR DESCRIPTION
Fix issues discovered when using a combination of legacy module system, debug extension, and JIT modules:
  - Improve step-into times by not stepping into library loading code.
  - Fix incorrect skip lists due to unsorted locations.
  - Fix memory leak in extension debugger by removing stale script IDs.
  - Allow mapping JS locations to Dart locations matching other JS lines, to match the behavior of Chrome DevTools.
 