### PR TITLE
Split `fakes.dart` into null-safe and non null-safe fakes

### DIFF
--- a/dwds/test/fixtures/migrated_fakes.dart
+++ b/dwds/test/fixtures/migrated_fakes.dart
@@ -1,0 +1,100 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:dwds/expression_compiler.dart';
+import 'package:dwds/src/debugging/metadata/provider.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:dwds/asset_reader.dart';
+
+class FakeStrategy implements LoadStrategy {
+  @override
+  Future<String> bootstrapFor(String entrypoint) async => 'dummy_bootstrap';
+
+  @override
+  shelf.Handler get handler =>
+      (request) => (request.url.path == 'someDummyPath')
+          ? shelf.Response.ok('some dummy response')
+          : shelf.Response.notFound('someDummyPath');
+
+  @override
+  String get id => 'dummy-id';
+
+  @override
+  String get moduleFormat => 'dummy-format';
+
+  @override
+  String get loadLibrariesModule => '';
+
+  @override
+  String get loadLibrariesSnippet => '';
+
+  @override
+  String loadLibrarySnippet(String libraryUri) => '';
+
+  @override
+  String get loadModuleSnippet => '';
+
+  @override
+  ReloadConfiguration get reloadConfiguration => ReloadConfiguration.none;
+
+  @override
+  String loadClientSnippet(String clientScript) => 'dummy-load-client-snippet';
+
+  @override
+  Future<String> moduleForServerPath(String entrypoint, String serverPath) =>
+      Future.value('');
+
+  @override
+  Future<String> serverPathForModule(String entrypoint, String module) =>
+      Future.value('');
+
+  @override
+  Future<String> sourceMapPathForModule(String entrypoint, String module) =>
+      Future.value('');
+
+  @override
+  String serverPathForAppUri(String appUri) => '';
+
+  @override
+  MetadataProvider metadataProviderFor(String entrypoint) =>
+      MetadataProvider(entrypoint, FakeAssetReader(fakeMetadata));
+
+  @override
+  void trackEntrypoint(String entrypoint) {}
+
+  @override
+  Future<Map<String, ModuleInfo>> moduleInfoForEntrypoint(String entrypoint) =>
+      throw UnimplementedError();
+}
+
+class FakeAssetReader implements AssetReader {
+  final String _metadata;
+  FakeAssetReader(this._metadata);
+  @override
+  Future<String> dartSourceContents(String serverPath) =>
+      throw UnimplementedError();
+
+  @override
+  Future<String> metadataContents(String serverPath) async => _metadata;
+
+  @override
+  Future<String> sourceMapContents(String serverPath) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> close() async {}
+}
+
+const fakeMetadata =
+    '{"version":"1.0.0","name":"web/main","closureName":"load__web__main",'
+    '"sourceMapUri":"foo/web/main.ddc.js.map",'
+    '"moduleUri":"foo/web/main.ddc.js",'
+    '"soundNullSafety":true,'
+    '"libraries":[{"name":"main",'
+    '"importUri":"org-dartlang-app:///web/main.dart",'
+    '"fileUri":"org-dartlang-app:///web/main.dart","partUris":[]}]}\n'
+    '// intentionally empty: package blah has no dart sources';

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -2,12 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.9
-
-import 'package:dwds/asset_reader.dart';
 import 'package:dwds/src/debugging/metadata/module_metadata.dart';
 import 'package:dwds/src/debugging/metadata/provider.dart';
 import 'package:test/test.dart';
+
+import 'fixtures/migrated_fakes.dart';
 
 const _emptySourceMetadata =
     '{"version":"1.0.0","name":"web/main","closureName":"load__web__main",'
@@ -37,24 +36,6 @@ const _fileUriMetadata =
     '"importUri":"file:/Users/foo/blah/sample/lib/bar.dart",'
     '"fileUri":"org-dartlang-app:///web/main.dart","partUris":[]}]}\n'
     '// intentionally empty: package blah has no dart sources';
-
-class FakeAssetReader implements AssetReader {
-  final String _metadata;
-  FakeAssetReader(this._metadata);
-  @override
-  Future<String> dartSourceContents(String serverPath) =>
-      throw UnimplementedError();
-
-  @override
-  Future<String> metadataContents(String serverPath) async => _metadata;
-
-  @override
-  Future<String> sourceMapContents(String serverPath) =>
-      throw UnimplementedError();
-
-  @override
-  Future<void> close() async {}
-}
 
 void main() {
   test('can parse metadata with empty sources', () async {

--- a/dwds/test/skip_list_test.dart
+++ b/dwds/test/skip_list_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
 import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/debugging/location.dart';
 import 'package:dwds/src/debugging/skip_list.dart';

--- a/dwds/test/skip_list_test.dart
+++ b/dwds/test/skip_list_test.dart
@@ -2,15 +2,28 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.9
 
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/debugging/location.dart';
 import 'package:dwds/src/debugging/skip_list.dart';
+import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:source_maps/parser.dart';
 import 'package:test/test.dart';
 
+import 'fixtures/migrated_fakes.dart';
+
+class TestStrategy extends FakeStrategy {
+  @override
+  String serverPathForAppUri(String appUri) {
+    return 'foo';
+  }
+}
+
 void main() {
-  SkipLists skipLists;
+  globalLoadStrategy = TestStrategy();
+
+  late SkipLists skipLists;
+  final dartUri = DartUri('org-dartlang-app://web/main.dart');
   group('SkipLists', () {
     setUp(() {
       skipLists = SkipLists();
@@ -19,9 +32,9 @@ void main() {
     test('do not include known ranges', () async {
       final skipList = await skipLists.compute('123', {
         Location.from(
-            'foo', TargetLineEntry(1, []), TargetEntry(2, 0, 0, 0), null),
+            'foo', TargetLineEntry(1, []), TargetEntry(2, 0, 0, 0), dartUri),
         Location.from(
-            'foo', TargetLineEntry(10, []), TargetEntry(20, 0, 0, 0), null),
+            'foo', TargetLineEntry(10, []), TargetEntry(20, 0, 0, 0), dartUri),
       });
       expect(skipList.length, 3);
       _validateRange(skipList.first, 0, 0, 1, 1);
@@ -32,9 +45,9 @@ void main() {
     test('do not include start of the file', () async {
       final skipList = await skipLists.compute('123', {
         Location.from(
-            'foo', TargetLineEntry(0, []), TargetEntry(0, 0, 0, 0), null),
+            'foo', TargetLineEntry(0, []), TargetEntry(0, 0, 0, 0), dartUri),
         Location.from(
-            'foo', TargetLineEntry(10, []), TargetEntry(20, 0, 0, 0), null),
+            'foo', TargetLineEntry(10, []), TargetEntry(20, 0, 0, 0), dartUri),
       });
       expect(skipList.length, 2);
       _validateRange(skipList[0], 0, 1, 10, 19);
@@ -44,9 +57,9 @@ void main() {
     test('does not depend on order of locations', () async {
       final skipList = await skipLists.compute('123', {
         Location.from(
-            'foo', TargetLineEntry(10, []), TargetEntry(20, 0, 0, 0), null),
+            'foo', TargetLineEntry(10, []), TargetEntry(20, 0, 0, 0), dartUri),
         Location.from(
-            'foo', TargetLineEntry(0, []), TargetEntry(0, 0, 0, 0), null),
+            'foo', TargetLineEntry(0, []), TargetEntry(0, 0, 0, 0), dartUri),
       });
       expect(skipList.length, 2);
       _validateRange(skipList[0], 0, 1, 10, 19);


### PR DESCRIPTION
Temporarily creates a new `migrated_fakes.dart` file for the purpose of the null-safe migration.

As I migrate files that depend on `fixtures/fakes.dart` to null-safety, will move those that use fakes with no non null-safe dependencies over to `fixtures:migrated_fakes.dart`.