### PR TITLE
Migrate `chrome_proxy_service_test` to null-safety

### DIFF
--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -110,13 +110,14 @@ class LibraryHelper extends Domain {
     List<ClassRef>? classRefs;
     if (result != null) {
       final classDescriptors =
-          ((result.value as Map<String, dynamic>)['classes'] as List?)
-              ?.cast<Map<String, Object>>();
-      classRefs = classDescriptors?.map<ClassRef>((classDescriptor) {
+          (result.value as Map<String, dynamic>)['classes'] ?? [];
+      classRefs = List<Map<String, dynamic>>.from(classDescriptors)
+          .map<ClassRef>((classDescriptor) {
+        final descriptor = Map<String, Object>.from(classDescriptor);
         final classMetaData = ClassMetaData(
-          jsName: classDescriptor['name'],
+          jsName: descriptor['name'],
           libraryId: libraryRef.id,
-          dartName: classDescriptor['dartName'],
+          dartName: descriptor['dartName'],
         );
         return classMetaData.classRef;
       }).toList();

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -113,11 +113,11 @@ class LibraryHelper extends Domain {
           (result.value as Map<String, dynamic>)['classes'] ?? [];
       classRefs = List<Map<String, dynamic>>.from(classDescriptors)
           .map<ClassRef>((classDescriptor) {
-        final descriptor = Map<String, Object>.from(classDescriptor);
+        // final descriptor = Map<String, Object>.from(classDescriptor);
         final classMetaData = ClassMetaData(
-          jsName: descriptor['name'],
+          jsName: classDescriptor['name'] as Object?,
           libraryId: libraryRef.id,
-          dartName: descriptor['dartName'],
+          dartName: classDescriptor['dartName'] as Object?,
         );
         return classMetaData.classRef;
       }).toList();

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -107,20 +107,19 @@ class LibraryHelper extends Domain {
       _logger.warning('Library ${libraryRef.uri} is not loaded. '
           'This can happen for unreferenced libraries.');
     }
-    List<ClassRef>? classRefs;
+    final classRefs = <ClassRef>[];
     if (result != null) {
+      final jsonValues = result.value as Map<String, dynamic>;
       final classDescriptors =
-          (result.value as Map<String, dynamic>)['classes'] ?? [];
-      classRefs = List<Map<String, dynamic>>.from(classDescriptors)
-          .map<ClassRef>((classDescriptor) {
-        // final descriptor = Map<String, Object>.from(classDescriptor);
+          List<Map<String, dynamic>>.from(jsonValues['classes'] ?? []);
+      for (final classDescriptor in classDescriptors) {
         final classMetaData = ClassMetaData(
           jsName: classDescriptor['name'] as Object?,
           libraryId: libraryRef.id,
           dartName: classDescriptor['dartName'] as Object?,
         );
-        return classMetaData.classRef;
-      }).toList();
+        classRefs.add(classMetaData.classRef);
+      }
     }
     return Library(
       name: libraryRef.name,

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -1359,9 +1359,9 @@ void main() {
       final isolateId = vm.isolates!.first.id!;
       final scriptList = await service.getScripts(isolateId);
 
-      final uris = scriptList.scripts!.map((e) => e.uri).toList();
-      final resolvedUris = await service.lookupResolvedPackageUris(
-          isolateId, uris as List<String>);
+      final uris = scriptList.scripts!.map((e) => e.uri!).toList();
+      final resolvedUris =
+          await service.lookupResolvedPackageUris(isolateId, uris);
 
       expect(
           resolvedUris.uris,
@@ -1406,12 +1406,12 @@ void main() {
       final isolateId = vm.isolates!.first.id!;
       final scriptList = await service.getScripts(isolateId);
 
-      final uris = scriptList.scripts!.map((e) => e.uri).toList();
-      final resolvedUris = await service.lookupResolvedPackageUris(
-          isolateId, uris as List<String>);
+      final uris = scriptList.scripts!.map((e) => e.uri!).toList();
+      final resolvedUris =
+          await service.lookupResolvedPackageUris(isolateId, uris);
 
       final packageUris = await service.lookupPackageUris(
-          isolateId, resolvedUris.uris as List<String>);
+          isolateId, List<String>.from(resolvedUris.uris!));
       expect(
           packageUris.uris,
           containsAll([
@@ -1426,13 +1426,12 @@ void main() {
       final isolateId = vm.isolates!.first.id!;
       final scriptList = await service.getScripts(isolateId);
 
-      final uris = scriptList.scripts!.map((e) => e.uri).toList();
-      final resolvedUrisWithLocal = await service.lookupResolvedPackageUris(
-          isolateId, uris as List<String>,
-          local: true);
+      final uris = scriptList.scripts!.map((e) => e.uri!).toList();
+      final resolvedUrisWithLocal =
+          await service.lookupResolvedPackageUris(isolateId, uris, local: true);
 
       final packageUrisWithLocal = await service.lookupPackageUris(
-          isolateId, resolvedUrisWithLocal.uris as List<String>);
+          isolateId, List<String>.from(resolvedUrisWithLocal.uris!));
       expect(
           packageUrisWithLocal.uris,
           containsAll([
@@ -1445,7 +1444,7 @@ void main() {
           await service.lookupResolvedPackageUris(isolateId, uris, local: true);
 
       final packageUrisWithoutLocal = await service.lookupPackageUris(
-          isolateId, resolvedUrisWithoutLocal.uris as List<String>);
+          isolateId, List<String>.from(resolvedUrisWithoutLocal.uris!));
       expect(
           packageUrisWithoutLocal.uris,
           containsAll([

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.9
 
 @TestOn('vm')
 import 'dart:async';
@@ -48,65 +47,65 @@ void main() {
 
     group('breakpoints', () {
       VM vm;
-      Isolate isolate;
+      late Isolate isolate;
 
-      ScriptList scripts;
-      ScriptRef mainScript;
+      late ScriptList scripts;
+      late ScriptRef mainScript;
 
       setUp(() async {
         setCurrentLogWriter(debug: debug);
         vm = await fetchChromeProxyService(context.debugConnection).getVM();
         isolate = await fetchChromeProxyService(context.debugConnection)
-            .getIsolate(vm.isolates.first.id);
+            .getIsolate(vm.isolates!.first.id!);
         scripts = await fetchChromeProxyService(context.debugConnection)
-            .getScripts(isolate.id);
-        mainScript = scripts.scripts
-            .firstWhere((each) => each.uri.contains('main.dart'));
+            .getScripts(isolate.id!);
+        mainScript = scripts.scripts!
+            .firstWhere((each) => each.uri!.contains('main.dart'));
       });
 
       test('addBreakpoint', () async {
         // TODO: Much more testing.
         final line = await context.findBreakpointLine(
-            'printHelloWorld', isolate.id, mainScript);
+            'printHelloWorld', isolate.id!, mainScript);
         final firstBp =
-            await service.addBreakpoint(isolate.id, mainScript.id, line);
+            await service.addBreakpoint(isolate.id!, mainScript.id!, line);
         expect(firstBp, isNotNull);
         expect(firstBp.id, isNotNull);
 
         final secondBp =
-            await service.addBreakpoint(isolate.id, mainScript.id, line);
+            await service.addBreakpoint(isolate.id!, mainScript.id!, line);
         expect(secondBp, isNotNull);
         expect(secondBp.id, isNotNull);
 
         expect(firstBp.id, equals(secondBp.id));
 
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id, firstBp.id);
+        await service.removeBreakpoint(isolate.id!, firstBp.id!);
       });
 
       test('addBreakpoint succeeds when sending the same breakpoint twice',
           () async {
         final line = await context.findBreakpointLine(
-            'printHelloWorld', isolate.id, mainScript);
-        final firstBp = service.addBreakpoint(isolate.id, mainScript.id, line);
-        final secondBp = service.addBreakpoint(isolate.id, mainScript.id, line);
+            'printHelloWorld', isolate.id!, mainScript);
+        final firstBp = service.addBreakpoint(isolate.id!, mainScript.id!, line);
+        final secondBp = service.addBreakpoint(isolate.id!, mainScript.id!, line);
 
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id, (await firstBp).id);
+        await service.removeBreakpoint(isolate.id!, (await firstBp).id!);
         expect((await firstBp).id, equals((await secondBp).id));
       });
 
       test('addBreakpoint in nonsense location throws', () async {
-        expect(service.addBreakpoint(isolate.id, mainScript.id, 200000),
-            throwsA(predicate((e) => e is RPCError && e.code == 102)));
+        expect(service.addBreakpoint(isolate.id!, mainScript.id!, 200000),
+            throwsA(predicate((dynamic e) => e is RPCError && e.code == 102)));
       });
 
       test('addBreakpoint on a part file', () async {
-        final partScript = scripts.scripts
-            .firstWhere((script) => script.uri.contains('part.dart'));
-        final bp = await service.addBreakpoint(isolate.id, partScript.id, 10);
+        final partScript = scripts.scripts!
+            .firstWhere((script) => script.uri!.contains('part.dart'));
+        final bp = await service.addBreakpoint(isolate.id!, partScript.id!, 10);
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id, bp.id);
+        await service.removeBreakpoint(isolate.id!, bp.id!);
         expect(bp.id, isNotNull);
       });
 
@@ -117,26 +116,26 @@ void main() {
 
       test('addBreakpointWithScriptUri', () async {
         final line = await context.findBreakpointLine(
-            'printHelloWorld', isolate.id, mainScript);
+            'printHelloWorld', isolate.id!, mainScript);
         final bp = await service.addBreakpointWithScriptUri(
-            isolate.id, mainScript.uri, line);
+            isolate.id!, mainScript.uri!, line);
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id, bp.id);
+        await service.removeBreakpoint(isolate.id!, bp.id!);
         expect(bp.id, isNotNull);
       });
 
       test('addBreakpointWithScriptUri absolute file URI', () async {
         final current = context.workingDirectory;
         final test = path.join(path.dirname(current), '_test');
-        final scriptPath = Uri.parse(mainScript.uri).path.substring(1);
+        final scriptPath = Uri.parse(mainScript.uri!).path.substring(1);
         final fullPath = path.join(test, scriptPath);
         final fileUri = Uri.file(fullPath);
         final line = await context.findBreakpointLine(
-            'printHelloWorld', isolate.id, mainScript);
+            'printHelloWorld', isolate.id!, mainScript);
         final bp = await service.addBreakpointWithScriptUri(
-            isolate.id, '$fileUri', line);
+            isolate.id!, '$fileUri', line);
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id, bp.id);
+        await service.removeBreakpoint(isolate.id!, bp.id!);
         expect(bp.id, isNotNull);
       });
 
@@ -144,20 +143,20 @@ void main() {
         await expectLater(
             service.removeBreakpoint(null, null), throwsSentinelException);
         await expectLater(
-            service.removeBreakpoint(isolate.id, null), throwsRPCError);
+            service.removeBreakpoint(isolate.id!, null), throwsRPCError);
       });
 
       test("removeBreakpoint that doesn't exist fails", () async {
         await expectLater(
-            service.removeBreakpoint(isolate.id, '1234'), throwsRPCError);
+            service.removeBreakpoint(isolate.id!, '1234'), throwsRPCError);
       });
 
       test('add and remove breakpoint', () async {
         final line = await context.findBreakpointLine(
-            'printHelloWorld', isolate.id, mainScript);
-        final bp = await service.addBreakpoint(isolate.id, mainScript.id, line);
+            'printHelloWorld', isolate.id!, mainScript);
+        final bp = await service.addBreakpoint(isolate.id!, mainScript.id!, line);
         expect(isolate.breakpoints, [bp]);
-        await service.removeBreakpoint(isolate.id, bp.id);
+        await service.removeBreakpoint(isolate.id!, bp.id!);
         expect(isolate.breakpoints, isEmpty);
       });
     });
@@ -205,7 +204,7 @@ void main() {
               'code': '-32001',
               'details': jsonEncode(errorDetails),
             }),
-            throwsA(predicate((error) =>
+            throwsA(predicate((dynamic error) =>
                 error is RPCError &&
                 error.code == -32001 &&
                 error.details == jsonEncode(errorDetails))));
@@ -242,9 +241,9 @@ void main() {
 
     test('getMemoryUsage', () async {
       final vm = await service.getVM();
-      final isolate = await service.getIsolate(vm.isolates.first.id);
+      final isolate = await service.getIsolate(vm.isolates!.first.id!);
 
-      final memoryUsage = await service.getMemoryUsage(isolate.id);
+      final memoryUsage = await service.getMemoryUsage(isolate.id!);
 
       expect(memoryUsage.heapUsage, isNotNull);
       expect(memoryUsage.heapUsage, greaterThan(0));
@@ -253,13 +252,13 @@ void main() {
     });
 
     group('evaluate', () {
-      Isolate isolate;
-      LibraryRef bootstrap;
+      late Isolate isolate;
+      LibraryRef? bootstrap;
 
       setUpAll(() async {
         setCurrentLogWriter(debug: debug);
         final vm = await service.getVM();
-        isolate = await service.getIsolate(vm.isolates.first.id);
+        isolate = await service.getIsolate(vm.isolates!.first.id!);
         bootstrap = isolate.rootLib;
       });
 
@@ -271,7 +270,7 @@ void main() {
         test('can return strings', () async {
           expect(
               await service.evaluate(
-                  isolate.id, bootstrap.id, "helloString('world')"),
+                  isolate.id!, bootstrap!.id!, "helloString('world')"),
               const TypeMatcher<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'value', 'world'));
         });
@@ -279,14 +278,14 @@ void main() {
         test('can return bools', () async {
           expect(
               await service.evaluate(
-                  isolate.id, bootstrap.id, 'helloBool(true)'),
+                  isolate.id!, bootstrap!.id!, 'helloBool(true)'),
               const TypeMatcher<InstanceRef>().having(
                   (instance) => instance.valueAsString,
                   'valueAsString',
                   'true'));
           expect(
               await service.evaluate(
-                  isolate.id, bootstrap.id, 'helloBool(false)'),
+                  isolate.id!, bootstrap!.id!, 'helloBool(false)'),
               const TypeMatcher<InstanceRef>().having(
                   (instance) => instance.valueAsString,
                   'valueAsString',
@@ -296,12 +295,12 @@ void main() {
         test('can return nums', () async {
           expect(
               await service.evaluate(
-                  isolate.id, bootstrap.id, 'helloNum(42.0)'),
+                  isolate.id!, bootstrap!.id!, 'helloNum(42.0)'),
               const TypeMatcher<InstanceRef>().having(
                   (instance) => instance.valueAsString, 'valueAsString', '42'));
           expect(
               await service.evaluate(
-                  isolate.id, bootstrap.id, 'helloNum(42.2)'),
+                  isolate.id!, bootstrap!.id!, 'helloNum(42.2)'),
               const TypeMatcher<InstanceRef>().having(
                   (instance) => instance.valueAsString,
                   'valueAsString',
@@ -310,7 +309,7 @@ void main() {
 
         test('can return objects with ids', () async {
           final object = await service.evaluate(
-              isolate.id, bootstrap.id, 'createObject("cool")');
+              isolate.id!, bootstrap!.id!, 'createObject("cool")');
           expect(
               object,
               const TypeMatcher<InstanceRef>()
@@ -326,15 +325,15 @@ void main() {
 
           Future<InstanceRef> createRemoteObject(String message) async {
             return await service.evaluate(
-                    isolate.id, bootstrap.id, 'createObject("$message")')
+                    isolate.id!, bootstrap!.id!, 'createObject("$message")')
                 as InstanceRef;
           }
 
           test('single scope object', () async {
             final instance = await createRemoteObject('A');
             final result = await service.evaluate(
-                isolate.id, bootstrap.id, 'messageFor(arg1)',
-                scope: {'arg1': instance.id});
+                isolate.id!, bootstrap!.id!, 'messageFor(arg1)',
+                scope: {'arg1': instance.id!});
             expect(
                 result,
                 const TypeMatcher<InstanceRef>().having(
@@ -347,8 +346,8 @@ void main() {
             final instance1 = await createRemoteObject('A');
             final instance2 = await createRemoteObject('B');
             final result = await service.evaluate(
-                isolate.id, bootstrap.id, 'messagesCombined(arg1, arg2)',
-                scope: {'arg1': instance1.id, 'arg2': instance2.id});
+                isolate.id!, bootstrap!.id!, 'messagesCombined(arg1, arg2)',
+                scope: {'arg1': instance1.id!, 'arg2': instance2.id!});
             expect(
                 result,
                 const TypeMatcher<InstanceRef>().having(
@@ -388,12 +387,12 @@ void main() {
 
       test('works for existing isolates', () async {
         final vm = await service.getVM();
-        final result = await service.getIsolate(vm.isolates.first.id);
+        final result = await service.getIsolate(vm.isolates!.first.id!);
         expect(result, const TypeMatcher<Isolate>());
         final isolate = result;
         expect(isolate.name, contains('main'));
         // TODO: library names change with kernel dart-lang/sdk#36736
-        expect(isolate.rootLib.uri, endsWith('.dart'));
+        expect(isolate.rootLib!.uri, endsWith('.dart'));
 
         expect(
             isolate.libraries,
@@ -411,18 +410,18 @@ void main() {
     });
 
     group('getObject', () {
-      Isolate isolate;
-      LibraryRef bootstrap;
+      late Isolate isolate;
+      LibraryRef? bootstrap;
 
-      Library rootLibrary;
+      Library? rootLibrary;
 
       setUpAll(() async {
         setCurrentLogWriter(debug: debug);
         final vm = await service.getVM();
-        isolate = await service.getIsolate(vm.isolates.first.id);
+        isolate = await service.getIsolate(vm.isolates!.first.id!);
         bootstrap = isolate.rootLib;
         rootLibrary =
-            await service.getObject(isolate.id, bootstrap.id) as Library;
+            await service.getObject(isolate.id!, bootstrap!.id!) as Library;
       });
 
       setUp(() {
@@ -432,15 +431,15 @@ void main() {
       test('root Library', () async {
         expect(rootLibrary, isNotNull);
         // TODO: library names change with kernel dart-lang/sdk#36736
-        expect(rootLibrary.uri, endsWith('main.dart'));
-        expect(rootLibrary.classes, hasLength(1));
-        final testClass = rootLibrary.classes.first;
+        expect(rootLibrary!.uri, endsWith('main.dart'));
+        expect(rootLibrary!.classes, hasLength(1));
+        final testClass = rootLibrary!.classes!.first;
         expect(testClass.name, 'MyTestClass');
       });
 
       test('Library only contains included scripts', () async {
         final library =
-            await service.getObject(isolate.id, rootLibrary.id) as Library;
+            await service.getObject(isolate.id!, rootLibrary!.id!) as Library;
         expect(library.scripts, hasLength(2));
         expect(
             library.scripts,
@@ -454,8 +453,8 @@ void main() {
 
       test('Can get the same library in parallel', () async {
         final futures = [
-          service.getObject(isolate.id, rootLibrary.id),
-          service.getObject(isolate.id, rootLibrary.id),
+          service.getObject(isolate.id!, rootLibrary!.id!),
+          service.getObject(isolate.id!, rootLibrary!.id!),
         ];
         final results = await Future.wait(futures);
         final library1 = results[0] as Library;
@@ -467,21 +466,21 @@ void main() {
         'Classes',
         () async {
           final testClass = await service.getObject(
-              isolate.id, rootLibrary.classes.first.id) as Class;
+              isolate.id!, rootLibrary!.classes!.first.id!) as Class;
           expect(
               testClass.functions,
               unorderedEquals([
-                predicate((FuncRef f) => f.name == 'staticHello' && f.isStatic),
-                predicate((FuncRef f) => f.name == 'message' && !f.isStatic),
-                predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic),
-                predicate((FuncRef f) => f.name == 'hello' && !f.isStatic),
-                predicate((FuncRef f) => f.name == '_equals' && !f.isStatic),
-                predicate((FuncRef f) => f.name == 'hashCode' && !f.isStatic),
-                predicate((FuncRef f) => f.name == 'toString' && !f.isStatic),
+                predicate((FuncRef f) => f.name == 'staticHello' && f.isStatic!),
+                predicate((FuncRef f) => f.name == 'message' && !f.isStatic!),
+                predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic!),
+                predicate((FuncRef f) => f.name == 'hello' && !f.isStatic!),
+                predicate((FuncRef f) => f.name == '_equals' && !f.isStatic!),
+                predicate((FuncRef f) => f.name == 'hashCode' && !f.isStatic!),
+                predicate((FuncRef f) => f.name == 'toString' && !f.isStatic!),
                 predicate(
-                    (FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic),
+                    (FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic!),
                 predicate(
-                    (FuncRef f) => f.name == 'runtimeType' && !f.isStatic),
+                    (FuncRef f) => f.name == 'runtimeType' && !f.isStatic!),
               ]));
           expect(
               testClass.fields,
@@ -489,21 +488,21 @@ void main() {
                 predicate((FieldRef f) =>
                     f.name == 'message' &&
                     f.declaredType != null &&
-                    !f.isStatic &&
-                    !f.isConst &&
-                    f.isFinal),
+                    !f.isStatic! &&
+                    !f.isConst! &&
+                    f.isFinal!),
                 predicate((FieldRef f) =>
                     f.name == 'notFinal' &&
                     f.declaredType != null &&
-                    !f.isStatic &&
-                    !f.isConst &&
-                    !f.isFinal),
+                    !f.isStatic! &&
+                    !f.isConst! &&
+                    !f.isFinal!),
                 predicate((FieldRef f) =>
                     f.name == 'staticMessage' &&
                     f.declaredType != null &&
-                    f.isStatic &&
-                    !f.isConst &&
-                    !f.isFinal),
+                    f.isStatic! &&
+                    !f.isConst! &&
+                    !f.isFinal!),
               ]));
         },
         // TODO(elliette): Remove once 2.15.0 is the stable release.
@@ -515,24 +514,24 @@ void main() {
 
       test('Runtime classes', () async {
         final testClass = await service.getObject(
-            isolate.id, 'classes|dart:_runtime|_Type') as Class;
+            isolate.id!, 'classes|dart:_runtime|_Type') as Class;
         expect(testClass.name, '_Type');
       });
 
       test('String', () async {
         final worldRef = await service.evaluate(
-            isolate.id, bootstrap.id, "helloString('world')") as InstanceRef;
+            isolate.id!, bootstrap!.id!, "helloString('world')") as InstanceRef;
         final world =
-            await service.getObject(isolate.id, worldRef.id) as Instance;
+            await service.getObject(isolate.id!, worldRef.id!) as Instance;
         expect(world.valueAsString, 'world');
       });
 
       test('Large strings not truncated', () async {
         final largeString = await service.evaluate(
-                isolate.id, bootstrap.id, "helloString('${'abcde' * 250}')")
+                isolate.id!, bootstrap!.id!, "helloString('${'abcde' * 250}')")
             as InstanceRef;
         expect(largeString.valueAsStringIsTruncated, isNot(isTrue));
-        expect(largeString.valueAsString.length, largeString.length);
+        expect(largeString.valueAsString!.length, largeString.length);
         expect(largeString.length, 5 * 250);
       });
 
@@ -567,65 +566,65 @@ void main() {
       test('Lists', () async {
         final list = await createList();
         final inst =
-            await service.getObject(isolate.id, list.objectId) as Instance;
+            await service.getObject(isolate.id!, list.objectId!) as Instance;
         expect(inst.length, 1001);
         expect(inst.offset, null);
         expect(inst.count, null);
-        final fifth = inst.elements[4] as InstanceRef;
+        final fifth = inst.elements![4] as InstanceRef;
         expect(fifth.valueAsString, '100');
-        final sixth = inst.elements[5] as InstanceRef;
+        final sixth = inst.elements![5] as InstanceRef;
         expect(sixth.valueAsString, '5');
       });
 
       test('Maps', () async {
         final map = await createMap();
         final inst =
-            await service.getObject(isolate.id, map.objectId) as Instance;
+            await service.getObject(isolate.id!, map.objectId!) as Instance;
         expect(inst.length, 1001);
         expect(inst.offset, null);
         expect(inst.count, null);
-        final fifth = inst.associations[4];
+        final fifth = inst.associations![4];
         expect(fifth.key.valueAsString, '4');
         expect(fifth.value.valueAsString, '996');
-        final sixth = inst.associations[5];
+        final sixth = inst.associations![5];
         expect(sixth.key.valueAsString, '5');
         expect(sixth.value.valueAsString, '995');
       });
 
       test('bool', () async {
         final ref = await service.evaluate(
-            isolate.id, bootstrap.id, 'helloBool(true)') as InstanceRef;
-        final obj = await service.getObject(isolate.id, ref.id) as Instance;
+            isolate.id!, bootstrap!.id!, 'helloBool(true)') as InstanceRef;
+        final obj = await service.getObject(isolate.id!, ref.id!) as Instance;
         expect(obj.kind, InstanceKind.kBool);
-        expect(obj.classRef.name, 'Bool');
+        expect(obj.classRef!.name, 'Bool');
         expect(obj.valueAsString, 'true');
       });
 
       test('num', () async {
         final ref = await service.evaluate(
-            isolate.id, bootstrap.id, 'helloNum(42)') as InstanceRef;
-        final obj = await service.getObject(isolate.id, ref.id) as Instance;
+            isolate.id!, bootstrap!.id!, 'helloNum(42)') as InstanceRef;
+        final obj = await service.getObject(isolate.id!, ref.id!) as Instance;
         expect(obj.kind, InstanceKind.kDouble);
-        expect(obj.classRef.name, 'Double');
+        expect(obj.classRef!.name, 'Double');
         expect(obj.valueAsString, '42');
       });
 
       test('null', () async {
         final ref = await service.evaluate(
-            isolate.id, bootstrap.id, 'helloNum(null)') as InstanceRef;
-        final obj = await service.getObject(isolate.id, ref.id) as Instance;
+            isolate.id!, bootstrap!.id!, 'helloNum(null)') as InstanceRef;
+        final obj = await service.getObject(isolate.id!, ref.id!) as Instance;
         expect(obj.kind, InstanceKind.kNull);
-        expect(obj.classRef.name, 'Null');
+        expect(obj.classRef!.name, 'Null');
         expect(obj.valueAsString, 'null');
       });
 
       test('Scripts', () async {
-        final scripts = await service.getScripts(isolate.id);
-        assert(scripts.scripts.isNotEmpty);
-        for (var scriptRef in scripts.scripts) {
+        final scripts = await service.getScripts(isolate.id!);
+        assert(scripts.scripts!.isNotEmpty);
+        for (var scriptRef in scripts.scripts!) {
           final script =
-              await service.getObject(isolate.id, scriptRef.id) as Script;
-          final serverPath = DartUri(script.uri, 'hello_world/').serverPath;
+              await service.getObject(isolate.id!, scriptRef.id!) as Script;
+          final serverPath = DartUri(script.uri!, 'hello_world/').serverPath;
           final result = await http
               .get(Uri.parse('http://localhost:${context.port}/$serverPath'));
           expect(script.source, result.body);
@@ -638,17 +637,17 @@ void main() {
         test('Lists with offset/count are truncated', () async {
           final list = await createList();
           final inst = await service.getObject(
-            isolate.id,
-            list.objectId,
+            isolate.id!,
+            list.objectId!,
             count: 7,
             offset: 4,
           ) as Instance;
           expect(inst.length, 1001);
           expect(inst.offset, 4);
           expect(inst.count, 7);
-          final fifth = inst.elements[0] as InstanceRef;
+          final fifth = inst.elements![0] as InstanceRef;
           expect(fifth.valueAsString, '100');
-          final sixth = inst.elements[1] as InstanceRef;
+          final sixth = inst.elements![1] as InstanceRef;
           expect(sixth.valueAsString, '5');
         });
 
@@ -656,33 +655,33 @@ void main() {
             () async {
           final list = await createList();
           final inst = await service.getObject(
-            isolate.id,
-            list.objectId,
+            isolate.id!,
+            list.objectId!,
             count: 5,
             offset: 1000,
           ) as Instance;
           expect(inst.length, 1001);
           expect(inst.offset, 1000);
           expect(inst.count, 1);
-          final only = inst.elements[0] as InstanceRef;
+          final only = inst.elements![0] as InstanceRef;
           expect(only.valueAsString, '5');
         });
 
         test('Maps with offset/count are truncated', () async {
           final map = await createMap();
           final inst = await service.getObject(
-            isolate.id,
-            map.objectId,
+            isolate.id!,
+            map.objectId!,
             count: 7,
             offset: 4,
           ) as Instance;
           expect(inst.length, 1001);
           expect(inst.offset, 4);
           expect(inst.count, 7);
-          final fifth = inst.associations[0];
+          final fifth = inst.associations![0];
           expect(fifth.key.valueAsString, '4');
           expect(fifth.value.valueAsString, '996');
-          final sixth = inst.associations[1];
+          final sixth = inst.associations![1];
           expect(sixth.key.valueAsString, '5');
           expect(sixth.value.valueAsString, '995');
         });
@@ -691,25 +690,25 @@ void main() {
             () async {
           final map = await createMap();
           final inst = await service.getObject(
-            isolate.id,
-            map.objectId,
+            isolate.id!,
+            map.objectId!,
             count: 5,
             offset: 1000,
           ) as Instance;
           expect(inst.length, 1001);
           expect(inst.offset, 1000);
           expect(inst.count, 1);
-          final only = inst.associations[0];
+          final only = inst.associations![0];
           expect(only.key.valueAsString, '1000');
           expect(only.value.valueAsString, '0');
         });
 
         test('Strings with offset/count are truncated', () async {
           final worldRef = await service.evaluate(
-              isolate.id, bootstrap.id, "helloString('world')") as InstanceRef;
+              isolate.id!, bootstrap!.id!, "helloString('world')") as InstanceRef;
           final world = await service.getObject(
-            isolate.id,
-            worldRef.id,
+            isolate.id!,
+            worldRef.id!,
             count: 2,
             offset: 1,
           ) as Instance;
@@ -723,10 +722,10 @@ void main() {
             'Strings are truncated to the end if offset/count runs off the end',
             () async {
           final worldRef = await service.evaluate(
-              isolate.id, bootstrap.id, "helloString('world')") as InstanceRef;
+              isolate.id!, bootstrap!.id!, "helloString('world')") as InstanceRef;
           final world = await service.getObject(
-            isolate.id,
-            worldRef.id,
+            isolate.id!,
+            worldRef.id!,
             count: 5,
             offset: 3,
           ) as Instance;
@@ -740,8 +739,8 @@ void main() {
           'offset/count parameters are ignored for Classes',
           () async {
             final testClass = await service.getObject(
-              isolate.id,
-              rootLibrary.classes.first.id,
+              isolate.id!,
+              rootLibrary!.classes!.first.id!,
               offset: 100,
               count: 100,
             ) as Class;
@@ -749,17 +748,17 @@ void main() {
                 testClass.functions,
                 unorderedEquals([
                   predicate(
-                      (FuncRef f) => f.name == 'staticHello' && f.isStatic),
-                  predicate((FuncRef f) => f.name == 'message' && !f.isStatic),
-                  predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic),
-                  predicate((FuncRef f) => f.name == 'hello' && !f.isStatic),
-                  predicate((FuncRef f) => f.name == '_equals' && !f.isStatic),
-                  predicate((FuncRef f) => f.name == 'hashCode' && !f.isStatic),
-                  predicate((FuncRef f) => f.name == 'toString' && !f.isStatic),
+                      (FuncRef f) => f.name == 'staticHello' && f.isStatic!),
+                  predicate((FuncRef f) => f.name == 'message' && !f.isStatic!),
+                  predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic!),
+                  predicate((FuncRef f) => f.name == 'hello' && !f.isStatic!),
+                  predicate((FuncRef f) => f.name == '_equals' && !f.isStatic!),
+                  predicate((FuncRef f) => f.name == 'hashCode' && !f.isStatic!),
+                  predicate((FuncRef f) => f.name == 'toString' && !f.isStatic!),
                   predicate(
-                      (FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic),
+                      (FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic!),
                   predicate(
-                      (FuncRef f) => f.name == 'runtimeType' && !f.isStatic),
+                      (FuncRef f) => f.name == 'runtimeType' && !f.isStatic!),
                 ]));
             expect(
                 testClass.fields,
@@ -767,21 +766,21 @@ void main() {
                   predicate((FieldRef f) =>
                       f.name == 'message' &&
                       f.declaredType != null &&
-                      !f.isStatic &&
-                      !f.isConst &&
-                      f.isFinal),
+                      !f.isStatic! &&
+                      !f.isConst! &&
+                      f.isFinal!),
                   predicate((FieldRef f) =>
                       f.name == 'notFinal' &&
                       f.declaredType != null &&
-                      !f.isStatic &&
-                      !f.isConst &&
-                      !f.isFinal),
+                      !f.isStatic! &&
+                      !f.isConst! &&
+                      !f.isFinal!),
                   predicate((FieldRef f) =>
                       f.name == 'staticMessage' &&
                       f.declaredType != null &&
-                      f.isStatic &&
-                      !f.isConst &&
-                      !f.isFinal),
+                      f.isStatic! &&
+                      !f.isConst! &&
+                      !f.isFinal!),
                 ]));
           },
           // TODO(elliette): Remove once 2.15.0 is the stable release.
@@ -793,43 +792,43 @@ void main() {
 
         test('offset/count parameters are ignored for bools', () async {
           final ref = await service.evaluate(
-              isolate.id, bootstrap.id, 'helloBool(true)') as InstanceRef;
+              isolate.id!, bootstrap!.id!, 'helloBool(true)') as InstanceRef;
           final obj = await service.getObject(
-            isolate.id,
-            ref.id,
+            isolate.id!,
+            ref.id!,
             offset: 100,
             count: 100,
           ) as Instance;
           expect(obj.kind, InstanceKind.kBool);
-          expect(obj.classRef.name, 'Bool');
+          expect(obj.classRef!.name, 'Bool');
           expect(obj.valueAsString, 'true');
         });
 
         test('offset/count parameters are ignored for nums', () async {
           final ref = await service.evaluate(
-              isolate.id, bootstrap.id, 'helloNum(42)') as InstanceRef;
+              isolate.id!, bootstrap!.id!, 'helloNum(42)') as InstanceRef;
           final obj = await service.getObject(
-            isolate.id,
-            ref.id,
+            isolate.id!,
+            ref.id!,
             offset: 100,
             count: 100,
           ) as Instance;
           expect(obj.kind, InstanceKind.kDouble);
-          expect(obj.classRef.name, 'Double');
+          expect(obj.classRef!.name, 'Double');
           expect(obj.valueAsString, '42');
         });
 
         test('offset/count parameters are ignored for null', () async {
           final ref = await service.evaluate(
-              isolate.id, bootstrap.id, 'helloNum(null)') as InstanceRef;
+              isolate.id!, bootstrap!.id!, 'helloNum(null)') as InstanceRef;
           final obj = await service.getObject(
-            isolate.id,
-            ref.id,
+            isolate.id!,
+            ref.id!,
             offset: 100,
             count: 100,
           ) as Instance;
           expect(obj.kind, InstanceKind.kNull);
-          expect(obj.classRef.name, 'Null');
+          expect(obj.classRef!.name, 'Null');
           expect(obj.valueAsString, 'null');
         });
       });
@@ -837,15 +836,15 @@ void main() {
 
     test('getScripts', () async {
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
       final scripts = await service.getScripts(isolateId);
       expect(scripts, isNotNull);
       expect(scripts.scripts, isNotEmpty);
 
-      final scriptUris = scripts.scripts.map((s) => s.uri);
+      final scriptUris = scripts.scripts!.map((s) => s.uri);
 
       // Contains main script only once.
-      expect(scriptUris.where((uri) => uri.contains('hello_world/main.dart')),
+      expect(scriptUris.where((uri) => uri!.contains('hello_world/main.dart')),
           hasLength(1));
 
       // Containts a known script.
@@ -864,7 +863,7 @@ void main() {
 
       test('Coverage report', () async {
         final vm = await service.getVM();
-        final isolateId = vm.isolates.first.id;
+        final isolateId = vm.isolates!.first.id!;
 
         await expectLater(
             service.getSourceReport(isolateId, ['Coverage']), throwsRPCError);
@@ -872,7 +871,7 @@ void main() {
 
       test('Coverage report', () async {
         final vm = await service.getVM();
-        final isolateId = vm.isolates.first.id;
+        final isolateId = vm.isolates!.first.id!;
 
         await expectLater(
             service.getSourceReport(isolateId, ['Coverage'],
@@ -882,7 +881,7 @@ void main() {
 
       test('report type not understood', () async {
         final vm = await service.getVM();
-        final isolateId = vm.isolates.first.id;
+        final isolateId = vm.isolates!.first.id!;
 
         await expectLater(
             service.getSourceReport(isolateId, ['FooBar']), throwsRPCError);
@@ -890,10 +889,10 @@ void main() {
 
       test('PossibleBreakpoints report', () async {
         final vm = await service.getVM();
-        final isolateId = vm.isolates.first.id;
+        final isolateId = vm.isolates!.first.id!;
         final scripts = await service.getScripts(isolateId);
-        final mainScript = scripts.scripts
-            .firstWhere((script) => script.uri.contains('main.dart'));
+        final mainScript = scripts.scripts!
+            .firstWhere((script) => script.uri!.contains('main.dart'));
 
         final sourceReport = await service.getSourceReport(
           isolateId,
@@ -904,153 +903,153 @@ void main() {
         expect(sourceReport.scripts, isNotEmpty);
         expect(sourceReport.ranges, isNotEmpty);
 
-        final sourceReportRange = sourceReport.ranges.first;
+        final sourceReportRange = sourceReport.ranges!.first;
         expect(sourceReportRange.possibleBreakpoints, isNotEmpty);
       });
     });
 
     group('Pausing', () {
-      String isolateId;
-      Stream<Event> stream;
+      String? isolateId;
+      late Stream<Event> stream;
       ScriptList scripts;
-      ScriptRef mainScript;
+      late ScriptRef mainScript;
 
       setUp(() async {
         setCurrentLogWriter(debug: debug);
         final vm = await service.getVM();
-        isolateId = vm.isolates.first.id;
-        scripts = await service.getScripts(isolateId);
+        isolateId = vm.isolates!.first.id;
+        scripts = await service.getScripts(isolateId!);
         await service.streamListen('Debug');
         stream = service.onEvent('Debug');
-        mainScript = scripts.scripts
-            .firstWhere((script) => script.uri.contains('main.dart'));
+        mainScript = scripts.scripts!
+            .firstWhere((script) => script.uri!.contains('main.dart'));
       });
 
       test('at breakpoints sets pauseBreakPoints', () async {
         final line = await context.findBreakpointLine(
-            'callPrintCount', isolateId, mainScript);
-        final bp = await service.addBreakpoint(isolateId, mainScript.id, line);
+            'callPrintCount', isolateId!, mainScript);
+        final bp = await service.addBreakpoint(isolateId!, mainScript.id!, line);
         final event = await stream
             .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-        final pauseBreakpoints = event.pauseBreakpoints;
+        final pauseBreakpoints = event.pauseBreakpoints!;
         expect(pauseBreakpoints, hasLength(1));
         expect(pauseBreakpoints.first.id, bp.id);
-        await service.removeBreakpoint(isolateId, bp.id);
+        await service.removeBreakpoint(isolateId!, bp.id!);
       });
 
       tearDown(() async {
         // Resume execution to not impact other tests.
-        await service.resume(isolateId);
+        await service.resume(isolateId!);
       });
     });
 
     group('Step', () {
-      String isolateId;
-      Stream<Event> stream;
+      String? isolateId;
+      late Stream<Event> stream;
       ScriptList scripts;
       ScriptRef mainScript;
 
       setUp(() async {
         setCurrentLogWriter(debug: debug);
         final vm = await service.getVM();
-        isolateId = vm.isolates.first.id;
-        scripts = await service.getScripts(isolateId);
+        isolateId = vm.isolates!.first.id;
+        scripts = await service.getScripts(isolateId!);
         await service.streamListen('Debug');
         stream = service.onEvent('Debug');
-        mainScript = scripts.scripts
-            .firstWhere((script) => script.uri.contains('main.dart'));
+        mainScript = scripts.scripts!
+            .firstWhere((script) => script.uri!.contains('main.dart'));
         final line = await context.findBreakpointLine(
-            'callPrintCount', isolateId, mainScript);
-        final bp = await service.addBreakpoint(isolateId, mainScript.id, line);
+            'callPrintCount', isolateId!, mainScript);
+        final bp = await service.addBreakpoint(isolateId!, mainScript.id!, line);
         // Wait for breakpoint to trigger.
         await stream
             .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-        await service.removeBreakpoint(isolateId, bp.id);
+        await service.removeBreakpoint(isolateId!, bp.id!);
       });
 
       tearDown(() async {
         // Resume execution to not impact other tests.
-        await service.resume(isolateId);
+        await service.resume(isolateId!);
       });
 
       test('Into goes to the next Dart location', () async {
-        await service.resume(isolateId, step: 'Into');
+        await service.resume(isolateId!, step: 'Into');
         // Wait for the step to actually occur.
         await stream
             .firstWhere((event) => event.kind == EventKind.kPauseInterrupted);
-        final stack = await service.getStack(isolateId);
+        final stack = await service.getStack(isolateId!);
         expect(stack, isNotNull);
-        final first = stack.frames.first;
+        final first = stack.frames!.first;
         expect(first.kind, 'Regular');
-        expect(first.code.kind, 'Dart');
-        expect(first.code.name, 'printCount');
+        expect(first.code!.kind, 'Dart');
+        expect(first.code!.name, 'printCount');
       });
 
       test('Over goes to the next Dart location', () async {
-        await service.resume(isolateId, step: 'Over');
+        await service.resume(isolateId!, step: 'Over');
         // Wait for the step to actually occur.
         await stream
             .firstWhere((event) => event.kind == EventKind.kPauseInterrupted);
-        final stack = await service.getStack(isolateId);
+        final stack = await service.getStack(isolateId!);
         expect(stack, isNotNull);
-        final first = stack.frames.first;
+        final first = stack.frames!.first;
         expect(first.kind, 'Regular');
-        expect(first.code.kind, 'Dart');
-        expect(first.code.name, '<closure>');
+        expect(first.code!.kind, 'Dart');
+        expect(first.code!.name, '<closure>');
       });
 
       test('Out goes to the next Dart location', () async {
-        await service.resume(isolateId, step: 'Out');
+        await service.resume(isolateId!, step: 'Out');
         // Wait for the step to actually occur.
         await stream
             .firstWhere((event) => event.kind == EventKind.kPauseInterrupted);
-        final stack = await service.getStack(isolateId);
+        final stack = await service.getStack(isolateId!);
         expect(stack, isNotNull);
-        final first = stack.frames.first;
+        final first = stack.frames!.first;
         expect(first.kind, 'Regular');
-        expect(first.code.kind, 'Dart');
-        expect(first.code.name, '<closure>');
+        expect(first.code!.kind, 'Dart');
+        expect(first.code!.name, '<closure>');
       });
     });
 
     group('getStack', () {
-      String isolateId;
-      Stream<Event> stream;
+      String? isolateId;
+      late Stream<Event> stream;
       ScriptList scripts;
-      ScriptRef mainScript;
+      late ScriptRef mainScript;
 
       setUp(() async {
         setCurrentLogWriter(debug: debug);
         final vm = await service.getVM();
-        isolateId = vm.isolates.first.id;
-        scripts = await service.getScripts(isolateId);
+        isolateId = vm.isolates!.first.id;
+        scripts = await service.getScripts(isolateId!);
         await service.streamListen('Debug');
         stream = service.onEvent('Debug');
-        mainScript = scripts.scripts
-            .firstWhere((each) => each.uri.contains('main.dart'));
+        mainScript = scripts.scripts!
+            .firstWhere((each) => each.uri!.contains('main.dart'));
       });
 
       test('throws if not paused', () async {
-        await expectLater(service.getStack(isolateId), throwsRPCError);
+        await expectLater(service.getStack(isolateId!), throwsRPCError);
       });
 
       /// Support function for pausing and returning the stack at a line.
-      Future<Stack> breakAt(String breakpointId, {int limit}) async {
+      Future<Stack> breakAt(String breakpointId, {int? limit}) async {
         final line = await context.findBreakpointLine(
-            breakpointId, isolateId, mainScript);
-        Breakpoint bp;
+            breakpointId, isolateId!, mainScript);
+        Breakpoint? bp;
         try {
-          bp = await service.addBreakpoint(isolateId, mainScript.id, line);
+          bp = await service.addBreakpoint(isolateId!, mainScript.id!, line);
           // Wait for breakpoint to trigger.
           await stream
               .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
-          return await service.getStack(isolateId, limit: limit);
+          return await service.getStack(isolateId!, limit: limit);
         } finally {
           // Remove breakpoint and resume so it doesn't impact other tests.
           if (bp != null) {
-            await service.removeBreakpoint(isolateId, bp.id);
+            await service.removeBreakpoint(isolateId!, bp.id!);
           }
-          await service.resume(isolateId);
+          await service.resume(isolateId!);
         }
       }
 
@@ -1058,24 +1057,24 @@ void main() {
         final stack = await breakAt('inPrintCount');
         expect(stack, isNotNull);
         expect(stack.frames, hasLength(2));
-        final first = stack.frames.first;
+        final first = stack.frames!.first;
         expect(first.kind, 'Regular');
-        expect(first.code.kind, 'Dart');
-        expect(first.code.name, 'printCount');
+        expect(first.code!.kind, 'Dart');
+        expect(first.code!.name, 'printCount');
       });
 
       test('stack has a variable', () async {
         final stack = await breakAt('callPrintCount');
         expect(stack, isNotNull);
         expect(stack.frames, hasLength(1));
-        final first = stack.frames.first;
+        final first = stack.frames!.first;
         expect(first.kind, 'Regular');
-        expect(first.code.kind, 'Dart');
-        expect(first.code.name, '<closure>');
+        expect(first.code!.kind, 'Dart');
+        expect(first.code!.name, '<closure>');
         // TODO: Make this more precise once this case doesn't
         // also include all the libraries.
         expect(first.vars, hasLength(greaterThanOrEqualTo(1)));
-        final underscore = first.vars.firstWhere((v) => v.name == '_');
+        final underscore = first.vars!.firstWhere((v) => v.name == '_');
         expect(underscore, isNotNull);
       });
 
@@ -1084,18 +1083,18 @@ void main() {
         expect(stack, isNotNull);
         expect(stack.frames, hasLength(greaterThan(1)));
 
-        final first = stack.frames.first;
+        final first = stack.frames!.first;
         expect(first.kind, 'Regular');
-        expect(first.code.kind, 'Dart');
+        expect(first.code!.kind, 'Dart');
 
         // We should have an async marker.
-        final suspensionFrames = stack.frames
+        final suspensionFrames = stack.frames!
             .where((frame) => frame.kind == FrameKind.kAsyncSuspensionMarker);
         expect(suspensionFrames, isNotEmpty);
 
         // We should have async frames.
         final asyncFrames =
-            stack.frames.where((frame) => frame.kind == FrameKind.kAsyncCausal);
+            stack.frames!.where((frame) => frame.kind == FrameKind.kAsyncCausal);
         expect(asyncFrames, isNotEmpty);
       });
 
@@ -1126,48 +1125,48 @@ void main() {
 
       test('break on exceptions with legacy setExceptionPauseMode', () async {
         final oldPauseMode =
-            (await service.getIsolate(isolateId)).exceptionPauseMode;
-        await service.setExceptionPauseMode(isolateId, ExceptionPauseMode.kAll);
+            (await service.getIsolate(isolateId!)).exceptionPauseMode!;
+        await service.setExceptionPauseMode(isolateId!, ExceptionPauseMode.kAll);
         // Wait for pausing to actually propagate.
         final event = await stream
             .firstWhere((event) => event.kind == EventKind.kPauseException);
         expect(event.exception, isNotNull);
         // Check that the exception stack trace has been mapped to Dart source files.
-        expect(event.exception.valueAsString, contains('main.dart'));
+        expect(event.exception!.valueAsString, contains('main.dart'));
 
-        final stack = await service.getStack(isolateId);
+        final stack = await service.getStack(isolateId!);
         expect(stack, isNotNull);
 
-        await service.setExceptionPauseMode(isolateId, oldPauseMode);
-        await service.resume(isolateId);
+        await service.setExceptionPauseMode(isolateId!, oldPauseMode);
+        await service.resume(isolateId!);
       });
 
       test('break on exceptions with setIsolatePauseMode', () async {
         final oldPauseMode =
-            (await service.getIsolate(isolateId)).exceptionPauseMode;
-        await service.setIsolatePauseMode(isolateId,
+            (await service.getIsolate(isolateId!)).exceptionPauseMode;
+        await service.setIsolatePauseMode(isolateId!,
             exceptionPauseMode: ExceptionPauseMode.kAll);
         // Wait for pausing to actually propagate.
         final event = await stream
             .firstWhere((event) => event.kind == EventKind.kPauseException);
         expect(event.exception, isNotNull);
 
-        final stack = await service.getStack(isolateId);
+        final stack = await service.getStack(isolateId!);
         expect(stack, isNotNull);
 
-        await service.setIsolatePauseMode(isolateId,
+        await service.setIsolatePauseMode(isolateId!,
             exceptionPauseMode: oldPauseMode);
-        await service.resume(isolateId);
+        await service.resume(isolateId!);
       });
 
       test('returns non-null stack when paused', () async {
-        await service.pause(isolateId);
+        await service.pause(isolateId!);
         // Wait for pausing to actually propagate.
         await stream
             .firstWhere((event) => event.kind == EventKind.kPauseInterrupted);
-        expect(await service.getStack(isolateId), isNotNull);
+        expect(await service.getStack(isolateId!), isNotNull);
         // Resume the isolate to not impact other tests.
-        await service.resume(isolateId);
+        await service.resume(isolateId!);
       });
     });
 
@@ -1176,7 +1175,7 @@ void main() {
       expect(vm.name, isNotNull);
       expect(vm.version, Platform.version);
       expect(vm.isolates, hasLength(1));
-      final isolate = vm.isolates.first;
+      final isolate = vm.isolates!.first;
       expect(isolate.id, isNotNull);
       expect(isolate.name, isNotNull);
       expect(isolate.number, isNotNull);
@@ -1190,17 +1189,17 @@ void main() {
 
     group('invoke', () {
       VM vm;
-      Isolate isolate;
-      LibraryRef bootstrap;
-      InstanceRef testInstance;
+      late Isolate isolate;
+      LibraryRef? bootstrap;
+      late InstanceRef testInstance;
 
       setUp(() async {
         setCurrentLogWriter(debug: debug);
         vm = await service.getVM();
-        isolate = await service.getIsolate(vm.isolates.first.id);
+        isolate = await service.getIsolate(vm.isolates!.first.id!);
         bootstrap = isolate.rootLib;
         testInstance = await service.evaluate(
-            isolate.id, bootstrap.id, 'myInstance') as InstanceRef;
+            isolate.id!, bootstrap!.id!, 'myInstance') as InstanceRef;
       });
 
       test('rootLib', () async {
@@ -1212,7 +1211,7 @@ void main() {
 
       test('toString()', () async {
         final remote =
-            await service.invoke(isolate.id, testInstance.id, 'toString', []);
+            await service.invoke(isolate.id!, testInstance.id!, 'toString', []);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
@@ -1223,7 +1222,7 @@ void main() {
 
       test('hello()', () async {
         final remote =
-            await service.invoke(isolate.id, testInstance.id, 'hello', []);
+            await service.invoke(isolate.id!, testInstance.id!, 'hello', []);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
@@ -1231,7 +1230,7 @@ void main() {
       });
 
       test('helloString', () async {
-        final remote = await service.invoke(isolate.id, bootstrap.id,
+        final remote = await service.invoke(isolate.id!, bootstrap!.id!,
             'helloString', ['#StringInstanceRef#abc']);
         expect(
             remote,
@@ -1245,7 +1244,7 @@ void main() {
 
       test('null argument', () async {
         final remote = await service
-            .invoke(isolate.id, bootstrap.id, 'helloString', ['objects/null']);
+            .invoke(isolate.id!, bootstrap!.id!, 'helloString', ['objects/null']);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
@@ -1258,7 +1257,7 @@ void main() {
 
       test('helloBool', () async {
         final remote = await service.invoke(
-            isolate.id, bootstrap.id, 'helloBool', ['objects/bool-true']);
+            isolate.id!, bootstrap!.id!, 'helloBool', ['objects/bool-true']);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
@@ -1271,7 +1270,7 @@ void main() {
 
       test('helloNum', () async {
         final remote = await service
-            .invoke(isolate.id, bootstrap.id, 'helloNum', ['objects/int-123']);
+            .invoke(isolate.id!, bootstrap!.id!, 'helloNum', ['objects/int-123']);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
@@ -1283,7 +1282,7 @@ void main() {
       });
 
       test('two object arguments', () async {
-        final remote = await service.invoke(isolate.id, bootstrap.id,
+        final remote = await service.invoke(isolate.id!, bootstrap!.id!,
             'messagesCombined', [testInstance.id, testInstance.id]);
         expect(
             remote,
@@ -1310,7 +1309,7 @@ void main() {
       await service.streamListen('Debug');
       final stream = service.onEvent('Debug');
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
       final pauseCompleter = Completer();
       final pauseSub = tabConnection.debugger.onPaused.listen((_) {
         pauseCompleter.complete();
@@ -1322,12 +1321,12 @@ void main() {
       expect(await service.pause(isolateId), const TypeMatcher<Success>());
       await stream
           .firstWhere((event) => event.kind == EventKind.kPauseInterrupted);
-      expect((await service.getIsolate(isolateId)).pauseEvent.kind,
+      expect((await service.getIsolate(isolateId)).pauseEvent!.kind,
           EventKind.kPauseInterrupted);
       await pauseCompleter.future;
       expect(await service.resume(isolateId), const TypeMatcher<Success>());
       await stream.firstWhere((event) => event.kind == EventKind.kResume);
-      expect((await service.getIsolate(isolateId)).pauseEvent.kind,
+      expect((await service.getIsolate(isolateId)).pauseEvent!.kind,
           EventKind.kResume);
       await resumeCompleter.future;
       await pauseSub.cancel();
@@ -1347,12 +1346,12 @@ void main() {
     test('lookupResolvedPackageUris converts package and org-dartlang-app uris',
         () async {
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
       final scriptList = await service.getScripts(isolateId);
 
-      final uris = scriptList.scripts.map((e) => e.uri).toList();
+      final uris = scriptList.scripts!.map((e) => e.uri).toList();
       final resolvedUris =
-          await service.lookupResolvedPackageUris(isolateId, uris);
+          await service.lookupResolvedPackageUris(isolateId, uris as List<String>);
 
       expect(
           resolvedUris.uris,
@@ -1366,7 +1365,7 @@ void main() {
     test('lookupResolvedPackageUris does not translate non-existent paths',
         () async {
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
 
       final resolvedUris = await service.lookupResolvedPackageUris(isolateId, [
         'package:does/not/exist.dart',
@@ -1378,7 +1377,7 @@ void main() {
 
     test('lookupResolvedPackageUris translates dart uris', () async {
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
 
       final resolvedUris = await service.lookupResolvedPackageUris(isolateId, [
         'dart:html',
@@ -1394,15 +1393,15 @@ void main() {
     test('lookupPackageUris finds package and org-dartlang-app paths',
         () async {
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
       final scriptList = await service.getScripts(isolateId);
 
-      final uris = scriptList.scripts.map((e) => e.uri).toList();
+      final uris = scriptList.scripts!.map((e) => e.uri).toList();
       final resolvedUris =
-          await service.lookupResolvedPackageUris(isolateId, uris);
+          await service.lookupResolvedPackageUris(isolateId, uris as List<String>);
 
       final packageUris =
-          await service.lookupPackageUris(isolateId, resolvedUris.uris);
+          await service.lookupPackageUris(isolateId, resolvedUris.uris as List<String>);
       expect(
           packageUris.uris,
           containsAll([
@@ -1414,15 +1413,15 @@ void main() {
 
     test('lookupPackageUris ignores local parameter', () async {
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
       final scriptList = await service.getScripts(isolateId);
 
-      final uris = scriptList.scripts.map((e) => e.uri).toList();
+      final uris = scriptList.scripts!.map((e) => e.uri).toList();
       final resolvedUrisWithLocal =
-          await service.lookupResolvedPackageUris(isolateId, uris, local: true);
+          await service.lookupResolvedPackageUris(isolateId, uris as List<String>, local: true);
 
       final packageUrisWithLocal = await service.lookupPackageUris(
-          isolateId, resolvedUrisWithLocal.uris);
+          isolateId, resolvedUrisWithLocal.uris as List<String>);
       expect(
           packageUrisWithLocal.uris,
           containsAll([
@@ -1435,7 +1434,7 @@ void main() {
           await service.lookupResolvedPackageUris(isolateId, uris, local: true);
 
       final packageUrisWithoutLocal = await service.lookupPackageUris(
-          isolateId, resolvedUrisWithoutLocal.uris);
+          isolateId, resolvedUrisWithoutLocal.uris as List<String>);
       expect(
           packageUrisWithoutLocal.uris,
           containsAll([
@@ -1447,7 +1446,7 @@ void main() {
 
     test('lookupPackageUris does not translate non-existent paths', () async {
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
 
       final resolvedUris = await service.lookupPackageUris(isolateId, [
         'org-dartlang-sdk:///sdk/does/not/exist.dart',
@@ -1459,7 +1458,7 @@ void main() {
 
     test('lookupPackageUris translates dart uris', () async {
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
 
       final resolvedUris = await service.lookupPackageUris(isolateId, [
         'org-dartlang-sdk:///sdk/lib/html/dart2js/html_dart2js.dart',
@@ -1483,7 +1482,7 @@ void main() {
 
     test('setExceptionPauseMode', () async {
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
       expect(await service.setExceptionPauseMode(isolateId, 'all'), _isSuccess);
       expect(await service.setExceptionPauseMode(isolateId, 'unhandled'),
           _isSuccess);
@@ -1505,7 +1504,7 @@ void main() {
 
     test('setName', () async {
       final vm = await service.getVM();
-      final isolateId = vm.isolates.first.id;
+      final isolateId = vm.isolates!.first.id!;
       expect(service.setName(isolateId, 'test'), completion(_isSuccess));
       final isolate = await service.getIsolate(isolateId);
       expect(isolate.name, 'test');
@@ -1523,7 +1522,7 @@ void main() {
 
     group('streamListen/onEvent', () {
       group('Debug', () {
-        Stream<Event> eventStream;
+        late Stream<Event> eventStream;
 
         setUp(() async {
           setCurrentLogWriter(debug: debug);
@@ -1564,7 +1563,7 @@ void main() {
       });
 
       group('Extension', () {
-        Stream<Event> eventStream;
+        late Stream<Event> eventStream;
 
         setUp(() async {
           setCurrentLogWriter(debug: debug);
@@ -1580,7 +1579,7 @@ void main() {
               emitsThrough(predicate((Event event) =>
                   event.kind == EventKind.kExtension &&
                   event.extensionKind == eventKind &&
-                  event.extensionData.data['example'] == 'data')));
+                  event.extensionData!.data['example'] == 'data')));
           await tabConnection.runtime.evaluate("postEvent('$eventKind');");
         });
 
@@ -1596,7 +1595,7 @@ void main() {
                   .having((event) => event.kind, 'kind', eventKind)
                   .having((event) => event.extensionKind, 'extensionKind',
                       extensionKind)
-                  .having((event) => event.extensionData.data['eventData'],
+                  .having((event) => event.extensionData!.data['eventData'],
                       'eventData', data);
 
           String emitDebugEvent(String data) =>
@@ -1628,7 +1627,7 @@ void main() {
       });
 
       group('Isolate', () {
-        Stream<Event> isolateEventStream;
+        late Stream<Event> isolateEventStream;
 
         setUp(() async {
           expect(await service.streamListen(EventStreams.kIsolate), _isSuccess);
@@ -1648,24 +1647,24 @@ void main() {
 
         test('lifecycle events', () async {
           final vm = await service.getVM();
-          final initialIsolateId = vm.isolates.first.id;
+          final initialIsolateId = vm.isolates!.first.id;
           final eventsDone = expectLater(
               isolateEventStream,
               emitsThrough(emitsInOrder([
                 predicate((Event event) =>
                     event.kind == EventKind.kIsolateExit &&
-                    event.isolate.id == initialIsolateId),
+                    event.isolate!.id == initialIsolateId),
                 predicate((Event event) =>
                     event.kind == EventKind.kIsolateStart &&
-                    event.isolate.id != initialIsolateId),
+                    event.isolate!.id != initialIsolateId),
                 predicate((Event event) =>
                     event.kind == EventKind.kIsolateRunnable &&
-                    event.isolate.id != initialIsolateId),
+                    event.isolate!.id != initialIsolateId),
               ])));
           service.destroyIsolate();
           await service.createIsolate(context.appConnection);
           await eventsDone;
-          expect((await service.getVM()).isolates.first.id,
+          expect((await service.getVM()).isolates!.first.id,
               isNot(initialIsolateId));
         });
 
@@ -1699,7 +1698,7 @@ void main() {
             service.onEvent('Stdout'),
             emitsThrough(predicate((Event event) =>
                 event.kind == EventKind.kWriteEvent &&
-                String.fromCharCodes(base64.decode(event.bytes))
+                String.fromCharCodes(base64.decode(event.bytes!))
                     .contains('hello'))));
         await tabConnection.runtime.evaluate('console.log("hello");');
       });
@@ -1711,7 +1710,7 @@ void main() {
             stderrStream,
             emitsThrough(predicate((Event event) =>
                 event.kind == EventKind.kWriteEvent &&
-                String.fromCharCodes(base64.decode(event.bytes))
+                String.fromCharCodes(base64.decode(event.bytes!))
                     .contains('Error'))));
         await tabConnection.runtime.evaluate('console.error("Error");');
       });
@@ -1723,7 +1722,7 @@ void main() {
             stderrStream,
             emitsThrough(predicate((Event event) =>
                 event.kind == EventKind.kWriteEvent &&
-                String.fromCharCodes(base64.decode(event.bytes))
+                String.fromCharCodes(base64.decode(event.bytes!))
                     .contains('main.dart'))));
         await tabConnection.runtime.evaluate('throwUncaughtException();');
       });
@@ -1735,7 +1734,7 @@ void main() {
         expect(
             stream,
             emitsThrough(predicate((Event e) =>
-                e.kind == EventKind.kVMUpdate && e.vm.name == 'test')));
+                e.kind == EventKind.kVMUpdate && e.vm!.name == 'test')));
         await service.setVMName('test');
       });
     });
@@ -1751,9 +1750,9 @@ void main() {
       final event = await stream.first;
       expect(event.kind, EventKind.kLogging);
 
-      final logRecord = event.logRecord;
-      expect(logRecord.message.valueAsString, message);
-      expect(logRecord.loggerName.valueAsString, 'testLogCategory');
+      final logRecord = event.logRecord!;
+      expect(logRecord.message!.valueAsString, message);
+      expect(logRecord.loggerName!.valueAsString, 'testLogCategory');
     });
   });
 }

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
 @TestOn('vm')
 import 'dart:async';
 import 'dart:convert';
@@ -87,8 +86,10 @@ void main() {
           () async {
         final line = await context.findBreakpointLine(
             'printHelloWorld', isolate.id!, mainScript);
-        final firstBp = service.addBreakpoint(isolate.id!, mainScript.id!, line);
-        final secondBp = service.addBreakpoint(isolate.id!, mainScript.id!, line);
+        final firstBp =
+            service.addBreakpoint(isolate.id!, mainScript.id!, line);
+        final secondBp =
+            service.addBreakpoint(isolate.id!, mainScript.id!, line);
 
         // Remove breakpoint so it doesn't impact other tests.
         await service.removeBreakpoint(isolate.id!, (await firstBp).id!);
@@ -154,7 +155,8 @@ void main() {
       test('add and remove breakpoint', () async {
         final line = await context.findBreakpointLine(
             'printHelloWorld', isolate.id!, mainScript);
-        final bp = await service.addBreakpoint(isolate.id!, mainScript.id!, line);
+        final bp =
+            await service.addBreakpoint(isolate.id!, mainScript.id!, line);
         expect(isolate.breakpoints, [bp]);
         await service.removeBreakpoint(isolate.id!, bp.id!);
         expect(isolate.breakpoints, isEmpty);
@@ -470,7 +472,8 @@ void main() {
           expect(
               testClass.functions,
               unorderedEquals([
-                predicate((FuncRef f) => f.name == 'staticHello' && f.isStatic!),
+                predicate(
+                    (FuncRef f) => f.name == 'staticHello' && f.isStatic!),
                 predicate((FuncRef f) => f.name == 'message' && !f.isStatic!),
                 predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic!),
                 predicate((FuncRef f) => f.name == 'hello' && !f.isStatic!),
@@ -705,7 +708,8 @@ void main() {
 
         test('Strings with offset/count are truncated', () async {
           final worldRef = await service.evaluate(
-              isolate.id!, bootstrap!.id!, "helloString('world')") as InstanceRef;
+                  isolate.id!, bootstrap!.id!, "helloString('world')")
+              as InstanceRef;
           final world = await service.getObject(
             isolate.id!,
             worldRef.id!,
@@ -722,7 +726,8 @@ void main() {
             'Strings are truncated to the end if offset/count runs off the end',
             () async {
           final worldRef = await service.evaluate(
-              isolate.id!, bootstrap!.id!, "helloString('world')") as InstanceRef;
+                  isolate.id!, bootstrap!.id!, "helloString('world')")
+              as InstanceRef;
           final world = await service.getObject(
             isolate.id!,
             worldRef.id!,
@@ -750,11 +755,14 @@ void main() {
                   predicate(
                       (FuncRef f) => f.name == 'staticHello' && f.isStatic!),
                   predicate((FuncRef f) => f.name == 'message' && !f.isStatic!),
-                  predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic!),
+                  predicate(
+                      (FuncRef f) => f.name == 'notFinal' && !f.isStatic!),
                   predicate((FuncRef f) => f.name == 'hello' && !f.isStatic!),
                   predicate((FuncRef f) => f.name == '_equals' && !f.isStatic!),
-                  predicate((FuncRef f) => f.name == 'hashCode' && !f.isStatic!),
-                  predicate((FuncRef f) => f.name == 'toString' && !f.isStatic!),
+                  predicate(
+                      (FuncRef f) => f.name == 'hashCode' && !f.isStatic!),
+                  predicate(
+                      (FuncRef f) => f.name == 'toString' && !f.isStatic!),
                   predicate(
                       (FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic!),
                   predicate(
@@ -928,7 +936,8 @@ void main() {
       test('at breakpoints sets pauseBreakPoints', () async {
         final line = await context.findBreakpointLine(
             'callPrintCount', isolateId!, mainScript);
-        final bp = await service.addBreakpoint(isolateId!, mainScript.id!, line);
+        final bp =
+            await service.addBreakpoint(isolateId!, mainScript.id!, line);
         final event = await stream
             .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
         final pauseBreakpoints = event.pauseBreakpoints!;
@@ -960,7 +969,8 @@ void main() {
             .firstWhere((script) => script.uri!.contains('main.dart'));
         final line = await context.findBreakpointLine(
             'callPrintCount', isolateId!, mainScript);
-        final bp = await service.addBreakpoint(isolateId!, mainScript.id!, line);
+        final bp =
+            await service.addBreakpoint(isolateId!, mainScript.id!, line);
         // Wait for breakpoint to trigger.
         await stream
             .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
@@ -1093,8 +1103,8 @@ void main() {
         expect(suspensionFrames, isNotEmpty);
 
         // We should have async frames.
-        final asyncFrames =
-            stack.frames!.where((frame) => frame.kind == FrameKind.kAsyncCausal);
+        final asyncFrames = stack.frames!
+            .where((frame) => frame.kind == FrameKind.kAsyncCausal);
         expect(asyncFrames, isNotEmpty);
       });
 
@@ -1126,7 +1136,8 @@ void main() {
       test('break on exceptions with legacy setExceptionPauseMode', () async {
         final oldPauseMode =
             (await service.getIsolate(isolateId!)).exceptionPauseMode!;
-        await service.setExceptionPauseMode(isolateId!, ExceptionPauseMode.kAll);
+        await service.setExceptionPauseMode(
+            isolateId!, ExceptionPauseMode.kAll);
         // Wait for pausing to actually propagate.
         final event = await stream
             .firstWhere((event) => event.kind == EventKind.kPauseException);
@@ -1243,8 +1254,8 @@ void main() {
       });
 
       test('null argument', () async {
-        final remote = await service
-            .invoke(isolate.id!, bootstrap!.id!, 'helloString', ['objects/null']);
+        final remote = await service.invoke(
+            isolate.id!, bootstrap!.id!, 'helloString', ['objects/null']);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
@@ -1269,8 +1280,8 @@ void main() {
       });
 
       test('helloNum', () async {
-        final remote = await service
-            .invoke(isolate.id!, bootstrap!.id!, 'helloNum', ['objects/int-123']);
+        final remote = await service.invoke(
+            isolate.id!, bootstrap!.id!, 'helloNum', ['objects/int-123']);
         expect(
             remote,
             const TypeMatcher<InstanceRef>().having(
@@ -1350,8 +1361,8 @@ void main() {
       final scriptList = await service.getScripts(isolateId);
 
       final uris = scriptList.scripts!.map((e) => e.uri).toList();
-      final resolvedUris =
-          await service.lookupResolvedPackageUris(isolateId, uris as List<String>);
+      final resolvedUris = await service.lookupResolvedPackageUris(
+          isolateId, uris as List<String>);
 
       expect(
           resolvedUris.uris,
@@ -1397,11 +1408,11 @@ void main() {
       final scriptList = await service.getScripts(isolateId);
 
       final uris = scriptList.scripts!.map((e) => e.uri).toList();
-      final resolvedUris =
-          await service.lookupResolvedPackageUris(isolateId, uris as List<String>);
+      final resolvedUris = await service.lookupResolvedPackageUris(
+          isolateId, uris as List<String>);
 
-      final packageUris =
-          await service.lookupPackageUris(isolateId, resolvedUris.uris as List<String>);
+      final packageUris = await service.lookupPackageUris(
+          isolateId, resolvedUris.uris as List<String>);
       expect(
           packageUris.uris,
           containsAll([
@@ -1417,8 +1428,9 @@ void main() {
       final scriptList = await service.getScripts(isolateId);
 
       final uris = scriptList.scripts!.map((e) => e.uri).toList();
-      final resolvedUrisWithLocal =
-          await service.lookupResolvedPackageUris(isolateId, uris as List<String>, local: true);
+      final resolvedUrisWithLocal = await service.lookupResolvedPackageUris(
+          isolateId, uris as List<String>,
+          local: true);
 
       final packageUrisWithLocal = await service.lookupPackageUris(
           isolateId, resolvedUrisWithLocal.uris as List<String>);

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -111,8 +111,7 @@ void main() {
       });
 
       test('addBreakpointAtEntry', () async {
-        await expectLater(
-            service.addBreakpointAtEntry(null, null), throwsRPCError);
+        await expectLater(service.addBreakpointAtEntry('', ''), throwsRPCError);
       });
 
       test('addBreakpointWithScriptUri', () async {
@@ -142,9 +141,9 @@ void main() {
 
       test('removeBreakpoint null arguments', () async {
         await expectLater(
-            service.removeBreakpoint(null, null), throwsSentinelException);
+            service.removeBreakpoint('', ''), throwsSentinelException);
         await expectLater(
-            service.removeBreakpoint(isolate.id!, null), throwsRPCError);
+            service.removeBreakpoint(isolate.id!, ''), throwsRPCError);
       });
 
       test("removeBreakpoint that doesn't exist fails", () async {
@@ -237,7 +236,8 @@ void main() {
       });
 
       test('setVMTimelineFlags', () async {
-        await expectLater(service.setVMTimelineFlags(null), throwsRPCError);
+        await expectLater(
+            service.setVMTimelineFlags(<String>[]), throwsRPCError);
       });
     });
 
@@ -363,15 +363,15 @@ void main() {
 
     test('evaluateInFrame', () async {
       await expectLater(
-          service.evaluateInFrame(null, null, null), throwsSentinelException);
+          service.evaluateInFrame('', 0, ''), throwsSentinelException);
     });
 
     test('getAllocationProfile', () async {
-      await expectLater(service.getAllocationProfile(null), throwsRPCError);
+      await expectLater(service.getAllocationProfile(''), throwsRPCError);
     });
 
     test('getClassList', () async {
-      await expectLater(service.getClassList(null), throwsRPCError);
+      await expectLater(service.getClassList(''), throwsRPCError);
     });
 
     test('getFlagList', () async {
@@ -379,7 +379,7 @@ void main() {
     });
 
     test('getInstances', () async {
-      await expectLater(service.getInstances(null, null, null), throwsRPCError);
+      await expectLater(service.getInstances('', '', 0), throwsRPCError);
     });
 
     group('getIsolate', () {
@@ -1309,11 +1309,11 @@ void main() {
     });
 
     test('kill', () async {
-      await expectLater(service.kill(null), throwsRPCError);
+      await expectLater(service.kill(''), throwsRPCError);
     });
 
     test('onEvent', () async {
-      expect(() => service.onEvent(null), throwsRPCError);
+      expect(() => service.onEvent(''), throwsRPCError);
     });
 
     test('pause / resume', () async {
@@ -1346,12 +1346,11 @@ void main() {
 
     test('getInboundReferences', () async {
       await expectLater(
-          service.getInboundReferences(null, null, null), throwsRPCError);
+          service.getInboundReferences('', '', 0), throwsRPCError);
     });
 
     test('getRetainingPath', () async {
-      await expectLater(
-          service.getRetainingPath(null, null, null), throwsRPCError);
+      await expectLater(service.getRetainingPath('', '', 0), throwsRPCError);
     });
 
     test('lookupResolvedPackageUris converts package and org-dartlang-app uris',
@@ -1485,11 +1484,11 @@ void main() {
 
     test('registerService', () async {
       await expectLater(
-          service.registerService('ext.foo.bar', null), throwsRPCError);
+          service.registerService('ext.foo.bar', ''), throwsRPCError);
     });
 
     test('reloadSources', () async {
-      await expectLater(service.reloadSources(null), throwsRPCError);
+      await expectLater(service.reloadSources(''), throwsRPCError);
     });
 
     test('setExceptionPauseMode', () async {
@@ -1506,12 +1505,12 @@ void main() {
     });
 
     test('setFlag', () async {
-      await expectLater(service.setFlag(null, null), throwsRPCError);
+      await expectLater(service.setFlag('', ''), throwsRPCError);
     });
 
     test('setLibraryDebuggable', () async {
       await expectLater(
-          service.setLibraryDebuggable(null, null, null), throwsRPCError);
+          service.setLibraryDebuggable('', '', false), throwsRPCError);
     });
 
     test('setName', () async {
@@ -1529,7 +1528,7 @@ void main() {
     });
 
     test('streamCancel', () async {
-      await expectLater(service.streamCancel(null), throwsRPCError);
+      await expectLater(service.streamCancel(''), throwsRPCError);
     });
 
     group('streamListen/onEvent', () {

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -353,11 +353,12 @@ class TestContext {
           : 'http://localhost:$port/$basePath/$path';
 
       await _webDriver?.get(appUrl);
-      final tab = await (connection.getTab((t) => t.url == appUrl)
-          as FutureOr<ChromeTab>);
-      _tabConnection = await tab.connect();
-      await tabConnection.runtime.enable();
-      await tabConnection.debugger.enable();
+      final tab = await connection.getTab((t) => t.url == appUrl);
+      if (tab != null) {
+        _tabConnection = await tab.connect();
+        await tabConnection.runtime.enable();
+        await tabConnection.debugger.enable();
+      }
 
       if (enableDebugExtension) {
         final extensionTab = await _fetchDartDebugExtensionTab(connection);


### PR DESCRIPTION
I did not refactor away the null-assert !s added by the Dart migration tool. Because this is a test, the null-assert !s should catch any regressions if something we expect to be non-null returns null.