### PR TITLE
Remove passing --debugger-module-names to frontend server in tests

### DIFF
--- a/frontend_server_common/CHANGELOG.md
+++ b/frontend_server_common/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Doe not pass `-debugger-module-names` flag to the frontend server.
+
 ## 0.2.0
 
 - Migrate to null safety

--- a/frontend_server_common/lib/src/frontend_server_client.dart
+++ b/frontend_server_common/lib/src/frontend_server_client.dart
@@ -382,7 +382,6 @@ class ResidentCompiler {
         '--platform',
         platformDill,
       ],
-      '--debugger-module-names',
       '--experimental-emit-debug-metadata',
       if (verbose) '--verbose'
     ];

--- a/frontend_server_common/pubspec.yaml
+++ b/frontend_server_common/pubspec.yaml
@@ -1,7 +1,7 @@
 name: frontend_server_common
 publish_to: none
 description: >-
-  Frontend server integration code to use for dwds tests. Mimicks flutter code.
+  Frontend server integration code to use for dwds tests. Mimics flutter code.
 environment:
   sdk: ">=2.17.0 <3.0.0"
 


### PR DESCRIPTION
This flag is true by default in the frontend server currently, so no change in behavior is expected.

Towards: https://github.com/dart-lang/webdev/issues/1692