### PR TITLE
Prep Webdev 2.7.10 release 

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 2.7.10-dev
+## 2.7.10
+- Pin DWDS version to avoid dependency conflicts with `package:vm_service`.
 
 ## 2.7.9
 - Add an option to pass user data directory to chrome: `user-data-dir`.

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.7.10-dev';
+const packageVersion = '2.7.10';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `dart run build_runner build`.
-version: 2.7.10-dev
+version: 2.7.10
 # We should not depend on a dev SDK before publishing.
 # publish_to: none
 description: >-
@@ -18,7 +18,8 @@ dependencies:
   browser_launcher: ^1.1.0
   crypto: ^3.0.2
   dds: ^2.2.0
-  dwds: ^14.0.3-dev
+  # Pin DWDS to avoid dependency conflicts with vm_service:
+  dwds: 14.0.3
   http: ^0.13.4
   http_multi_server: ^3.2.0
   io: ^1.0.3


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/1632

In https://github.com/dart-lang/webdev/pull/1633, we updated the `vm_service` version required by DWDS. Before releasing DWDS, we should release Webdev with a pin on the older version of DWDS. Otherwise, the moment we release DWDS, Webdev users will get the following error:

```
Because every version of dwds at {{new version}} depends on vm_service ^9.0.0 and webdev depends on vm_service ^8.3.0, dwds at {{new version}} is forbidden.
So, because webdev depends on dwds at {{new version}, version solving failed.
```

