### PR TITLE
Mark mono_repo outputs as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
-
 # Exclude compiled file from github statistics
 **/injected/client.js linguist-generated=true
+# mono_repo generated files
+.github/workflows/dart.yml linguist-generated=true
+tool/ci.sh linguist-generated=true


### PR DESCRIPTION
Tag the github actions workflow and `tool/ci.sh` as `linguist-generated`
so that diff is collapsed by default. Changes in these files are not
easy or necessary to review, the changes in `mono_pkg.yml` files are the
important ones.