### PR TITLE
remove a todo from the frontend_server_client readme

### DIFF
--- a/frontend_server_client/CHANGELOG.md
+++ b/frontend_server_client/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.3-dev
+
+
 ## 2.1.2
 
 - Force kill the frontend server after one second when calling shutdown. It

--- a/frontend_server_client/README.md
+++ b/frontend_server_client/README.md
@@ -1,9 +1,8 @@
+[![pub package](https://img.shields.io/pub/v/frontend_server_client.svg)](https://pub.dev/packages/frontend_server_client)
+[![package publisher](https://img.shields.io/pub/publisher/frontend_server_client.svg)](https://pub.dev/packages/frontend_server_client/publisher)
+
 This package provides a client interface around the frontend_server compiler
 which ships with the Dart SDK.
-
-## Usage
-
-TODO
 
 ## SDK Versioning Policy
 

--- a/frontend_server_client/pubspec.yaml
+++ b/frontend_server_client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: frontend_server_client
-version: 2.1.2
+version: 2.1.3-dev
 description: >-
   Client code to start and interact with the frontend_server compiler from the
   Dart SDK.


### PR DESCRIPTION
- remove a todo from the frontend_server_client readme
- rev the pubspec version (some changes had landed here since the last publish)
- add some std markdown badges to the readme