### PR TITLE
Update DartUri to handle more urls

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Allows correct relative source map paths resolution.
   - Add `PackageUriMapper` class to allow mapping uris to server paths.
 - Update the min SDK constraint to 2.18.0.
+- Make DartUri work for `google3:` uris.
 
 **Breaking changes**
 

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -502,7 +502,7 @@ class Debugger extends Domain {
 
     final url = urlForScriptId(location.scriptId);
     if (url == null) {
-      logger.severe('Failed to create dart frame for ${frame.functionName}: '
+      logger.fine('Failed to create dart frame for ${frame.functionName}: '
           'cannot find url for script ${location.scriptId}');
       return null;
     }

--- a/dwds/lib/src/utilities/dart_uri.dart
+++ b/dwds/lib/src/utilities/dart_uri.dart
@@ -31,7 +31,7 @@ class DartUri {
   factory DartUri(String uri, [String? root]) {
     // TODO(annagrin): Support creating DartUris from `dart:` uris.
     // Issue: https://github.com/dart-lang/webdev/issues/1584
-    if (uri.startsWith('org-dartlang-app:')) {
+    if (uri.startsWith('org-dartlang-app:') || uri.startsWith('google3:')) {
       return DartUri._fromDartLangUri(uri);
     }
     if (uri.startsWith('package:')) {

--- a/dwds/test/dart_uri_test.dart
+++ b/dwds/test/dart_uri_test.dart
@@ -19,10 +19,13 @@ class TestStrategy extends FakeStrategy {
   String? serverPathForAppUri(String appUrl) {
     final appUri = Uri.parse(appUrl);
     if (appUri.isScheme('org-dartlang-app')) {
-      return 'foo';
+      return appUri.path;
     }
     if (appUri.isScheme('package')) {
-      return '/packages/${appUri.path}';
+      return 'packages/${appUri.path}';
+    }
+    if (appUri.isScheme('google3')) {
+      return appUri.path;
     }
     return null;
   }
@@ -42,8 +45,13 @@ void main() {
     });
 
     test('parses org-dartlang-app paths', () {
-      final uri = DartUri('org-dartlang-app:////blah/main.dart');
-      expect(uri.serverPath, 'foo');
+      final uri = DartUri('org-dartlang-app:///blah/main.dart');
+      expect(uri.serverPath, '/blah/main.dart');
+    });
+
+    test('parses google3 paths', () {
+      final uri = DartUri('google3:///blah/main.dart');
+      expect(uri.serverPath, '/blah/main.dart');
     });
 
     test('parses packages paths', () {
@@ -86,7 +94,7 @@ void main() {
         expect(resolved, 'org-dartlang-sdk:///sdk/lib/io/io.dart');
       }, skip: 'https://github.com/dart-lang/webdev/issues/1584');
 
-      test('can unresolve uris', () {
+      test('can un-resolve uris', () {
         final unresolved =
             DartUri.toPackageUri('org-dartlang-sdk:///sdk/lib/io/io.dart');
         expect(unresolved, 'dart:io');

--- a/fixtures/_testCircular1/lib/library1.dart
+++ b/fixtures/_testCircular1/lib/library1.dart
@@ -12,3 +12,7 @@ import 'package:_test_circular2/library2.dart';
 String concatenate(String a, String b) {
   return '$a$b'; // Breakpoint: Concatenate
 }
+
+void printGlobal() {
+  print(globalValue);
+}

--- a/fixtures/_testCircular1Sound/lib/library1.dart
+++ b/fixtures/_testCircular1Sound/lib/library1.dart
@@ -10,3 +10,7 @@ import 'package:_test_circular2_sound/library2.dart';
 String concatenate(String a, String b) {
   return '$a$b'; // Breakpoint: Concatenate
 }
+
+void printGlobal() {
+  print(globalValue);
+}

--- a/fixtures/_testCircular2/lib/library2.dart
+++ b/fixtures/_testCircular2/lib/library2.dart
@@ -6,6 +6,8 @@
 
 import 'package:_test_circular1/library1.dart';
 
+int globalValue = 0;
+
 void testCircularDependencies() {
   print(concatenate('a', 'b')); // Breakpoint: testCircularDependencies
 }

--- a/fixtures/_testCircular2Sound/lib/library2.dart
+++ b/fixtures/_testCircular2Sound/lib/library2.dart
@@ -4,6 +4,8 @@
 
 import 'package:_test_circular1_sound/library1.dart';
 
+int globalValue = 0;
+
 void testCircularDependencies() {
   print(concatenate('a', 'b')); // Breakpoint: testCircularDependencies
 }


### PR DESCRIPTION
Latest changes to `DartUri` do not allow schemes such as `google3:`, which breaks automatic rolls into google3.

- Handle `google3:` uris in `DartUri`
- Add tests