### PR TITLE
Remove // ignore: unsafe_html.

### DIFF
--- a/dwds/web/client.dart
+++ b/dwds/web/client.dart
@@ -123,7 +123,6 @@ Future<void>? main() {
         if (!event.success) {
           final alert = 'DevTools failed to open with:\n${event.error}';
           if (event.promptExtension && window.confirm(alert)) {
-            // ignore: unsafe_html
             window.open('https://goo.gle/dart-debug-extension', '_blank');
           } else {
             window.alert(alert);


### PR DESCRIPTION
This has no effect because unsafe_html is unignorable.