### PR TITLE
Update `package:file` to latest version

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Expression evaluation performance improvement:
   - Batch `ChromeProxyService.evaluate()` requests that are close in time
     and are executed in the same library and scope.
+- Update `package:file` version to `6.13` or greater to handle https://github.com/dart-lang/sdk/issues/49647.
 
 ## 16.0.0
 

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   collection: ^1.15.0
   crypto: ^3.0.2
   dds: ^2.2.5
-  file: ^6.1.2
+  file: ^6.1.3
   http: ^0.13.4
   http_multi_server: ^3.2.0
   logging: ^1.0.2

--- a/frontend_server_common/pubspec.yaml
+++ b/frontend_server_common/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   dwds:
     path: ../dwds
-  file: ^6.0.0
+  file: ^6.1.3
   logging: ^1.0.1
   meta: ^1.4.0
   mime: ^1.0.0


### PR DESCRIPTION
`package:file` needs to be updated to the latest version before releasing DWDS and webdev due to https://github.com/dart-lang/sdk/issues/49647