### PR TITLE
Remove unused ExpressionCompilerService.handler code

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 15.0.1-dev
+- Remove no longer used `ExpressionCompilerService.handler`.
+
 ## 15.0.0
 - Port some `dwds` files to null safety.
 - Fix failing `frontend_server_evaluate` tests.

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -7,9 +7,7 @@ import 'dart:isolate';
 
 import 'package:async/async.dart';
 import 'package:logging/logging.dart';
-import 'package:shelf/shelf.dart';
 
-import '../utilities/dart_uri.dart';
 import '../utilities/sdk_configuration.dart';
 import 'expression_compiler.dart';
 
@@ -218,16 +216,14 @@ class _Compiler {
 ///
 /// Users need to stop the service by calling [stop].
 class ExpressionCompilerService implements ExpressionCompiler {
-  final _logger = Logger('ExpressionCompilerService');
   final _compiler = Completer<_Compiler>();
   final String _address;
   final FutureOr<int> _port;
-  final Handler _assetHandler;
   final bool _verbose;
 
   final SdkConfigurationProvider _sdkConfigurationProvider;
 
-  ExpressionCompilerService(this._address, this._port, this._assetHandler,
+  ExpressionCompilerService(this._address, this._port,
       {bool verbose = false,
       SdkConfigurationProvider? sdkConfigurationProvider})
       : _verbose = verbose,
@@ -270,57 +266,5 @@ class ExpressionCompilerService implements ExpressionCompiler {
 
   Future<void> stop() async {
     if (_compiler.isCompleted) return (await _compiler.future).stop();
-  }
-
-  /// Handles resource requests from expression compiler worker.
-  ///
-  /// Handles REST get requests of the form:
-  /// http://host:port/getResource?uri=<resource uri>
-  ///
-  /// Where the resource uri can be a package Uri for a dart file
-  /// or a server path for a full dill file.
-  /// Translates given resource uri to a server path and redirects
-  /// the request to the asset handler.
-  FutureOr<Response> handler(Request request) async {
-    final uri = request.requestedUri.queryParameters['uri'];
-    try {
-      final query = request.requestedUri.path;
-      _logger.finest('request: ${request.method} ${request.requestedUri}');
-
-      if (query != '/getResource' || uri == null) {
-        return Response.notFound(uri);
-      }
-
-      if (!uri.endsWith('.dart') && !uri.endsWith('.dill')) {
-        return Response.notFound(uri);
-      }
-
-      var serverPath = uri;
-      if (uri.endsWith('.dart')) {
-        serverPath = DartUri(uri).serverPath;
-      }
-
-      _logger.finest('serverpath for $uri: $serverPath');
-
-      request = Request(
-        request.method,
-        Uri(
-          scheme: request.requestedUri.scheme,
-          host: request.requestedUri.host,
-          port: request.requestedUri.port,
-          path: serverPath,
-        ),
-        protocolVersion: request.protocolVersion,
-        context: request.context,
-        headers: request.headers,
-        handlerPath: request.handlerPath,
-        encoding: request.encoding,
-      );
-
-      return await _assetHandler(request);
-    } catch (e, s) {
-      _logger.severe('Error loading $uri', e, s);
-      rethrow;
-    }
   }
 }

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '15.0.0';
+const packageVersion = '15.0.1-dev';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 15.0.0
+version: 15.0.1-dev
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM
   service protocol.

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -60,15 +60,12 @@ void main() async {
       // start expression compilation service
       Response assetHandler(request) =>
           Response(200, body: File.fromUri(kernel).readAsBytesSync());
-      service = ExpressionCompilerService('localhost', port, assetHandler,
-          verbose: false);
+      service = ExpressionCompilerService('localhost', port, verbose: false);
 
       await service.initialize(moduleFormat: 'amd');
 
       // setup asset server
-      serveHttpRequests(
-          server, Cascade().add(service.handler).add(assetHandler).handler,
-          (e, s) {
+      serveHttpRequests(server, assetHandler, (e, s) {
         logger.warning('Error serving requests', e, s);
       });
 

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -244,7 +244,6 @@ class TestContext {
               ddcService = ExpressionCompilerService(
                 'localhost',
                 port,
-                assetHandler,
                 verbose: verboseCompiler,
                 sdkConfigurationProvider: sdkConfigurationProvider,
               );

--- a/dwds/test/fixtures/server.dart
+++ b/dwds/test/fixtures/server.dart
@@ -127,10 +127,6 @@ class TestServer {
 
     cascade = cascade.add(dwds.handler).add(assetHandler);
 
-    if (ddcService != null) {
-      cascade = cascade.add(ddcService.handler);
-    }
-
     serveHttpRequests(
         server,
         pipeline

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.7.11-dev
+- Remove no longer used `ExpressionCompilerService.handler`.
+
 ## 2.7.10
 - Pin DWDS version to avoid dependency conflicts with `package:vm_service`.
 

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -131,7 +131,6 @@ class WebDevServer {
         ddcService = ExpressionCompilerService(
           options.configuration.hostname,
           options.port,
-          assetHandler,
           verbose: options.configuration.verbose,
         );
       }
@@ -161,9 +160,6 @@ class WebDevServer {
       pipeline = pipeline.addMiddleware(dwds.middleware);
       cascade = cascade.add(dwds.handler);
       cascade = cascade.add(assetHandler);
-      if (ddcService != null) {
-        cascade = cascade.add(ddcService.handler);
-      }
     } else {
       cascade = cascade.add(assetHandler);
     }

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.7.10';
+const packageVersion = '2.7.11-dev';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `dart run build_runner build`.
-version: 2.7.10
+version: 2.7.11-dev
 # We should not depend on a dev SDK before publishing.
 # publish_to: none
 description: >-
@@ -34,7 +34,7 @@ dependencies:
   shelf_static: ^1.1.0
   stack_trace: ^1.10.0
   sse: ^4.1.0
-  vm_service: ^8.3.0
+  vm_service: ^9.0.0
   webkit_inspection_protocol: ^1.0.1
   yaml: ^3.1.1
 
@@ -49,9 +49,9 @@ dev_dependencies:
   webdriver: ^3.0.0
 
 # Comment out before releasing webdev.
-# dependency_overrides:
-#   dwds:
-#     path: ../dwds
+dependency_overrides:
+  dwds:
+    path: ../dwds
 
 executables:
   webdev:


### PR DESCRIPTION
Remove unused `ExpressionCompilerService.handler` code.

The handler was a proxy for communication to the asset server. Note that the only former user, `expression_compiler_worker.dart` in the SDK is already changed to communicate to the asset server directly.