### PR TITLE
Stringify URL when resource is not found

### DIFF
--- a/dwds/lib/src/loaders/legacy.dart
+++ b/dwds/lib/src/loaders/legacy.dart
@@ -72,7 +72,7 @@ class LegacyStrategy extends LoadStrategy {
   ) : super(assetReader);
 
   @override
-  Handler get handler => (request) => Response.notFound(request.url);
+  Handler get handler => (request) => Response.notFound(request.url.toString());
 
   @override
   String get id => 'legacy';


### PR DESCRIPTION
Resolves the following error when a resource is not found:

```
Invalid argument(s): Response body "favicon.ico" must be a String or a Stream.
package:shelf/src/response.dart 212:8               new Response.notFound
package:dwds/src/loaders/legacy.dart 75:48          LegacyStrategy.handler.<fn>
package:dwds/src/handlers/injector.dart 126:61      DwdsInjector.middleware.<fn>.<fn>
```