### PR TITLE
Fix getStack race conditions on isolate start

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -5,9 +5,11 @@
   evaluation using a compiler in all scenarios.
 - Fix a bug where evaluation would fail with more than one parameter in
   the scope.
-- Remove showing uncaptured values from the stack during evaluation.
+- Remove showing un-captured values from the stack during evaluation.
 - Refactor code to break most circular dependencies between files.
 - Migrate `package:dwds` to null safety.
+- Make `ChromeProxyService.getStack` wait for the debugger to perform initial
+  resume operation. This avoids race conditions on isolate start.
 
 **Breaking changes**
 - Remove no longer used `ExpressionCompilerService.handler`.

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -150,7 +150,7 @@ class Debugger extends Domain {
 
   /// Returns the current Dart stack for the paused debugger.
   ///
-  /// Returns null if the debugger is not paused.
+  /// Throws RPCError if the debugger is not paused.
   ///
   /// The returned stack will contain up to [limit] frames if provided.
   Future<Stack> getStack({int? limit}) async {

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -46,6 +46,10 @@ class ChromeProxyService implements VmServiceInterface {
   Future<void> get isInitialized => _initializedCompleter.future;
   Completer<void> _initializedCompleter = Completer<void>();
 
+  /// Signals when isolate starts.
+  Future<void> get isStarted => _startedCompleter.future;
+  Completer<void> _startedCompleter = Completer<void>();
+
   /// Signals when expression compiler is ready to evaluate.
   Future<void> get isCompilerInitialized => _compilerCompleter.future;
   Completer<void> _compilerCompleter = Completer<void>();
@@ -252,6 +256,7 @@ class ChromeProxyService implements VmServiceInterface {
 
     unawaited(appConnection.onStart.then((_) async {
       await debugger.resumeFromStart();
+      _startedCompleter.complete();
     }));
 
     final isolateRef = inspector.isolateRef;
@@ -301,6 +306,7 @@ class ChromeProxyService implements VmServiceInterface {
     final isolateRef = inspector.isolateRef;
 
     _initializedCompleter = Completer<void>();
+    _startedCompleter = Completer<void>();
     _compilerCompleter = Completer<void>();
     _streamNotify(
         'Isolate',
@@ -573,12 +579,13 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
   /// Returns the current stack.
   ///
-  /// Returns null if the corresponding isolate is not paused.
+  /// Throws RPCError the corresponding isolate is not paused.
   ///
   /// The returned stack will contain up to [limit] frames if provided.
   @override
   Future<Stack> getStack(String isolateId, {int? limit}) async {
     await isInitialized;
+    await isStarted;
     _checkIsolate('getStack', isolateId);
     return (await debuggerFuture).getStack(limit: limit);
   }
@@ -718,6 +725,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
     if (inspector.appConnection.isStarted) {
       return captureElapsedTime(() async {
         await isInitialized;
+        await isStarted;
         _checkIsolate('resume', isolateId);
         return await (await debuggerFuture)
             .resume(step: step, frameIndex: frameIndex);


### PR DESCRIPTION
Make `ChromeProxyService.getStack` wait for the debugger to perform initial resume operation.
This avoids race conditions on isolate start if `getStack` is called too soon.  

See failures in https://github.com/dart-lang/webdev/pull/1701 tests on windows for examples:

<img width="851" alt="image" src="https://user-images.githubusercontent.com/12737689/181853400-fd2e6fde-01f5-450a-81ca-0c286ab8f059.png">
