### PR TITLE
Fix file serving bug when using the Dart Debug Extension

### DIFF
--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -507,7 +507,7 @@ class DevHandler {
           _hostname,
           extensionDebugger,
           extensionDebugger.executionContext,
-          devToolsRequest.tabUrl,
+          basePathForServerUri(devToolsRequest.tabUrl),
           _assetReader,
           _loadStrategy,
           connection,


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/dart-lang/webdev/pull/1658

That change modified a parameter in `DebugService.start` from the full URL to only the root. We were correctly passing this when the debug service was started normally, but not when it was started from the Dart Debug Extension.
