### PR TITLE
Prepare Dart Debug Extension for release

### DIFF
--- a/dwds/debug_extension/CHANGELOG.md
+++ b/dwds/debug_extension/CHANGELOG.md
@@ -1,12 +1,10 @@
-## 1.31
-- Replace manual extension allowlist by configuring `externally_connectable` in
-  the `manifest.json`. See https://developer.chrome.com/docs/extensions/mv3/manifest/externally_connectable/
-  for details.
-
 ## 1.30
 - Batch extension `Debugger.scriptParsed` events and send batches every 1000ms
   to the server.
 - Enable null-safety.
+- Replace manual extension allowlist by configuring `externally_connectable` in
+  the `manifest.json`. See https://developer.chrome.com/docs/extensions/mv3/manifest/externally_connectable/
+  for details.
   
 ## 1.29
 

--- a/dwds/debug_extension/pubspec.yaml
+++ b/dwds/debug_extension/pubspec.yaml
@@ -1,6 +1,6 @@
 name: extension
 publish_to: none
-version: 1.31.0
+version: 1.30.0
 homepage: https://github.com/dart-lang/webdev
 description: >-
   A chrome extension for Dart debugging.

--- a/dwds/debug_extension/web/manifest.json
+++ b/dwds/debug_extension/web/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Dart Debug Extension",
-    "version": "1.31",
+    "version": "1.30",
     "minimum_chrome_version": "10.0",
     "devtools_page": "devtools.html",
     "externally_connectable": {


### PR DESCRIPTION
Version was bumped up one to many (current version is `1.29`, next release is `1.30`). 