### PR TITLE
Prevent `flutter_tools` crash when the Dart execution context cannot be found

### DIFF
--- a/dwds/lib/src/debugging/execution_context.dart
+++ b/dwds/lib/src/debugging/execution_context.dart
@@ -30,8 +30,13 @@ class RemoteDebuggerExecutionContext extends ExecutionContext {
   Future<int> get id async {
     if (_id != null) return _id;
     _logger.fine('Looking for Dart execution context...');
+    const timeoutInMs = 100;
     while (await _contexts.hasNext
-        .timeout(const Duration(milliseconds: 100), onTimeout: () => false)) {
+        .timeout(const Duration(milliseconds: timeoutInMs), onTimeout: () {
+      _logger.warning(
+          'Timed out finding an execution context after $timeoutInMs ms.');
+      return false;
+    })) {
       var context = await _contexts.next;
       _logger.fine('Checking context id: $context');
       try {

--- a/dwds/lib/src/debugging/execution_context.dart
+++ b/dwds/lib/src/debugging/execution_context.dart
@@ -32,7 +32,11 @@ class RemoteDebuggerExecutionContext extends ExecutionContext {
     _logger.fine('Looking for Dart execution context...');
     const timeoutInMs = 100;
     while (await _contexts.hasNext
-        .timeout(const Duration(milliseconds: 50), onTimeout: () => false)) {
+        .timeout(const Duration(milliseconds: timeoutInMs), onTimeout: () {
+      _logger.warning(
+          'Timed out finding an execution context after $timeoutInMs ms.');
+      return false;
+    })) {
       final context = await _contexts.next;
       _logger.fine('Checking context id: $context');
       try {

--- a/dwds/lib/src/debugging/execution_context.dart
+++ b/dwds/lib/src/debugging/execution_context.dart
@@ -31,7 +31,7 @@ class RemoteDebuggerExecutionContext extends ExecutionContext {
     if (_id != null) return _id;
     _logger.fine('Looking for Dart execution context...');
     while (await _contexts.hasNext
-        .timeout(const Duration(milliseconds: 50), onTimeout: () => false)) {
+        .timeout(const Duration(milliseconds: 100), onTimeout: () => false)) {
       var context = await _contexts.next;
       _logger.fine('Checking context id: $context');
       try {

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -563,7 +563,7 @@ function($argsString) {
       'contextId': await contextId,
     };
     try {
-      var extensionsResult =
+      final extensionsResult =
           await remoteDebugger.sendCommand('Runtime.evaluate', params: params);
       handleErrorIfPresent(extensionsResult, evalContents: expression);
       extensionRpcs.addAll(

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -172,7 +172,7 @@ class AppInspector extends Domain {
     await appInspector._initialize();
     return appInspector;
   }
-  
+
   /// Returns the ID for the execution context or null if not found.
   Future<int> get contextId async {
     try {


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/95916

We now catch any errors getting the `executionContext.id` in DWDS and add `severe` logs in that case. (Without catching the error it crashes `flutter_tools`). 

I also doubled the timeout for finding the next execution context, in case we weren't finding the execution context due to timeouts. Added some logging for when that occurs. 