### PR TITLE
Support `--source` in `FrontendServerClient`

### DIFF
--- a/frontend_server_client/CHANGELOG.md
+++ b/frontend_server_client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.0
+
+- Add `additionalSources` parameter to `FrontendServerClient`, for passing
+  additional `--source`s to the kernel compiler.
+
 ## 3.0.0
 
 - Update the `compile` api to return a non-null `CompileResult`, and instead

--- a/frontend_server_client/lib/src/frontend_server_client.dart
+++ b/frontend_server_client/lib/src/frontend_server_client.dart
@@ -57,6 +57,7 @@ class FrontendServerClient {
     String target = 'vm', // The kernel target type.
     bool verbose = false, // Verbose logs, including server/client messages
     bool printIncrementalDependencies = true,
+    List<String> additionalSources = const [],
   }) async {
     var feServer = await Process.start(Platform.resolvedExecutable, [
       if (debug) '--observe',
@@ -80,6 +81,10 @@ class FrontendServerClient {
       if (enabledExperiments != null)
         for (var experiment in enabledExperiments)
           '--enable-experiment=$experiment',
+      if (additionalSources.isNotEmpty) ...[
+        '--source',
+        ...additionalSources,
+      ],
     ]);
     var feServerStdoutLines = StreamQueue(feServer.stdout
         .transform(utf8.decoder)

--- a/frontend_server_client/lib/src/frontend_server_client.dart
+++ b/frontend_server_client/lib/src/frontend_server_client.dart
@@ -81,9 +81,9 @@ class FrontendServerClient {
       if (enabledExperiments != null)
         for (var experiment in enabledExperiments)
           '--enable-experiment=$experiment',
-      if (additionalSources.isNotEmpty) ...[
+      for (var source in additionalSources) ...[
         '--source',
-        ...additionalSources,
+        source,
       ],
     ]);
     var feServerStdoutLines = StreamQueue(feServer.stdout

--- a/frontend_server_client/pubspec.yaml
+++ b/frontend_server_client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: frontend_server_client
-version: 3.0.0
+version: 3.1.0
 description: >-
   Client code to start and interact with the frontend_server compiler from the
   Dart SDK.


### PR DESCRIPTION
https://dart-review.googlesource.com/c/sdk/+/231334 introduced passing additional sources to `gen_kernel`.

This PR exposes this option in the `FrontendServerClient` so that it can be invoked from pub/dartdev which uses this API.