### PR TITLE
Add option to run a full build

### DIFF
--- a/webdev/lib/src/command/build_command.dart
+++ b/webdev/lib/src/command/build_command.dart
@@ -76,6 +76,13 @@ class BuildCommand extends Command<int> {
       client.registerBuildTarget(DefaultBuildTarget((b) => b
         ..target = configuration.outputInput
         ..outputLocation = outputLocation?.toBuilder()));
+
+      // If we're supposed to do a full build, add an empty target so that all
+      // assets are built.
+      if (configuration.fullBuild) {
+        client.registerBuildTarget(DefaultBuildTarget((b) => b..target = ''));
+      }
+
       client.startBuild();
       var exitCode = 0;
       var gotBuildStart = false;

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -29,6 +29,7 @@ const logRequestsFlag = 'log-requests';
 const outputFlag = 'output';
 const outputNone = 'NONE';
 const releaseFlag = 'release';
+const fullBuildFlag = 'full-build';
 const requireBuildWebCompilersFlag = 'build-web-compilers';
 const enableExpressionEvaluationFlag = 'enable-expression-evaluation';
 const verboseFlag = 'verbose';
@@ -99,6 +100,7 @@ class Configuration {
   final String outputInput;
   final String outputPath;
   final bool _release;
+  final bool _fullBuild;
   final ReloadConfiguration _reload;
   final bool _requireBuildWebCompilers;
   final bool _enableExpressionEvaluation;
@@ -124,6 +126,7 @@ class Configuration {
     this.outputPath,
     ReloadConfiguration reload,
     bool release,
+    bool fullBuild,
     bool requireBuildWebCompilers,
     bool enableExpressionEvaluation,
     bool verbose,
@@ -143,6 +146,7 @@ class Configuration {
         _logRequests = logRequests,
         _output = output,
         _release = release,
+        _fullBuild = fullBuild,
         _reload = reload,
         _requireBuildWebCompilers = requireBuildWebCompilers,
         _disableDds = disableDds,
@@ -214,6 +218,7 @@ class Configuration {
       logRequests: other._logRequests ?? _logRequests,
       output: other._output ?? _output,
       release: other._release ?? _release,
+      fullBuild: other._fullBuild ?? _fullBuild,
       reload: other._reload ?? _reload,
       requireBuildWebCompilers:
           other._requireBuildWebCompilers ?? _requireBuildWebCompilers,
@@ -256,6 +261,8 @@ class Configuration {
   String get output => _output ?? outputNone;
 
   bool get release => _release ?? false;
+
+  bool get fullBuild => _fullBuild ?? false;
 
   ReloadConfiguration get reload => _reload ?? ReloadConfiguration.none;
 
@@ -365,6 +372,10 @@ class Configuration {
         ? argResults[releaseFlag] as bool
         : defaultConfiguration.release;
 
+    var fullBuild = argResults.options.contains(fullBuildFlag)
+        ? argResults[fullBuildFlag] as bool
+        : defaultConfiguration.fullBuild;
+
     var requireBuildWebCompilers =
         argResults.options.contains(requireBuildWebCompilersFlag)
             ? argResults[requireBuildWebCompilersFlag] as bool
@@ -404,6 +415,7 @@ class Configuration {
       outputInput: outputInput,
       outputPath: outputPath,
       release: release,
+      fullBuild: fullBuild,
       reload: _parseReloadConfiguration(argResults),
       requireBuildWebCompilers: requireBuildWebCompilers,
       disableDds: disableDds,

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -46,6 +46,11 @@ void addSharedArgs(ArgParser argParser,
         defaultsTo: releaseDefault,
         negatable: true,
         help: 'Build with release mode defaults for builders.')
+    ..addFlag(
+      fullBuildFlag,
+      help: 'Always build all files instead of just the directories served or '
+          'written.',
+    )
     ..addFlag(requireBuildWebCompilersFlag,
         defaultsTo: true,
         negatable: true,

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -140,11 +140,15 @@ void _registerBuildTargets(
   }
   // Empty string indicates we should build everything, register a corresponding
   // target.
-  if (configuration.outputInput == '' && configuration.outputPath != null) {
-    var outputLocation = OutputLocation((b) => b
-      ..output = configuration.outputPath
-      ..useSymlinks = true
-      ..hoist = false);
+  var buildAll = configuration.fullBuild ||
+      (configuration.outputInput == '' && configuration.outputPath != null);
+  if (buildAll) {
+    var outputLocation = configuration.outputPath != null
+        ? OutputLocation((b) => b
+          ..output = configuration.outputPath
+          ..useSymlinks = true
+          ..hoist = false)
+        : null;
     client.registerBuildTarget(DefaultBuildTarget((b) => b
       ..target = ''
       ..outputLocation = outputLocation?.toBuilder()));


### PR DESCRIPTION
This adds the `--full-build` option. When enabled, the `webdev serve` and `webdev build` commands will add an empty target to the build daemon, ensuring that all assets are built.

This option is needed to properly build all assets in the desired folders (#1200).

Closes #1733.