### PR TITLE
Migrate `debugger_test`, `inspector_test`, and `instance_test` to null-safety

### DIFF
--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.9
 
 @TestOn('vm')
 import 'dart:async';
@@ -23,12 +22,12 @@ import 'fixtures/debugger_data.dart';
 import 'fixtures/fakes.dart';
 
 final context = TestContext();
-AppInspector inspector;
-Debugger debugger;
-FakeWebkitDebugger webkitDebugger;
-StreamController<DebuggerPausedEvent> pausedController;
-Locations locations;
-SkipLists skipLists;
+late AppInspector inspector;
+late Debugger debugger;
+late FakeWebkitDebugger webkitDebugger;
+late StreamController<DebuggerPausedEvent> pausedController;
+late Locations locations;
+late SkipLists skipLists;
 
 class TestStrategy extends FakeStrategy {
   @override
@@ -109,8 +108,8 @@ void main() async {
     expect(frames, isNotNull);
     expect(frames, isNotEmpty);
 
-    final firstFrame = frames[0];
-    final frame1Variables = firstFrame.vars.map((each) => each.name).toList();
+    final firstFrameVars = frames[0].vars!;
+    final frame1Variables = firstFrameVars.map((each) => each.name).toList();
     expect(frame1Variables, ['a', 'b']);
   });
 
@@ -185,7 +184,7 @@ void main() async {
       expect(
           Debugger.logger.onRecord,
           emitsThrough(predicate(
-              (log) => log.message == 'Error calculating Dart frames')));
+              (dynamic log) => log.message == 'Error calculating Dart frames')));
     });
   });
 }

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
 @TestOn('vm')
 import 'dart:async';
 
@@ -183,8 +182,8 @@ void main() async {
       }));
       expect(
           Debugger.logger.onRecord,
-          emitsThrough(predicate(
-              (dynamic log) => log.message == 'Error calculating Dart frames')));
+          emitsThrough(predicate((dynamic log) =>
+              log.message == 'Error calculating Dart frames')));
     });
   });
 }

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
 @TestOn('vm')
 import 'package:dwds/dwds.dart';
 import 'package:dwds/src/connections/debug_connection.dart';

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -53,7 +53,8 @@ void main() {
     test('for a null', () async {
       final remoteObject = await libraryPublicFinal();
       final nullVariable = await inspector.loadField(remoteObject, 'notFinal');
-      final ref = await (inspector.instanceRefFor(nullVariable) as FutureOr<InstanceRef>);
+      final ref = await (inspector.instanceRefFor(nullVariable)
+          as FutureOr<InstanceRef>);
       expect(ref.valueAsString, 'null');
       expect(ref.kind, InstanceKind.kNull);
       final classRef = ref.classRef!;
@@ -64,7 +65,8 @@ void main() {
     test('for a double', () async {
       final remoteObject = await libraryPublicFinal();
       final count = await inspector.loadField(remoteObject, 'count');
-      final ref = await (inspector.instanceRefFor(count) as FutureOr<InstanceRef>);
+      final ref =
+          await (inspector.instanceRefFor(count) as FutureOr<InstanceRef>);
       expect(ref.valueAsString, '0');
       expect(ref.kind, InstanceKind.kDouble);
       final classRef = ref.classRef!;
@@ -75,7 +77,8 @@ void main() {
     test('for a class', () async {
       final remoteObject = await libraryPublicFinal();
       final count = await inspector.loadField(remoteObject, 'myselfField');
-      final ref = await (inspector.instanceRefFor(count) as FutureOr<InstanceRef>);
+      final ref =
+          await (inspector.instanceRefFor(count) as FutureOr<InstanceRef>);
       expect(ref.kind, InstanceKind.kPlainInstance);
       final classRef = ref.classRef!;
       expect(classRef.name, 'MyTestClass<dynamic>');
@@ -90,7 +93,8 @@ void main() {
       final properties = await debugger.getProperties(remoteObject.objectId!);
       final closure =
           properties.firstWhere((property) => property.name == 'closure');
-      final instanceRef = await (inspector.instanceRefFor(closure.value!) as FutureOr<InstanceRef>);
+      final instanceRef = await (inspector.instanceRefFor(closure.value!)
+          as FutureOr<InstanceRef>);
       final functionName = instanceRef.closureFunction!.name;
       // Older SDKs do not contain function names
       if (functionName != 'Closure') {
@@ -101,7 +105,8 @@ void main() {
 
     test('for a list', () async {
       final remoteObject = await libraryPublic();
-      final ref = await (inspector.instanceRefFor(remoteObject) as FutureOr<InstanceRef>);
+      final ref = await (inspector.instanceRefFor(remoteObject)
+          as FutureOr<InstanceRef>);
       expect(ref.length, greaterThan(0));
       expect(ref.kind, InstanceKind.kList);
       expect(ref.classRef!.name, 'List<String>');
@@ -110,7 +115,8 @@ void main() {
     test('for map', () async {
       final remoteObject =
           await inspector.jsEvaluate(libraryVariableExpression('map'));
-      final ref = await (inspector.instanceRefFor(remoteObject) as FutureOr<InstanceRef>);
+      final ref = await (inspector.instanceRefFor(remoteObject)
+          as FutureOr<InstanceRef>);
       expect(ref.length, 2);
       expect(ref.kind, InstanceKind.kMap);
       expect(ref.classRef!.name, 'LinkedMap<Object, Object>');
@@ -119,7 +125,8 @@ void main() {
     test('for an IdentityMap', () async {
       final remoteObject =
           await inspector.jsEvaluate(libraryVariableExpression('identityMap'));
-      final ref = await (inspector.instanceRefFor(remoteObject) as FutureOr<InstanceRef>);
+      final ref = await (inspector.instanceRefFor(remoteObject)
+          as FutureOr<InstanceRef>);
       expect(ref.length, 2);
       expect(ref.kind, InstanceKind.kMap);
       expect(ref.classRef!.name, 'IdentityMap<String, int>');
@@ -129,7 +136,8 @@ void main() {
   group('instance', () {
     test('for class object', () async {
       final remoteObject = await libraryPublicFinal();
-      final instance = await (inspector.instanceFor(remoteObject) as FutureOr<Instance>);
+      final instance =
+          await (inspector.instanceFor(remoteObject) as FutureOr<Instance>);
       expect(instance.kind, InstanceKind.kPlainInstance);
       final classRef = instance.classRef!;
       expect(classRef, isNotNull);
@@ -156,7 +164,8 @@ void main() {
       final properties = await debugger.getProperties(remoteObject.objectId!);
       final closure =
           properties.firstWhere((property) => property.name == 'closure');
-      final instance = await (inspector.instanceFor(closure.value!) as FutureOr<Instance>);
+      final instance =
+          await (inspector.instanceFor(closure.value!) as FutureOr<Instance>);
       expect(instance.kind, InstanceKind.kClosure);
       expect(instance.classRef!.name, 'Closure');
     });
@@ -165,7 +174,8 @@ void main() {
       final libraryRemoteObject = await libraryPublicFinal();
       final fieldRemoteObject =
           await inspector.loadField(libraryRemoteObject, 'myselfField');
-      final instance = await (inspector.instanceFor(fieldRemoteObject) as FutureOr<Instance>);
+      final instance = await (inspector.instanceFor(fieldRemoteObject)
+          as FutureOr<Instance>);
       expect(instance.kind, InstanceKind.kPlainInstance);
       final classRef = instance.classRef!;
       expect(classRef, isNotNull);
@@ -174,7 +184,8 @@ void main() {
 
     test('for a list', () async {
       final remote = await libraryPublic();
-      final instance = await (inspector.instanceFor(remote) as FutureOr<Instance>);
+      final instance =
+          await (inspector.instanceFor(remote) as FutureOr<Instance>);
       expect(instance.kind, InstanceKind.kList);
       final classRef = instance.classRef!;
       expect(classRef, isNotNull);
@@ -186,7 +197,8 @@ void main() {
     test('for a map', () async {
       final remote =
           await inspector.jsEvaluate(libraryVariableExpression('map'));
-      final instance = await (inspector.instanceFor(remote) as FutureOr<Instance>);
+      final instance =
+          await (inspector.instanceFor(remote) as FutureOr<Instance>);
       expect(instance.kind, InstanceKind.kMap);
       final classRef = instance.classRef!;
       expect(classRef.name, 'LinkedMap<Object, Object>');
@@ -201,7 +213,8 @@ void main() {
     test('for an identityMap', () async {
       final remote =
           await inspector.jsEvaluate(libraryVariableExpression('identityMap'));
-      final instance = await (inspector.instanceFor(remote) as FutureOr<Instance>);
+      final instance =
+          await (inspector.instanceFor(remote) as FutureOr<Instance>);
       expect(instance.kind, InstanceKind.kMap);
       final classRef = instance.classRef!;
       expect(classRef.name, 'IdentityMap<String, int>');
@@ -213,7 +226,8 @@ void main() {
       // The VM only uses kind List for SDK lists, and we follow that.
       final remote =
           await inspector.jsEvaluate(libraryVariableExpression('notAList'));
-      final instance = await (inspector.instanceFor(remote) as FutureOr<Instance>);
+      final instance =
+          await (inspector.instanceFor(remote) as FutureOr<Instance>);
       expect(instance.kind, InstanceKind.kPlainInstance);
       final classRef = instance.classRef!;
       expect(classRef.name, 'NotReallyAList');


### PR DESCRIPTION
Left in all the null-assert `!`s since this is a test, so we would like the assertions to fail if something changes to make what we expect to be non-null to actually be null. 