### PR TITLE
Migrate a handful of tests to null-safety

### DIFF
--- a/dwds/test/frontend_server_breakpoint_test.dart
+++ b/dwds/test/frontend_server_breakpoint_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.9
-
 @TestOn('vm')
 import 'dart:async';
 
@@ -53,33 +51,33 @@ void main() {
 
     group('breakpoint', () {
       VM vm;
-      Isolate isolate;
+      late Isolate isolate;
       ScriptList scripts;
-      ScriptRef mainScript;
-      Stream<Event> stream;
+      late ScriptRef mainScript;
+      late Stream<Event> stream;
 
       setUp(() async {
         setCurrentLogWriter(debug: debug);
         vm = await service.getVM();
-        isolate = await service.getIsolate(vm.isolates.first.id);
-        scripts = await service.getScripts(isolate.id);
+        isolate = await service.getIsolate(vm.isolates!.first.id!);
+        scripts = await service.getScripts(isolate.id!);
 
         await service.streamListen('Debug');
         stream = service.onEvent('Debug');
 
-        mainScript = scripts.scripts
-            .firstWhere((each) => each.uri.contains('main.dart'));
+        mainScript = scripts.scripts!
+            .firstWhere((each) => each.uri!.contains('main.dart'));
       });
 
       tearDown(() async {
-        await service.resume(isolate.id);
+        await service.resume(isolate.id!);
       });
 
       test('set breakpoint', () async {
         final line = await context.findBreakpointLine(
-            'printLocal', isolate.id, mainScript);
+            'printLocal', isolate.id!, mainScript);
         final bp = await service.addBreakpointWithScriptUri(
-            isolate.id, mainScript.uri, line);
+            isolate.id!, mainScript.uri!, line);
 
         await stream.firstWhere(
             (Event event) => event.kind == EventKind.kPauseBreakpoint);
@@ -87,14 +85,14 @@ void main() {
         expect(bp, isNotNull);
 
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id, bp.id);
+        await service.removeBreakpoint(isolate.id!, bp.id!);
       });
 
       test('set breakpoint again', () async {
         final line = await context.findBreakpointLine(
-            'printLocal', isolate.id, mainScript);
+            'printLocal', isolate.id!, mainScript);
         final bp = await service.addBreakpointWithScriptUri(
-            isolate.id, mainScript.uri, line);
+            isolate.id!, mainScript.uri!, line);
 
         await stream.firstWhere(
             (Event event) => event.kind == EventKind.kPauseBreakpoint);
@@ -102,15 +100,15 @@ void main() {
         expect(bp, isNotNull);
 
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id, bp.id);
+        await service.removeBreakpoint(isolate.id!, bp.id!);
       });
 
       test('set breakpoint inside a JavaScript line succeeds', () async {
         final line = await context.findBreakpointLine(
-            'printNestedObjectMultiLine', isolate.id, mainScript);
+            'printNestedObjectMultiLine', isolate.id!, mainScript);
         final column = 0;
         final bp = await service.addBreakpointWithScriptUri(
-            isolate.id, mainScript.uri, line,
+            isolate.id!, mainScript.uri!, line,
             column: column);
 
         await stream.firstWhere(
@@ -125,7 +123,7 @@ void main() {
                 .having((loc) => loc.column, 'column', greaterThan(column)));
 
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id, bp.id);
+        await service.removeBreakpoint(isolate.id!, bp.id!);
       });
     });
   });

--- a/dwds/test/frontend_server_breakpoint_test.dart
+++ b/dwds/test/frontend_server_breakpoint_test.dart
@@ -81,7 +81,7 @@ void main() {
         final line = await context.findBreakpointLine(
             'printLocal', isolateId, mainScript);
         final bp = await service.addBreakpointWithScriptUri(
-            isolateId, mainScriptUri!, line);
+            isolateId, mainScriptUri, line);
 
         await stream.firstWhere(
             (Event event) => event.kind == EventKind.kPauseBreakpoint);
@@ -96,7 +96,7 @@ void main() {
         final line = await context.findBreakpointLine(
             'printLocal', isolateId, mainScript);
         final bp = await service.addBreakpointWithScriptUri(
-            isolateId, mainScriptUri!, line);
+            isolateId, mainScriptUri, line);
 
         await stream.firstWhere(
             (Event event) => event.kind == EventKind.kPauseBreakpoint);
@@ -112,7 +112,7 @@ void main() {
             'printNestedObjectMultiLine', isolateId, mainScript);
         final column = 0;
         final bp = await service.addBreakpointWithScriptUri(
-            isolateId, mainScriptUri!, line,
+            isolateId, mainScriptUri, line,
             column: column);
 
         await stream.firstWhere(

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.9
-
 @TestOn('vm')
 @Timeout(Duration(minutes: 5))
 import 'package:dwds/src/loaders/strategy.dart';
@@ -180,9 +178,9 @@ void main() {
           ));
 
       var vm = await client.getVM();
-      var isolateId = vm.isolates.first.id;
+      var isolateId = vm.isolates!.first.id!;
       var isolate = await client.getIsolate(isolateId);
-      var library = isolate.rootLib.uri;
+      var library = isolate.rootLib!.uri!;
 
       await client.evaluate(
         isolateId,
@@ -194,9 +192,9 @@ void main() {
           const TypeMatcher<Success>());
 
       vm = await client.getVM();
-      isolateId = vm.isolates.first.id;
+      isolateId = vm.isolates!.first.id!;
       isolate = await client.getIsolate(isolateId);
-      library = isolate.rootLib.uri;
+      library = isolate.rootLib!.uri!;
 
       await client.evaluate(
         isolateId,
@@ -237,15 +235,15 @@ void main() {
     test('can hot restart while paused', () async {
       final client = context.debugConnection.vmService;
       var vm = await client.getVM();
-      var isolateId = vm.isolates.first.id;
+      var isolateId = vm.isolates!.first.id!;
       await client.streamListen('Debug');
       final stream = client.onEvent('Debug');
       final scriptList = await client.getScripts(isolateId);
-      final main = scriptList.scripts
-          .firstWhere((script) => script.uri.contains('main.dart'));
+      final main = scriptList.scripts!
+          .firstWhere((script) => script.uri!.contains('main.dart'));
       final bpLine =
           await context.findBreakpointLine('printCount', isolateId, main);
-      await client.addBreakpoint(isolateId, main.id, bpLine);
+      await client.addBreakpoint(isolateId, main.id!, bpLine);
       await stream
           .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
@@ -258,43 +256,44 @@ void main() {
       expect(source.contains('Gary is awesome!'), isTrue);
 
       vm = await client.getVM();
-      isolateId = vm.isolates.first.id;
+      isolateId = vm.isolates!.first.id!;
       final isolate = await client.getIsolate(isolateId);
 
       // Previous breakpoint should still exist.
-      expect(isolate.breakpoints.isNotEmpty, isTrue);
-      final bp = isolate.breakpoints.first;
+      expect(isolate.breakpoints!.isNotEmpty, isTrue);
+      final bp = isolate.breakpoints!.first;
 
       // Should pause eventually.
       await stream
           .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
-      expect(await client.removeBreakpoint(isolate.id, bp.id), isA<Success>());
-      expect(await client.resume(isolate.id), isA<Success>());
+      expect(
+          await client.removeBreakpoint(isolate.id!, bp.id!), isA<Success>());
+      expect(await client.resume(isolate.id!), isA<Success>());
     });
 
     test('can evaluate expressions after hot restart ', () async {
       final client = context.debugConnection.vmService;
       var vm = await client.getVM();
-      var isolateId = vm.isolates.first.id;
+      var isolateId = vm.isolates!.first.id!;
       await client.streamListen('Debug');
       final stream = client.onEvent('Debug');
       final scriptList = await client.getScripts(isolateId);
-      final main = scriptList.scripts
-          .firstWhere((script) => script.uri.contains('main.dart'));
+      final main = scriptList.scripts!
+          .firstWhere((script) => script.uri!.contains('main.dart'));
       final bpLine =
           await context.findBreakpointLine('printCount', isolateId, main);
-      await client.addBreakpoint(isolateId, main.id, bpLine);
+      await client.addBreakpoint(isolateId, main.id!, bpLine);
       await stream
           .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
 
       await client.callServiceExtension('hotRestart');
 
       vm = await client.getVM();
-      isolateId = vm.isolates.first.id;
+      isolateId = vm.isolates!.first.id!;
       final isolate = await client.getIsolate(isolateId);
-      final library = isolate.rootLib.uri;
-      final bp = isolate.breakpoints.first;
+      final library = isolate.rootLib!.uri!;
+      final bp = isolate.breakpoints!.first;
 
       // Should pause eventually.
       final event = await stream
@@ -302,13 +301,13 @@ void main() {
 
       // Expression evaluation while paused on a breakpoint should work.
       var result = await client.evaluateInFrame(
-          isolate.id, event.topFrame.index, 'count');
+          isolate.id!, event.topFrame!.index!, 'count');
       expect(
           result,
           isA<InstanceRef>().having((instance) => instance.valueAsString,
               'valueAsString', greaterThanOrEqualTo('0')));
 
-      await client.removeBreakpoint(isolateId, bp.id);
+      await client.removeBreakpoint(isolateId, bp.id!);
       await client.resume(isolateId);
 
       // Expression evaluation while running should work.

--- a/dwds/test/restore_breakpoints_test.dart
+++ b/dwds/test/restore_breakpoints_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.9
-
 @TestOn('vm')
 import 'dart:async';
 
@@ -33,33 +31,33 @@ void main() {
 
   group('breakpoints', () {
     VM vm;
-    Isolate isolate;
+    late Isolate isolate;
     ScriptList scripts;
-    ScriptRef mainScript;
-    Stream<Event> isolateEventStream;
+    late ScriptRef mainScript;
+    late Stream<Event> isolateEventStream;
 
     setUp(() async {
       setCurrentLogWriter();
       vm = await fetchChromeProxyService(context.debugConnection).getVM();
       isolate = await fetchChromeProxyService(context.debugConnection)
-          .getIsolate(vm.isolates.first.id);
+          .getIsolate(vm.isolates!.first.id!);
       scripts = await fetchChromeProxyService(context.debugConnection)
-          .getScripts(isolate.id);
-      mainScript =
-          scripts.scripts.firstWhere((each) => each.uri.contains('main.dart'));
+          .getScripts(isolate.id!);
+      mainScript = scripts.scripts!
+          .firstWhere((each) => each.uri!.contains('main.dart'));
       isolateEventStream = service.onEvent('Isolate');
     });
 
     tearDown(() async {
       // Remove breakpoints so they don't impact other tests.
-      for (var breakpoint in isolate.breakpoints.toList()) {
-        await service.removeBreakpoint(isolate.id, breakpoint.id);
+      for (var breakpoint in isolate.breakpoints!.toList()) {
+        await service.removeBreakpoint(isolate.id!, breakpoint.id!);
       }
     });
 
     test('restore after refresh', () async {
       final firstBp =
-          await service.addBreakpoint(isolate.id, mainScript.id, 23);
+          await service.addBreakpoint(isolate.id!, mainScript.id!, 23);
       expect(firstBp, isNotNull);
       expect(firstBp.id, isNotNull);
 
@@ -76,14 +74,14 @@ void main() {
       await eventsDone;
 
       vm = await service.getVM();
-      isolate = await service.getIsolate(vm.isolates.first.id);
+      isolate = await service.getIsolate(vm.isolates!.first.id!);
 
-      expect(isolate.breakpoints.length, equals(1));
+      expect(isolate.breakpoints!.length, equals(1));
     }, timeout: const Timeout.factor(2));
 
     test('restore after hot restart', () async {
       final firstBp =
-          await service.addBreakpoint(isolate.id, mainScript.id, 23);
+          await service.addBreakpoint(isolate.id!, mainScript.id!, 23);
       expect(firstBp, isNotNull);
       expect(firstBp.id, isNotNull);
 
@@ -101,9 +99,9 @@ void main() {
       await eventsDone;
 
       vm = await service.getVM();
-      isolate = await service.getIsolate(vm.isolates.first.id);
+      isolate = await service.getIsolate(vm.isolates!.first.id!);
 
-      expect(isolate.breakpoints.length, equals(1));
+      expect(isolate.breakpoints!.length, equals(1));
     }, timeout: const Timeout.factor(2));
   });
 }

--- a/dwds/test/run_request_test.dart
+++ b/dwds/test/run_request_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.9
-
 @Timeout(Duration(minutes: 2))
 import 'dart:async';
 
@@ -31,8 +29,8 @@ void main() {
 
     test('can resume while paused at the start', () async {
       final vm = await service.getVM();
-      final isolate = await service.getIsolate(vm.isolates.first.id);
-      expect(isolate.pauseEvent.kind, EventKind.kPauseStart);
+      final isolate = await service.getIsolate(vm.isolates!.first.id!);
+      expect(isolate.pauseEvent!.kind, EventKind.kPauseStart);
       final stream = service.onEvent('Debug');
       final resumeCompleter = Completer();
       // The underlying stream is a broadcast stream so we need to add a
@@ -42,19 +40,19 @@ void main() {
           .then((_) {
         resumeCompleter.complete();
       }));
-      await service.resume(isolate.id);
+      await service.resume(isolate.id!);
       await resumeCompleter.future;
-      expect(isolate.pauseEvent.kind, EventKind.kResume);
+      expect(isolate.pauseEvent!.kind, EventKind.kResume);
     });
 
     test('correctly sets the isolate pauseEvent', () async {
       final vm = await service.getVM();
-      final isolate = await service.getIsolate(vm.isolates.first.id);
-      expect(isolate.pauseEvent.kind, EventKind.kPauseStart);
+      final isolate = await service.getIsolate(vm.isolates!.first.id!);
+      expect(isolate.pauseEvent!.kind, EventKind.kPauseStart);
       final stream = service.onEvent('Debug');
       context.appConnection.runMain();
       await stream.firstWhere((event) => event.kind == EventKind.kResume);
-      expect(isolate.pauseEvent.kind, EventKind.kResume);
+      expect(isolate.pauseEvent!.kind, EventKind.kResume);
     });
   });
 
@@ -70,8 +68,8 @@ void main() {
       context.appConnection.runMain();
       await context.startDebugging();
       final vm = await service.getVM();
-      final isolate = await service.getIsolate(vm.isolates.first.id);
-      expect(isolate.pauseEvent.kind, EventKind.kResume);
+      final isolate = await service.getIsolate(vm.isolates!.first.id!);
+      expect(isolate.pauseEvent!.kind, EventKind.kResume);
     });
   });
 }

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.9
-
 @TestOn('vm')
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/debugging/dart_scope.dart';
@@ -50,10 +48,10 @@ void main() {
 
   group('variable scope', () {
     VM vm;
-    String isolateId;
-    Stream<Event> stream;
+    String? isolateId;
+    late Stream<Event> stream;
     ScriptList scripts;
-    ScriptRef mainScript;
+    late ScriptRef mainScript;
     Stack stack;
 
     // TODO: Be able to set breakpoints before start/reload so we can exercise
@@ -62,30 +60,30 @@ void main() {
     /// Support function for pausing and returning the stack at a line.
     Future<Stack> breakAt(String breakpointId, ScriptRef scriptRef) async {
       final lineNumber =
-          await context.findBreakpointLine(breakpointId, isolateId, scriptRef);
+          await context.findBreakpointLine(breakpointId, isolateId!, scriptRef);
 
       final bp =
-          await service.addBreakpoint(isolateId, scriptRef.id, lineNumber);
+          await service.addBreakpoint(isolateId!, scriptRef.id!, lineNumber);
       // Wait for breakpoint to trigger.
       await stream
           .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
       // Remove breakpoint so it doesn't impact other tests.
-      await service.removeBreakpoint(isolateId, bp.id);
-      final stack = await service.getStack(isolateId);
+      await service.removeBreakpoint(isolateId!, bp.id!);
+      final stack = await service.getStack(isolateId!);
       return stack;
     }
 
     Future<Instance> getInstance(InstanceRef ref) async {
-      final result = await service.getObject(isolateId, ref.id);
+      final result = await service.getObject(isolateId!, ref.id!);
       expect(result, isA<Instance>());
       return result as Instance;
     }
 
-    void expectDartObject(String variableName, Instance instance) {
+    void expectDartObject(String? variableName, Instance instance) {
       expect(
           instance,
           isA<Instance>().having(
-              (instance) => instance.classRef.name,
+              (instance) => instance.classRef!.name,
               '$variableName: classRef.name',
               isNot(isIn([
                 'NativeJavaScriptObject',
@@ -93,37 +91,38 @@ void main() {
               ]))));
     }
 
-    Future<void> expectDartVariables(Map<String, InstanceRef> variables) async {
+    Future<void> expectDartVariables(
+        Map<String?, InstanceRef?> variables) async {
       for (var name in variables.keys) {
-        final instance = await getInstance(variables[name]);
+        final instance = await getInstance(variables[name]!);
         expectDartObject(name, instance);
       }
     }
 
-    Map<String, InstanceRef> getFrameVariables(Frame frame) {
-      return <String, InstanceRef>{
-        for (var variable in frame.vars)
-          variable.name: variable.value as InstanceRef,
+    Map<String?, InstanceRef?> getFrameVariables(Frame frame) {
+      return <String?, InstanceRef?>{
+        for (var variable in frame.vars!)
+          variable.name: variable.value as InstanceRef?,
       };
     }
 
     setUp(() async {
       vm = await service.getVM();
-      isolateId = vm.isolates.first.id;
-      scripts = await service.getScripts(isolateId);
+      isolateId = vm.isolates!.first.id;
+      scripts = await service.getScripts(isolateId!);
       await service.streamListen('Debug');
       stream = service.onEvent('Debug');
-      mainScript = scripts.scripts
-          .firstWhere((each) => each.uri.contains('scopes_main.dart'));
+      mainScript = scripts.scripts!
+          .firstWhere((each) => each.uri!.contains('scopes_main.dart'));
     });
 
     tearDown(() async {
-      await service.resume(isolateId);
+      await service.resume(isolateId!);
     });
 
     test('variables in static function', () async {
       stack = await breakAt('staticFunction', mainScript);
-      final variables = getFrameVariables(stack.frames.first);
+      final variables = getFrameVariables(stack.frames!.first);
       await expectDartVariables(variables);
 
       final variableNames = variables.keys.toList()..sort();
@@ -132,7 +131,7 @@ void main() {
 
     test('variables in function', () async {
       stack = await breakAt('nestedFunction', mainScript);
-      final variables = getFrameVariables(stack.frames.first);
+      final variables = getFrameVariables(stack.frames!.first);
       await expectDartVariables(variables);
 
       final variableNames = variables.keys.toList()..sort();
@@ -152,7 +151,7 @@ void main() {
 
     test('variables in closure nested in method', () async {
       stack = await breakAt('nestedClosure', mainScript);
-      final variables = getFrameVariables(stack.frames.first);
+      final variables = getFrameVariables(stack.frames!.first);
       await expectDartVariables(variables);
 
       final variableNames = variables.keys.toList()..sort();
@@ -162,7 +161,7 @@ void main() {
 
     test('variables in method', () async {
       stack = await breakAt('printMethod', mainScript);
-      final variables = getFrameVariables(stack.frames.first);
+      final variables = getFrameVariables(stack.frames!.first);
       await expectDartVariables(variables);
 
       final variableNames = variables.keys.toList()..sort();
@@ -171,7 +170,7 @@ void main() {
 
     test('variables in extension method', () async {
       stack = await breakAt('extension', mainScript);
-      final variables = getFrameVariables(stack.frames.first);
+      final variables = getFrameVariables(stack.frames!.first);
       await expectDartVariables(variables);
 
       final variableNames = variables.keys.toList()..sort();

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -79,7 +79,7 @@ void main() {
       return result as Instance;
     }
 
-    void expectDartObject(String? variableName, Instance instance) {
+    void expectDartObject(String variableName, Instance instance) {
       expect(
           instance,
           isA<Instance>().having(
@@ -95,7 +95,7 @@ void main() {
         Map<String?, InstanceRef?> variables) async {
       for (var name in variables.keys) {
         final instance = await getInstance(variables[name]!);
-        expectDartObject(name, instance);
+        expectDartObject(name!, instance);
       }
     }
 


### PR DESCRIPTION
Migrates the following tests to null-safety:

```
    test/run_request_test.dart
    test/frontend_server_callstack_test.dart
    test/restore_breakpoints_test.dart
    test/variable_scope_test.dart
    test/frontend_server_breakpoint_test.dart
    test/reload_test.dart
```