### PR TITLE
Fix null cast error on expression evaluation with missing class metadata

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -4,6 +4,8 @@
   Dart Debug Extension notifying that the Dart app is ready.
 - Include an optional param to `Dwds.start` to indicate whether it is running
   internally or externally.
+- Fix null cast error on expression evaluations after dwds fails to find class
+  metadata.
 
 ## 16.0.1
 

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -373,7 +373,7 @@ class Debugger extends Domain {
     // Filter out variables that do not come from dart code, such as native
     // JavaScript objects
     return boundVariables
-        .where((bv) => bv != null && !isNativeJsObject(bv.value as InstanceRef))
+        .where((bv) => isDisplayableObject(bv?.value))
         .toList()
         .cast();
   }
@@ -743,6 +743,9 @@ Future<T> sendCommandAndValidateResult<T>(
   }
   return result;
 }
+
+bool isDisplayableObject(Object? object) =>
+    object is Sentinel || object is InstanceRef && !isNativeJsObject(object);
 
 bool isNativeJsObject(InstanceRef instanceRef) {
   // New type representation of JS objects reifies them to a type suffixed with

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -180,7 +180,7 @@ class InstanceHelper extends Domain {
     var boundFields = await Future.wait(
         dartProperties.map<Future<BoundField>>((p) => _fieldFor(p, classRef)));
     boundFields = boundFields
-        .where((bv) => !isNativeJsObject(bv.value as InstanceRef))
+        .where((bv) => isDisplayableObject(bv.value))
         .toList()
       ..sort(_compareBoundFields);
     final result = Instance(

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -226,7 +226,7 @@ class ExpressionEvaluator {
     var result = await _debugger.evaluateJsOnCallFrameIndex(frameIndex, jsCode);
     result = await _formatEvaluationError(result);
 
-    _logger.finest('Evaluated "$expression" to "$result"');
+    _logger.finest('Evaluated "$expression" to "${result.json}"');
     return result;
   }
 

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -82,7 +82,7 @@ void testAll({
     }
   }
 
-  group('shared context with evaluation', () {
+  group('shared context with evaluation |', () {
     setUpAll(() async {
       setCurrentLogWriter(debug: debug);
       await context.setUp(
@@ -100,7 +100,7 @@ void testAll({
 
     setUp(() => setCurrentLogWriter(debug: debug));
 
-    group('evaluateInFrame', () {
+    group('evaluateInFrame |', () {
       VM vm;
       late Isolate isolate;
       late String isolateId;
@@ -137,6 +137,23 @@ void testAll({
 
       tearDown(() async {
         await setup.service.resume(isolateId);
+      });
+
+      test('does not crash if class metadata cannot be found', () async {
+        await onBreakPoint(isolateId, mainScript, 'printStream', () async {
+          final event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
+
+          final result = await setup.service
+              .evaluateInFrame(isolateId, event.topFrame!.index!, 'stream');
+          final instanceId = (result as InstanceRef).id!;
+          final instance = await setup.service.getObject(isolateId, instanceId);
+
+          expect(
+              instance,
+              isA<Instance>().having((instance) => instance.classRef!.name,
+                  'class name', '_AsBroadcastStream<int>'));
+        });
       });
 
       test('with scope override is not supported yet', () async {
@@ -523,7 +540,7 @@ void testAll({
       });
     });
 
-    group('evaluate', () {
+    group('evaluate |', () {
       VM vm;
       late Isolate isolate;
       late String isolateId;
@@ -611,7 +628,7 @@ void testAll({
     });
   }, timeout: const Timeout.factor(2));
 
-  group('shared context with no evaluation', () {
+  group('shared context with no evaluation |', () {
     setUpAll(() async {
       setCurrentLogWriter(debug: debug);
       await context.setUp(
@@ -628,7 +645,7 @@ void testAll({
 
     setUp(() => setCurrentLogWriter(debug: debug));
 
-    group('evaluateInFrame', () {
+    group('evaluateInFrame |', () {
       VM vm;
       late Isolate isolate;
       late String isolateId;

--- a/fixtures/_testPackage/web/main.dart
+++ b/fixtures/_testPackage/web/main.dart
@@ -42,6 +42,7 @@ void main() {
     printLoopVariable();
     printObjectMultiLine(); // Breakpoint: callPrintObjectMultiLine
     printNestedObjectsMultiLine(); // Breakpoint: callPrintEnclosingFunctionMultiLine
+    printStream(); // Breakpoint: callPrintStream
   });
 
   document.body.appendText(concatenate('Program', ' is running!'));
@@ -118,6 +119,14 @@ void printObjectMultiLine() {
 
 void printEnclosingObject(EnclosingClass o) {
   print(o); // Breakpoint: printEnclosingObject
+}
+
+void printStream() {
+  var controller = StreamController<int>();
+  var stream = controller.stream.asBroadcastStream();
+  var subscription = stream.listen(print);
+  controller.sink.add(0);
+  subscription.cancel(); // Breakpoint: printStream
 }
 
 ClassWithMethod createObject() {

--- a/fixtures/_testPackageSound/web/main.dart
+++ b/fixtures/_testPackageSound/web/main.dart
@@ -42,6 +42,7 @@ void main() async {
     printGeneric<int>(0);
     printObjectMultiLine(); // Breakpoint: callPrintObjectMultiLine
     printNestedObjectsMultiLine(); // Breakpoint: callPrintEnclosingFunctionMultiLine
+    printStream(); // Breakpoint: callPrintStream
   });
 
   document.body?.appendText(concatenate('Program', ' is running!'));
@@ -127,6 +128,14 @@ void printObjectMultiLine() {
 
 void printEnclosingObject(EnclosingClass o) {
   print(o); // Breakpoint: printEnclosingObject
+}
+
+void printStream() {
+  var controller = StreamController<int>();
+  var stream = controller.stream.asBroadcastStream();
+  var subscription = stream.listen(print);
+  controller.sink.add(0);
+  subscription.cancel(); // Breakpoint: printStream
 }
 
 ClassWithMethod createObject() {


### PR DESCRIPTION
If `dwds` cannot find class metadata for a type mentioned in the `instanceRef`, `vm_service.getObject` fails with a null cast error when trying to get the objects's properties (when populating bound variables).

Make sure we check for null values when we populate the bound variables.

Closes: https://github.com/dart-lang/webdev/issues/1783