### PR TITLE
Adds Puppeteer tests for MV3 Dart Debug Extension

### DIFF
--- a/dwds/debug_extension_mv3/.gitignore
+++ b/dwds/debug_extension_mv3/.gitignore
@@ -1,5 +1,3 @@
 build/
 compiled/
-pupeteer_tests/node_modules
-pupeteer_tests/package-lock.json
 extension_key.txt

--- a/dwds/debug_extension_mv3/.gitignore
+++ b/dwds/debug_extension_mv3/.gitignore
@@ -1,3 +1,5 @@
 build/
 compiled/
+pupeteer_tests/node_modules
+pupeteer_tests/package-lock.json
 extension_key.txt

--- a/dwds/debug_extension_mv3/web/background.dart
+++ b/dwds/debug_extension_mv3/web/background.dart
@@ -20,6 +20,14 @@ void main() {
 
 void _registerListeners() {
   chrome.runtime.onMessage.addListener(allowInterop(_handleRuntimeMessages));
+
+  // Detect clicks on the Dart Debug Extension icon.
+  chrome.action.onClicked.addListener(allowInterop(_startDebugSession));
+}
+
+void _startDebugSession(Tab _) async {
+  // TODO(elliette): Start a debug session instead.
+  _createTab('https://dart.dev/');
 }
 
 void _handleRuntimeMessages(
@@ -43,6 +51,14 @@ void _handleRuntimeMessages(
         // Update the icon to show that a Dart app has been detected:
         chrome.action.setIcon(IconInfo(path: 'dart.png'), /*callback*/ null);
       });
+}
+
+Future<Tab> _createTab(String url) async {
+  final tabPromise = chrome.tabs.create(TabInfo(
+    active: true,
+    url: url,
+  ));
+  return promiseToFuture<Tab>(tabPromise);
 }
 
 Future<Tab?> _getTab() async {

--- a/dwds/debug_extension_mv3/web/chrome_api.dart
+++ b/dwds/debug_extension_mv3/web/chrome_api.dart
@@ -74,6 +74,17 @@ class MessageSender {
 @anonymous
 class Tabs {
   external Object query(QueryInfo queryInfo);
+
+  external Object create(TabInfo tabInfo);
+}
+
+@JS()
+@anonymous
+class TabInfo {
+  external bool? get active;
+  external bool? get pinned;
+  external String? get url;
+  external factory TabInfo({bool? active, bool? pinned, String? url});
 }
 
 @JS()

--- a/dwds/test/puppeteer/.gitignore
+++ b/dwds/test/puppeteer/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/dwds/test/puppeteer/README.md
+++ b/dwds/test/puppeteer/README.md
@@ -1,0 +1,7 @@
+# Puppeteer tests for the MV3 Dart Debug Extension
+
+## How to run:
+* From the `dwds/test/puppeteer` directory, run: `dart puppeteer_setup.dart`
+* Wait for the test runner command to be printed to the console
+* From the `dwds/test/puppeteer` directory in a separate terminal window/tab, run the test runner command
+* When the test completes, use ctrl+c to exit the `pupeteer_setup`

--- a/dwds/test/puppeteer/extension.test.js
+++ b/dwds/test/puppeteer/extension.test.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+const puppeteer = require('puppeteer');
+
+let browser;
+let appUrl;
+let serviceWorker;
+
+beforeAll(async () => {
+  const [_, __, ___, extensionDirArg, appUrlArg] = process.argv;
+  appUrl = appUrlArg;
+  const pathToExtension = require('path').join(extensionDirArg);
+  browser = await puppeteer.launch({
+    headless: 'chrome',
+    args: [
+      `--disable-extensions-except=${pathToExtension}`,
+      `--load-extension=${pathToExtension}`,
+      '--disable-features=DialMediaRouteProvider',
+    ],
+  });
+  const serviceWorkerTarget = await browser.waitForTarget(
+    target => target.type() === 'service_worker'
+  );
+  serviceWorker = await serviceWorkerTarget.worker();
+});
+
+afterAll(async () => {
+  await browser.close();
+});
+
+describe('Dart Debug Extension', () => {
+  test('Clicking extension icon opens Dart docs', async () => {
+    // Navigate to the app tab:
+    const appTab = await browser.newPage();
+    await appTab.goto(appUrl, { waitUntil: ['domcontentloaded', "networkidle2"] });
+    await appTab.bringToFront();
+
+    // Click on the Dart Debug Extension icon:
+    await serviceWorker.evaluate(async () => {
+      const activeTabs = await chrome.tabs.query({ active: true });
+      const tab = activeTabs[0];
+      chrome.action.onClicked.dispatch(tab);
+    });
+
+    // Verify that the extension opened the Dart docs:
+    const newTabTarget = await browser.waitForTarget(
+      target => target.url() === 'https://dart.dev/'
+    );
+    const newTabPage = await newTabTarget.page();
+    expect(newTabPage).not.toBeNull();
+  });
+});

--- a/dwds/test/puppeteer/jest.config.json
+++ b/dwds/test/puppeteer/jest.config.json
@@ -1,0 +1,3 @@
+{
+    "preset": "jest-puppeteer"
+  }

--- a/dwds/test/puppeteer/package.json
+++ b/dwds/test/puppeteer/package.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "puppeteer": "^19.2.0"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.2.2",
+    "jest-puppeteer": "^6.1.1"
+  }
+}

--- a/dwds/test/puppeteer/puppeteer_setup.dart
+++ b/dwds/test/puppeteer/puppeteer_setup.dart
@@ -55,7 +55,6 @@ void main(List<String> arguments) async {
   // Install the node_modules:
   print('Installing node_modules...');
   await Process.run('npm', ['install']);
-  print('Starting the puppeteer tests...');
   final compiledExtensionDir = absoluteWebdevPath(
       currentPath: currentDir.path,
       relativeWebdevPath: 'dwds/debug_extension_mv3/compiled');

--- a/dwds/test/puppeteer/puppeteer_setup.dart
+++ b/dwds/test/puppeteer/puppeteer_setup.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:path/path.dart' as p;
+
+import '../fixtures/context.dart';
+
+const useSseFlagName = 'use-sse';
+
+void main(List<String> arguments) async {
+  exitCode = 0; // presume success
+
+  // Parse command-line arguments:
+  final parser = ArgParser()
+    ..addFlag(
+      useSseFlagName,
+      negatable: true,
+      defaultsTo: true,
+      abbr: 's',
+    );
+  final argResults = parser.parse(arguments);
+  final useSse = argResults[useSseFlagName] as bool;
+
+  // Build the Dart Debug Extension:
+  print('Building Dart Debug Extension...');
+  final currentDir = Directory.current;
+  final extensionDir = absoluteWebdevPath(
+      currentPath: currentDir.path,
+      relativeWebdevPath: 'dwds/debug_extension_mv3');
+  await Process.run(
+    'tool/build_extension.sh',
+    [],
+    workingDirectory: extensionDir,
+  );
+
+  // Create a test context to launch the test server:
+  print('Starting a test server...');
+  final context = TestContext(
+    directory: absoluteWebdevPath(
+      currentPath: currentDir.path,
+      relativeWebdevPath: 'fixtures/_test',
+    ),
+    entry: absoluteWebdevPath(
+      currentPath: currentDir.path,
+      relativeWebdevPath: 'fixtures/_test/example/append_body/main.dart',
+    ),
+  );
+  await context.setUp(serveDevTools: true, useSse: useSse, launchChrome: false);
+  final appUrl = context.appUrl;
+
+  // Install the node_modules:
+  print('Installing node_modules...');
+  await Process.run('npm', ['install']);
+  print('Starting the puppeteer tests...');
+  final compiledExtensionDir = absoluteWebdevPath(
+      currentPath: currentDir.path,
+      relativeWebdevPath: 'dwds/debug_extension_mv3/compiled');
+
+  print('============================================================');
+  print('====================TEST RUNNER COMMAND:====================');
+  print('============================================================');
+  print('npm test extension.test.js -- $compiledExtensionDir $appUrl');
+}
+
+String absoluteWebdevPath(
+    {required String currentPath, required String relativeWebdevPath}) {
+  final currentPathParts = p.split(currentPath);
+  final pathPartsToWebdev =
+      currentPathParts.sublist(0, currentPathParts.indexOf('webdev') + 1);
+  final relativePathParts = p.split(relativeWebdevPath);
+  final pathToDir = p.joinAll([...pathPartsToWebdev, ...relativePathParts]);
+  return pathToDir;
+}


### PR DESCRIPTION
* Instructions for how to run the new tests are in `dwds/tests/puppeteer/README`
* Currently the tests can only be run manually

![Screen Shot 2022-11-03 at 6 17 16 PM](https://user-images.githubusercontent.com/21270878/199867809-e116260d-c3af-47a7-a9ab-09039b599557.png)
