### PR TITLE
Pass working directory to `Process.run` when building debug extension in tests

### DIFF
--- a/dwds/debug_extension/tool/build_extension.sh
+++ b/dwds/debug_extension/tool/build_extension.sh
@@ -33,6 +33,6 @@ echo "Building DDC-compiled extension to dev_build/web directory."
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 dart run build_runner build web --delete-conflicting-outputs --output dev_build
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
- "Updating the manifest.json file in dev_build/web directory."
+echo "Updating the manifest.json file in dev_build/web directory."
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 dart tool/update_dev_manifest.dart

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -435,16 +435,12 @@ class TestContext {
       throw StateError(
           'Expected to be in /dwds directory, instead path was $currentDir.');
     }
-    try {
-      Directory.current = '$currentDir/debug_extension';
-      final process = await Process.run(
-        'tool/build_extension.sh',
-        ['prod'],
-      );
-      print(process.stdout);
-    } finally {
-      Directory.current = currentDir;
-    }
+    final process = await Process.run(
+      'tool/build_extension.sh',
+      ['prod'],
+      workingDirectory: '$currentDir/debug_extension',
+    );
+    print(process.stdout);
   }
 
   Future<ChromeTab> _fetchDartDebugExtensionTab(


### PR DESCRIPTION
Follow-up to https://github.com/dart-lang/webdev/pull/1717

Pass in working directory to `Process.run` instead of switching directories to build.