### PR TITLE
Log entire exception message instead of first line

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -6,6 +6,8 @@
   internally or externally.
 - Fix null cast error on expression evaluations after dwds fails to find class
   metadata.
+- Include the entire exception description up to the stacktrace in
+  `mapExceptionStackTrace`.
 
 ## 16.0.1
 

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
+import 'dart:math';
+
 import 'package:async/async.dart';
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
@@ -82,6 +84,9 @@ class AppInspector implements AppInspectorInterface {
 
   /// Regex used to extract the message from an exception description.
   static final exceptionMessageRegex = RegExp(r'^.*$', multiLine: true);
+
+  /// Regex used to extract a stack trace line from the exception description.
+  static final stackTraceLineRegex = RegExp(r'^\s*at\s.*$', multiLine: true);
 
   AppInspector._(
     this._appConnection,
@@ -611,8 +616,17 @@ class AppInspector implements AppInspectorInterface {
     if (mappedStack == null || mappedStack.isEmpty) {
       return description;
     }
-    var message = exceptionMessageRegex.firstMatch(description)?.group(0);
-    message = (message != null) ? '$message\n' : '';
+    final message = _allLinesBeforeStackTrace(description);
     return '$message$mappedStack';
+  }
+
+  String _allLinesBeforeStackTrace(String description) {
+    var message = '';
+    for (final match in exceptionMessageRegex.allMatches(description)) {
+      final isStackTraceLine = stackTraceLineRegex.hasMatch(match[0] ?? '');
+      if (isStackTraceLine) break;
+      message += '${match[0]}\n';
+    }
+    return message;
   }
 }

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
-import 'dart:math';
-
 import 'package:async/async.dart';
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -84,6 +84,20 @@ void main() {
     });
   });
 
+  group('mapExceptionStackTrace', () {
+    test('with a stack trace', () async {
+      final result =
+          await inspector.mapExceptionStackTrace(jsExceptionWithStackTrace);
+      expect(result, equals(formattedWithStackTrace));
+    });
+
+    test('without a stack trace', () async {
+      final result =
+          await inspector.mapExceptionStackTrace(jsExceptionNoStackTrace);
+      expect(result, equals(formattedNoStackTrace));
+    });
+  });
+
   test('send toString', () async {
     final remoteObject = await libraryPublicFinal();
     final toString =
@@ -203,3 +217,29 @@ void main() {
     });
   });
 }
+
+final jsExceptionWithStackTrace = '''
+Error: Assertion failed: org-dartlang-app:///web/scopes_main.dart:4:11
+false
+"THIS IS THE ASSERT MESSAGE"
+    at Object.assertFailed (org-dartlang-app:///web/scopes_main.dart.js:5297:15)
+''';
+
+final formattedWithStackTrace = '''
+Error: Assertion failed: org-dartlang-app:///web/scopes_main.dart:4:11
+false
+"THIS IS THE ASSERT MESSAGE"
+org-dartlang-app:///web/scopes_main.dart.js 5297:15  assertFailed
+''';
+
+final jsExceptionNoStackTrace = '''
+Error: Assertion failed: org-dartlang-app:///web/scopes_main.dart:4:11
+false
+"THIS IS THE ASSERT MESSAGE"
+''';
+
+final formattedNoStackTrace = '''
+Error: Assertion failed: org-dartlang-app:///web/scopes_main.dart:4:11
+false
+"THIS IS THE ASSERT MESSAGE"
+''';

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -100,8 +100,6 @@ void main() {
     test('single-line exception with a stack trace', () async {
       final result = await inspector
           .mapExceptionStackTrace(jsSingleLineExceptionWithStackTrace);
-      print('RESULT IS');
-      print(result);
       expect(result, equals(formattedSingleLineExceptionWithStackTrace));
     });
   });

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -85,16 +85,24 @@ void main() {
   });
 
   group('mapExceptionStackTrace', () {
-    test('with a stack trace', () async {
-      final result =
-          await inspector.mapExceptionStackTrace(jsExceptionWithStackTrace);
-      expect(result, equals(formattedWithStackTrace));
+    test('multi-line exception with a stack trace', () async {
+      final result = await inspector
+          .mapExceptionStackTrace(jsMultiLineExceptionWithStackTrace);
+      expect(result, equals(formattedMultiLineExceptionWithStackTrace));
     });
 
-    test('without a stack trace', () async {
-      final result =
-          await inspector.mapExceptionStackTrace(jsExceptionNoStackTrace);
-      expect(result, equals(formattedNoStackTrace));
+    test('multi-line exception without a stack trace', () async {
+      final result = await inspector
+          .mapExceptionStackTrace(jsMultiLineExceptionNoStackTrace);
+      expect(result, equals(formattedMultiLineExceptionNoStackTrace));
+    });
+
+    test('single-line exception with a stack trace', () async {
+      final result = await inspector
+          .mapExceptionStackTrace(jsSingleLineExceptionWithStackTrace);
+      print('RESULT IS');
+      print(result);
+      expect(result, equals(formattedSingleLineExceptionWithStackTrace));
     });
   });
 
@@ -218,28 +226,44 @@ void main() {
   });
 }
 
-final jsExceptionWithStackTrace = '''
+final jsMultiLineExceptionWithStackTrace = '''
 Error: Assertion failed: org-dartlang-app:///web/scopes_main.dart:4:11
 false
 "THIS IS THE ASSERT MESSAGE"
     at Object.assertFailed (org-dartlang-app:///web/scopes_main.dart.js:5297:15)
 ''';
 
-final formattedWithStackTrace = '''
+final formattedMultiLineExceptionWithStackTrace = '''
 Error: Assertion failed: org-dartlang-app:///web/scopes_main.dart:4:11
 false
 "THIS IS THE ASSERT MESSAGE"
 org-dartlang-app:///web/scopes_main.dart.js 5297:15  assertFailed
 ''';
 
-final jsExceptionNoStackTrace = '''
+final jsMultiLineExceptionNoStackTrace = '''
 Error: Assertion failed: org-dartlang-app:///web/scopes_main.dart:4:11
 false
 "THIS IS THE ASSERT MESSAGE"
 ''';
 
-final formattedNoStackTrace = '''
+final formattedMultiLineExceptionNoStackTrace = '''
 Error: Assertion failed: org-dartlang-app:///web/scopes_main.dart:4:11
 false
 "THIS IS THE ASSERT MESSAGE"
+''';
+
+final jsSingleLineExceptionWithStackTrace = '''
+Error: Unexpected null value.
+    at Object.throw_ [as throw] (http://localhost:63236/dart_sdk.js:5379:11)
+    at Object.nullCheck (http://localhost:63236/dart_sdk.js:5696:30)
+    at main (http://localhost:63236/packages/tmpapp/main.dart.lib.js:374:10)
+    at http://localhost:63236/web_entrypoint.dart.lib.js:41:33
+''';
+
+final formattedSingleLineExceptionWithStackTrace = '''
+Error: Unexpected null value.
+http://localhost:63236/dart_sdk.js 5379:11                      throw_
+http://localhost:63236/dart_sdk.js 5696:30                      nullCheck
+http://localhost:63236/packages/tmpapp/main.dart.lib.js 374:10  main
+http://localhost:63236/web_entrypoint.dart.lib.js 41:33         <fn>
 ''';


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/1781

See https://github.com/flutter/flutter/issues/114727#issuecomment-1307949198 for details