### PR TITLE
Enable  evaluation tests after sdk bug fix

### DIFF
--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -495,5 +495,5 @@ void main() {
         });
       });
     }
-  }, skip: 'dart-lang/sdk#49373');
+  });
 }


### PR DESCRIPTION
Closes: https://github.com/dart-lang/webdev/issues/1675