### PR TITLE
Use local dwds in webdev

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.7.13-dev
+
 ## 2.7.12
 
 - Migrate Webdev to null-safety.

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.7.12';
+const packageVersion = '2.7.13-dev';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `dart run build_runner build`.
-version: 2.7.12
+version: 2.7.13-dev
 # We should not depend on a dev SDK before publishing.
 # publish_to: none
 description: >-
@@ -50,9 +50,9 @@ dev_dependencies:
   webdriver: ^3.0.0
 
 # Comment out before releasing webdev.
-# dependency_overrides:
-#   dwds:
-#     path: ../dwds
+dependency_overrides:
+  dwds:
+    path: ../dwds
 
 executables:
   webdev:


### PR DESCRIPTION
Use local dwds in webdev to make sure we run e2e tests against current dwds version.