### PR TITLE
Run frontend server tests and fix failures

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 14.0.4-dev
 - Port some `dwds` files to null safety.
+- Fix failing `frontend_server_evaluate` tests.
 
 ## 14.0.3
 - Make data types null safe.

--- a/dwds/lib/src/debugging/location.dart
+++ b/dwds/lib/src/debugging/location.dart
@@ -5,6 +5,7 @@
 // @dart = 2.9
 
 import 'package:async/async.dart';
+import 'package:dwds/src/loaders/require.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_maps/parser.dart';
 import 'package:source_maps/source_maps.dart';
@@ -272,7 +273,7 @@ class Locations {
           await globalLoadStrategy.sourceMapPathForModule(_entrypoint, module);
       final sourceMapContents =
           await _assetReader.sourceMapContents(sourceMapPath);
-      final scriptLocation = p.url.dirname('/$modulePath');
+      final scriptLocation = p.url.dirname('/${relativizePath(modulePath)}');
       if (sourceMapContents == null) return result;
       // This happens to be a [SingleMapping] today in DDC.
       final mapping = parse(sourceMapContents);

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dwds/src/loaders/require.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:sse/server/sse_handler.dart';
@@ -201,7 +202,7 @@ class DevHandler {
       'localhost',
       webkitDebugger,
       executionContext,
-      appTab.url,
+      basePathForServerUri(appTab.url),
       _assetReader,
       _loadStrategy,
       appConnection,

--- a/dwds/lib/src/loaders/frontend_server_require.dart
+++ b/dwds/lib/src/loaders/frontend_server_require.dart
@@ -22,8 +22,7 @@ class FrontendServerRequireStrategyProvider {
   RequireStrategy _requireStrategy;
 
   FrontendServerRequireStrategyProvider(this._configuration, this._assetReader,
-      this._digestsProvider, String basePath)
-      : _basePath = basePathForServerUri(basePath);
+      this._digestsProvider, this._basePath);
 
   RequireStrategy get strategy => _requireStrategy ??= RequireStrategy(
         _configuration,
@@ -37,8 +36,12 @@ class FrontendServerRequireStrategyProvider {
         _assetReader,
       );
 
-  String _removeBasePath(String path) =>
-      path.startsWith(_basePath) ? path.substring(_basePath.length) : null;
+  String _removeBasePath(String path) {
+    if (_basePath.isEmpty) return path;
+    // If path is a server path it might start with a '/'.
+    final base = path.startsWith('/') ? '/$_basePath' : _basePath;
+    return path.startsWith(base) ? path.substring(base.length) : path;
+  }
 
   String _addBasePath(String serverPath) =>
       _basePath == null || _basePath.isEmpty

--- a/dwds/lib/src/loaders/require.dart
+++ b/dwds/lib/src/loaders/require.dart
@@ -17,16 +17,13 @@ import '../services/expression_compiler.dart';
 /// Find the path we are serving from the url.
 ///
 /// Example:
-///   https://localhost/base/index.html => /base
-///   https://localhost/base => /base
+///   https://localhost/bases/index.html => base
+///   https://localhost/base => base
 String basePathForServerUri(String url) {
   if (url == null) return null;
   final uri = Uri.parse(url);
   var base = uri.path.endsWith('.html') ? p.dirname(uri.path) : uri.path;
-  if (base.isNotEmpty) {
-    base = base.startsWith('/') ? base : '/$base';
-  }
-  return base;
+  return base = base.startsWith('/') ? base.substring(1) : base;
 }
 
 String relativizePath(String path) =>

--- a/dwds/lib/src/loaders/require.dart
+++ b/dwds/lib/src/loaders/require.dart
@@ -17,7 +17,7 @@ import '../services/expression_compiler.dart';
 /// Find the path we are serving from the url.
 ///
 /// Example:
-///   https://localhost/bases/index.html => base
+///   https://localhost/base/index.html => base
 ///   https://localhost/base => base
 String basePathForServerUri(String url) {
   if (url == null) return null;

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -62,8 +62,8 @@ class ChromeProxyService implements VmServiceInterface {
   Completer<void> _compilerCompleter = Completer<void>();
   Future<void> get isCompilerInitialized => _compilerCompleter.future;
 
-  /// The root URI at which we're serving.
-  final String uri;
+  /// The root at which we're serving.
+  final String root;
 
   final RemoteDebugger remoteDebugger;
   final ExecutionContext executionContext;
@@ -104,7 +104,7 @@ class ChromeProxyService implements VmServiceInterface {
 
   ChromeProxyService._(
     this._vm,
-    this.uri,
+    this.root,
     this._assetReader,
     this.remoteDebugger,
     this._modules,
@@ -120,14 +120,14 @@ class ChromeProxyService implements VmServiceInterface {
       appInspectorProvider,
       _locations,
       _skipLists,
-      uri,
+      root,
     );
     _debuggerCompleter.complete(debugger);
   }
 
   static Future<ChromeProxyService> create(
     RemoteDebugger remoteDebugger,
-    String tabUrl,
+    String root,
     AssetReader assetReader,
     LoadStrategy loadStrategy,
     AppConnection appConnection,
@@ -150,12 +150,12 @@ class ChromeProxyService implements VmServiceInterface {
       pid: -1,
     );
 
-    final modules = Modules(tabUrl);
-    final locations = Locations(assetReader, modules, tabUrl);
+    final modules = Modules(root);
+    final locations = Locations(assetReader, modules, root);
     final skipLists = SkipLists();
     final service = ChromeProxyService._(
       vm,
-      tabUrl,
+      root,
       assetReader,
       remoteDebugger,
       modules,
@@ -229,7 +229,7 @@ class ChromeProxyService implements VmServiceInterface {
       remoteDebugger,
       _assetReader,
       _locations,
-      uri,
+      root,
       debugger,
       executionContext,
       sdkConfiguration,
@@ -352,7 +352,7 @@ class ChromeProxyService implements VmServiceInterface {
           'The VM is unable to add a breakpoint '
               'at the specified line or function');
     }
-    final dartUri = DartUri(scriptUri, uri);
+    final dartUri = DartUri(scriptUri, root);
     final ref = await _inspector.scriptRefFor(dartUri.serverPath);
     return (await _debugger)
         .addBreakpoint(isolateId, ref.id, line, column: column);

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -210,7 +210,7 @@ class DebugService {
     String hostname,
     RemoteDebugger remoteDebugger,
     ExecutionContext executionContext,
-    String tabUrl,
+    String root,
     AssetReader assetReader,
     LoadStrategy loadStrategy,
     AppConnection appConnection,
@@ -225,7 +225,7 @@ class DebugService {
     useSse ??= false;
     final chromeProxyService = await ChromeProxyService.create(
       remoteDebugger,
-      tabUrl,
+      root,
       assetReader,
       loadStrategy,
       appConnection,

--- a/dwds/test/build_daemon_callstack_test.dart
+++ b/dwds/test/build_daemon_callstack_test.dart
@@ -46,15 +46,20 @@ void main() {
     // Enable verbose logging for debugging.
     final debug = false;
 
-    for (var soundNullSafety in [false, true]) {
+    for (var nullSafety in NullSafety.values) {
+      final soundNullSafety = nullSafety == NullSafety.sound;
       final setup = soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
       final context = setup.context;
 
-      group('${soundNullSafety ? "sound" : "weak"} null safety |', () {
+      group('${nullSafety.name} null safety |', () {
         setUpAll(() async {
           setCurrentLogWriter(debug: debug);
           await context.setUp(
-              enableExpressionEvaluation: true, verboseCompiler: debug);
+            compilationMode: CompilationMode.buildDaemon,
+            nullSafety: nullSafety,
+            enableExpressionEvaluation: true,
+            verboseCompiler: debug,
+          );
         });
 
         tearDownAll(() async {

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -15,18 +15,13 @@ void main() async {
   // Enable verbose logging for debugging.
   final debug = false;
 
-  for (var soundNullSafety in [false, true]) {
-    group('${soundNullSafety ? "sound" : "weak"} null safety |', () {
-      for (var basePath in ['', 'abc']) {
-        group('with base "$basePath" |', () {
-          testAll(
-            compilationMode: CompilationMode.buildDaemon,
-            soundNullSafety: soundNullSafety,
-            basePath: basePath,
-            debug: debug,
-          );
-        });
-      }
+  for (var nullSafety in NullSafety.values) {
+    group('${nullSafety.name} null safety |', () {
+      testAll(
+        compilationMode: CompilationMode.buildDaemon,
+        nullSafety: nullSafety,
+        debug: debug,
+      );
     });
   }
 }

--- a/dwds/test/dart_uri_test.dart
+++ b/dwds/test/dart_uri_test.dart
@@ -33,8 +33,7 @@ void main() {
     });
 
     test('parses package : paths with root', () {
-      final uri = DartUri(
-          'package:path/path.dart', 'foo/bar/blah');
+      final uri = DartUri('package:path/path.dart', 'foo/bar/blah');
       expect(uri.serverPath, 'foo/bar/blah/packages/path/path.dart');
     });
 

--- a/dwds/test/dart_uri_test.dart
+++ b/dwds/test/dart_uri_test.dart
@@ -34,7 +34,7 @@ void main() {
 
     test('parses package : paths with root', () {
       final uri = DartUri(
-          'package:path/path.dart', 'http://localhost:8080/foo/bar/blah');
+          'package:path/path.dart', 'foo/bar/blah');
       expect(uri.serverPath, 'foo/bar/blah/packages/path/path.dart');
     });
 

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -4,6 +4,7 @@
 
 // @dart = 2.9
 
+@TestOn('vm')
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -17,11 +18,9 @@ import 'package:test/test.dart';
 
 import 'fixtures/logging.dart';
 
-Logger _logger = Logger('ExpressionCompilerServiceTest');
-
-@TestOn('vm')
 void main() async {
   group('expression compiler service with fake asset server', () {
+    final logger = Logger('ExpressionCompilerServiceTest');
     ExpressionCompilerService service;
     HttpServer server;
     StreamController<String> output;
@@ -70,7 +69,7 @@ void main() async {
       serveHttpRequests(
           server, Cascade().add(service.handler).add(assetHandler).handler,
           (e, s) {
-        _logger.warning('Error serving requests', e, s);
+        logger.warning('Error serving requests', e, s);
       });
 
       // generate full dill

--- a/dwds/test/frontend_server_callstack_test.dart
+++ b/dwds/test/frontend_server_callstack_test.dart
@@ -46,16 +46,17 @@ void main() {
     // Enable verbose logging for debugging.
     final debug = false;
 
-    for (var soundNullSafety in [false, true]) {
+    for (var nullSafety in NullSafety.values) {
+      final soundNullSafety = nullSafety == NullSafety.sound;
       final setup = soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
       final context = setup.context;
 
-      group('${soundNullSafety ? "sound" : "weak"} null safety |', () {
+      group('${nullSafety.name} null safety |', () {
         setUpAll(() async {
           setCurrentLogWriter(debug: debug);
           await context.setUp(
               compilationMode: CompilationMode.frontendServer,
-              soundNullSafety: soundNullSafety,
+              nullSafety: nullSafety,
               enableExpressionEvaluation: true,
               verboseCompiler: debug);
         });

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -6,6 +6,8 @@
 
 @TestOn('vm')
 
+import 'dart:io';
+
 import 'package:test/test.dart';
 
 import 'fixtures/context.dart';
@@ -18,18 +20,24 @@ void main() async {
   for (var nullSafety in NullSafety.values) {
     group('${nullSafety.name} null safety |', () {
       for (var indexBaseMode in IndexBaseMode.values) {
-        group('with ${indexBaseMode.name} |', () {
-          testAll(
-            compilationMode: CompilationMode.frontendServer,
-            indexBaseMode: indexBaseMode,
-            nullSafety: nullSafety,
-            debug: debug,
-          );
-        },
-            skip: nullSafety ==
-                NullSafety
-                    .sound // https://github.com/dart-lang/webdev/issues/1591
+        group(
+          'with ${indexBaseMode.name} |',
+          () {
+            testAll(
+              compilationMode: CompilationMode.frontendServer,
+              indexBaseMode: indexBaseMode,
+              nullSafety: nullSafety,
+              debug: debug,
             );
+          },
+          skip: (nullSafety ==
+                  NullSafety
+                      .sound) // https://github.com/dart-lang/webdev/issues/1591
+              ||
+              (indexBaseMode == IndexBaseMode.base &&
+                  Platform
+                      .isWindows), // https://github.com/dart-lang/sdk/issues/49277
+        );
       }
     });
   }

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -15,19 +15,20 @@ void main() async {
   // Enable verbose logging for debugging.
   final debug = false;
 
-  for (var soundNullSafety in [false, true]) {
-    group('${soundNullSafety ? "sound" : "weak"} null safety |', () {
-      for (var basePath in ['', 'abc']) {
-        group('with base "$basePath" |', () {
+  for (var nullSafety in NullSafety.values) {
+    group('${nullSafety.name} null safety |', () {
+      for (var indexBaseMode in IndexBaseMode.values) {
+        group('with ${indexBaseMode.name} |', () {
           testAll(
             compilationMode: CompilationMode.frontendServer,
-            soundNullSafety: soundNullSafety,
-            basePath: basePath,
+            indexBaseMode: indexBaseMode,
+            nullSafety: nullSafety,
             debug: debug,
           );
         },
-            skip:
-                soundNullSafety // https://github.com/dart-lang/webdev/issues/1591
+            skip: nullSafety ==
+                NullSafety
+                    .sound // https://github.com/dart-lang/webdev/issues/1591
             );
       }
     });

--- a/fixtures/_testPackage/web/base_index.html
+++ b/fixtures/_testPackage/web/base_index.html
@@ -1,0 +1,8 @@
+<html>
+
+<head>
+  <base href="/abc/">
+  <script defer src="main.dart.js"></script>
+</head>
+
+</html>

--- a/fixtures/_testPackageSound/web/base_index.html
+++ b/fixtures/_testPackageSound/web/base_index.html
@@ -1,0 +1,8 @@
+<html>
+
+<head>
+  <base href="/abc/">
+  <script defer src="main.dart.js"></script>
+</head>
+
+</html>

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -26,7 +26,8 @@ class WebDevFS {
     this.fileSystem,
     this.hostname,
     this.port,
-    this.packageConfigPath,
+    this.projectDirectory,
+    this.packageConfigFile,
     this.index,
     this.urlTunneller,
     this.soundNullSafety,
@@ -36,7 +37,8 @@ class WebDevFS {
   TestAssetServer assetServer;
   final String hostname;
   final int port;
-  final String packageConfigPath;
+  final Uri projectDirectory;
+  final Uri packageConfigFile;
   final String index;
   final UrlEncoder urlTunneller;
   final bool soundNullSafety;
@@ -46,12 +48,10 @@ class WebDevFS {
 
   Future<Uri> create() async {
     _savedCurrentDirectory = fileSystem.currentDirectory;
-    // package_config.json is located in <project directory>/.dart_tool/package_config
-    var projectDirectory = p.dirname(p.dirname(packageConfigPath));
 
-    fileSystem.currentDirectory = projectDirectory;
+    fileSystem.currentDirectory = projectDirectory.toFilePath();
 
-    _packageConfig = await loadPackageConfigUri(Uri.file(packageConfigPath),
+    _packageConfig = await loadPackageConfigUri(packageConfigFile,
         loader: (Uri uri) => fileSystem.file(uri).readAsBytes());
 
     assetServer = await TestAssetServer.start(
@@ -65,14 +65,15 @@ class WebDevFS {
   }
 
   Future<UpdateFSReport> update({
-    String mainPath,
+    Uri mainUri,
     String dillOutputPath,
     @required ResidentCompiler generator,
     List<Uri> invalidatedFiles,
   }) async {
     assert(generator != null);
-    var outputDirectoryPath = fileSystem.file(mainPath).parent.path;
-    var entryPoint = mainPath;
+    final mainPath = mainUri.toFilePath();
+    final outputDirectoryPath = fileSystem.file(mainPath).parent.path;
+    final entryPoint = mainPath;
 
     assetServer.writeFile(
       '/main.dart.js',
@@ -98,9 +99,11 @@ class WebDevFS {
 
     generator.reset();
     var compilerOutput = await generator.recompile(
-        Uri.parse('org-dartlang-app:///$mainPath'), invalidatedFiles,
-        outputPath: p.join(dillOutputPath, 'app.dill'),
-        packageConfig: _packageConfig);
+      Uri.parse('org-dartlang-app:///$mainUri'),
+      invalidatedFiles,
+      outputPath: p.join(dillOutputPath, 'app.dill'),
+      packageConfig: _packageConfig,
+    );
     if (compilerOutput == null || compilerOutput.errorCount > 0) {
       return UpdateFSReport(success: false);
     }

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -27,7 +27,7 @@ class WebDevFS {
     this.hostname,
     this.port,
     this.packageConfigPath,
-    this.root,
+    this.index,
     this.urlTunneller,
     this.soundNullSafety,
   });
@@ -37,7 +37,7 @@ class WebDevFS {
   final String hostname;
   final int port;
   final String packageConfigPath;
-  final String root;
+  final String index;
   final UrlEncoder urlTunneller;
   final bool soundNullSafety;
   Directory _savedCurrentDirectory;
@@ -55,7 +55,7 @@ class WebDevFS {
         loader: (Uri uri) => fileSystem.file(uri).readAsBytes());
 
     assetServer = await TestAssetServer.start(
-        fileSystem, root, hostname, port, urlTunneller, _packageConfig);
+        fileSystem, index, hostname, port, urlTunneller, _packageConfig);
     return Uri.parse('http://$hostname:$port');
   }
 

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -73,7 +73,7 @@ class WebDevFS {
     assert(generator != null);
     final mainPath = mainUri.toFilePath();
     final outputDirectoryPath = fileSystem.file(mainPath).parent.path;
-    final entryPoint = mainPath;
+    final entryPoint = mainUri.toString();
 
     assetServer.writeFile(
       '/main.dart.js',

--- a/frontend_server_common/lib/src/frontend_server_client.dart
+++ b/frontend_server_common/lib/src/frontend_server_client.dart
@@ -253,20 +253,20 @@ class _RejectRequest extends _CompilationRequest {
 /// restarts the Flutter app.
 class ResidentCompiler {
   ResidentCompiler(
-    String sdkRoot, {
-    this.packageConfigPath,
+    this.sdkRoot, {
+    this.projectDirectory,
+    this.packageConfigFile,
     this.fileSystemRoots,
     this.fileSystemScheme,
     this.platformDill,
     this.verbose,
     CompilerMessageConsumer compilerMessageConsumer = defaultConsumer,
   })  : assert(sdkRoot != null),
-        _stdoutHandler = StdoutHandler(consumer: compilerMessageConsumer),
-        // This is a URI, not a file path, so the forward slash is correct even on Windows.
-        sdkRoot = sdkRoot.endsWith('/') ? sdkRoot : '$sdkRoot/';
+        _stdoutHandler = StdoutHandler(consumer: compilerMessageConsumer);
 
-  final String packageConfigPath;
-  final List<String> fileSystemRoots;
+  final Uri projectDirectory;
+  final Uri packageConfigFile;
+  final List<Uri> fileSystemRoots;
   final String fileSystemScheme;
   final String platformDill;
   final bool verbose;
@@ -364,14 +364,14 @@ class ResidentCompiler {
       '-Ddart.developer.causal_async_stacks=true',
       '--output-dill',
       outputFilePath,
-      if (packageConfigPath != null) ...<String>[
+      if (packageConfigFile != null) ...<String>[
         '--packages',
-        packageConfigPath,
+        '$packageConfigFile',
       ],
       if (fileSystemRoots != null)
-        for (final String root in fileSystemRoots) ...<String>[
+        for (final root in fileSystemRoots) ...<String>[
           '--filesystem-root',
-          root,
+          '$root',
         ],
       if (fileSystemScheme != null) ...<String>[
         '--filesystem-scheme',
@@ -387,9 +387,9 @@ class ResidentCompiler {
     ];
 
     _logger.info(args.join(' '));
-    var projectDirectory = p.dirname(p.dirname(packageConfigPath));
+    final workingDirectory = projectDirectory.toFilePath();
     _server = await Process.start(Platform.resolvedExecutable, args,
-        workingDirectory: projectDirectory);
+        workingDirectory: workingDirectory);
     _server.stdout
         .transform<String>(utf8.decoder)
         .transform<String>(const LineSplitter())
@@ -620,15 +620,15 @@ class TestExpressionCompiler implements ExpressionCompiler {
 /// Convert a file URI into a multi-root scheme URI if provided, otherwise
 /// return unmodified.
 @visibleForTesting
-String toMultiRootPath(
-    Uri fileUri, String scheme, List<String> fileSystemRoots) {
+String toMultiRootPath(Uri fileUri, String scheme, List<Uri> fileSystemRoots) {
   if (scheme == null || fileSystemRoots.isEmpty || fileUri.scheme != 'file') {
     return fileUri.toString();
   }
   final filePath = fileUri.toFilePath(windows: Platform.isWindows);
   for (final fileSystemRoot in fileSystemRoots) {
-    if (filePath.startsWith(fileSystemRoot)) {
-      return '$scheme://${filePath.substring(fileSystemRoot.length)}';
+    final rootPath = fileSystemRoot.toFilePath(windows: Platform.isWindows);
+    if (filePath.startsWith(rootPath)) {
+      return '$scheme://${filePath.substring(rootPath.length)}';
     }
   }
   return fileUri.toString();

--- a/frontend_server_common/lib/src/resident_runner.dart
+++ b/frontend_server_common/lib/src/resident_runner.dart
@@ -22,9 +22,9 @@ final Uri platformDillUnsound =
 final Uri platformDillSound =
     Uri.file(p.join(dartSdkPath, 'lib', '_internal', 'ddc_outline_sound.dill'));
 
-Logger _logger = Logger('ResidentWebRunner');
-
 class ResidentWebRunner {
+  final _logger = Logger('ResidentWebRunner');
+
   ResidentWebRunner(
       this.mainPath,
       this.urlTunneller,
@@ -58,7 +58,7 @@ class ResidentWebRunner {
   Uri uri;
   Iterable<String> modules;
 
-  Future<int> run(String hostname, int port, String root) async {
+  Future<int> run(String hostname, int port, String index) async {
     hostname ??= 'localhost';
 
     devFS = WebDevFS(
@@ -66,7 +66,7 @@ class ResidentWebRunner {
       hostname: hostname,
       port: port,
       packageConfigPath: packageConfigPath,
-      root: root,
+      index: index,
       urlTunneller: urlTunneller,
       soundNullSafety: soundNullSafety,
     );

--- a/frontend_server_common/lib/src/resident_runner.dart
+++ b/frontend_server_common/lib/src/resident_runner.dart
@@ -26,29 +26,34 @@ class ResidentWebRunner {
   final _logger = Logger('ResidentWebRunner');
 
   ResidentWebRunner(
-      this.mainPath,
+      this.mainUri,
       this.urlTunneller,
-      this.packageConfigPath,
+      this.projectDirectory,
+      this.packageConfigFile,
       this.fileSystemRoots,
       this.fileSystemScheme,
       this.outputPath,
       this.soundNullSafety,
       bool verbose) {
-    generator = ResidentCompiler(dartSdkPath,
-        packageConfigPath: packageConfigPath,
-        platformDill:
-            soundNullSafety ? '$platformDillSound' : '$platformDillUnsound',
-        fileSystemRoots: fileSystemRoots,
-        fileSystemScheme: fileSystemScheme,
-        verbose: verbose);
+    generator = ResidentCompiler(
+      dartSdkPath,
+      projectDirectory: projectDirectory,
+      packageConfigFile: packageConfigFile,
+      platformDill:
+          soundNullSafety ? '$platformDillSound' : '$platformDillUnsound',
+      fileSystemRoots: fileSystemRoots,
+      fileSystemScheme: fileSystemScheme,
+      verbose: verbose,
+    );
     expressionCompiler = TestExpressionCompiler(generator);
   }
 
   final UrlEncoder urlTunneller;
-  final String mainPath;
-  final String packageConfigPath;
+  final Uri mainUri;
+  final Uri projectDirectory;
+  final Uri packageConfigFile;
   final String outputPath;
-  final List<String> fileSystemRoots;
+  final List<Uri> fileSystemRoots;
   final String fileSystemScheme;
   final bool soundNullSafety;
 
@@ -65,7 +70,8 @@ class ResidentWebRunner {
       fileSystem: fileSystem,
       hostname: hostname,
       port: port,
-      packageConfigPath: packageConfigPath,
+      projectDirectory: projectDirectory,
+      packageConfigFile: packageConfigFile,
       index: index,
       urlTunneller: urlTunneller,
       soundNullSafety: soundNullSafety,
@@ -86,7 +92,7 @@ class ResidentWebRunner {
 
   Future<UpdateFSReport> _updateDevFS() async {
     var report = await devFS.update(
-        mainPath: mainPath,
+        mainUri: mainUri,
         dillOutputPath: outputPath,
         generator: generator,
         invalidatedFiles: []);


### PR DESCRIPTION
- Update `frontend_server_common` infrastructure to behave similar to flutter tools
- Serve the app from a base directory if specified in index.html
- Add test code for index.html with base
- Pass the root instead of the tab url in several places, simplify `dart_uri.dart` to match
- Fix issues discovered in tests

Closes: https://github.com/dart-lang/webdev/issues/1657