### PR TITLE
Add --enable-experiment flag to webdev commands

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -8,6 +8,7 @@
   metadata.
 - Include the entire exception description up to the stacktrace in
   `mapExceptionStackTrace`.
+- Allow enabling experiments in the expression compiler service.
 
 ## 16.0.1
 

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -68,6 +68,7 @@ class _Compiler {
     String moduleFormat,
     bool soundNullSafety,
     SdkConfiguration sdkConfiguration,
+    List<String> experiments,
     bool verbose,
   ) async {
     sdkConfiguration.validate();
@@ -92,6 +93,7 @@ class _Compiler {
       moduleFormat,
       if (verbose) '--verbose',
       soundNullSafety ? '--sound-null-safety' : '--no-sound-null-safety',
+      for (var experiment in experiments) '--enable-experiment=$experiment',
     ];
 
     _logger.info('Starting...');
@@ -230,14 +232,18 @@ class ExpressionCompilerService implements ExpressionCompiler {
   final _compiler = Completer<_Compiler>();
   final String _address;
   final FutureOr<int> _port;
+  final List<String> experiments;
   final bool _verbose;
 
   final SdkConfigurationProvider _sdkConfigurationProvider;
 
-  ExpressionCompilerService(this._address, this._port,
-      {bool verbose = false,
-      SdkConfigurationProvider? sdkConfigurationProvider})
-      : _verbose = verbose,
+  ExpressionCompilerService(
+    this._address,
+    this._port, {
+    bool verbose = false,
+    SdkConfigurationProvider? sdkConfigurationProvider,
+    this.experiments = const [],
+  })  : _verbose = verbose,
         _sdkConfigurationProvider =
             sdkConfigurationProvider ?? DefaultSdkConfigurationProvider();
 
@@ -265,6 +271,7 @@ class ExpressionCompilerService implements ExpressionCompiler {
       moduleFormat,
       soundNullSafety,
       await _sdkConfigurationProvider.configuration,
+      experiments,
       _verbose,
     );
 

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.7.13-dev
 
+- Add `--enable-experiment` flag to webdev commands and pass it
+  to the build runner and the expression compiler service.
+
 ## 2.7.12
 
 - Migrate Webdev to null-safety.

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -35,6 +35,7 @@ const nullSafetySound = 'sound';
 const nullSafetyUnsound = 'unsound';
 const nullSafetyAuto = 'auto';
 const disableDdsFlag = 'disable-dds';
+const enableExperimentOption = 'enable-experiment';
 
 ReloadConfiguration _parseReloadConfiguration(ArgResults argResults) {
   var auto = argResults.options.contains(autoOption)
@@ -103,6 +104,7 @@ class Configuration {
   final bool? _verbose;
   final bool? _disableDds;
   final String? _nullSafety;
+  final List<String>? _experiments;
 
   Configuration({
     bool? autoRun,
@@ -127,6 +129,7 @@ class Configuration {
     bool? verbose,
     bool? disableDds,
     String? nullSafety,
+    List<String>? experiments,
   })  : _autoRun = autoRun,
         _chromeDebugPort = chromeDebugPort,
         _debugExtension = debugExtension,
@@ -146,7 +149,8 @@ class Configuration {
         _disableDds = disableDds,
         _enableExpressionEvaluation = enableExpressionEvaluation,
         _verbose = verbose,
-        _nullSafety = nullSafety {
+        _nullSafety = nullSafety,
+        _experiments = experiments {
     _validateConfiguration();
   }
 
@@ -219,7 +223,8 @@ class Configuration {
       enableExpressionEvaluation:
           other._enableExpressionEvaluation ?? _enableExpressionEvaluation,
       verbose: other._verbose ?? _verbose,
-      nullSafety: other._nullSafety ?? _nullSafety);
+      nullSafety: other._nullSafety ?? _nullSafety,
+      experiments: other._experiments ?? _experiments);
 
   factory Configuration.noInjectedClientDefaults() =>
       Configuration(autoRun: false, debug: false, debugExtension: false);
@@ -269,6 +274,8 @@ class Configuration {
   /// 'auto' indicates that the default `package:build_web_compilers`
   /// behavior should be used.
   String get nullSafety => _nullSafety ?? 'auto';
+
+  List<String> get experiments => _experiments ?? [];
 
   /// Returns a new configuration with values updated from the parsed args.
   static Configuration fromArgs(ArgResults? argResults,
@@ -385,6 +392,11 @@ class Configuration {
         ? argResults[disableDdsFlag] as bool?
         : defaultConfiguration.disableDds;
 
+    var experiments = argResults.options.contains(enableExperimentOption) &&
+            argResults.wasParsed(enableExperimentOption)
+        ? argResults[enableExperimentOption] as List<String>?
+        : defaultConfiguration.experiments;
+
     return Configuration(
       autoRun: defaultConfiguration.autoRun,
       chromeDebugPort: chromeDebugPort,
@@ -408,6 +420,7 @@ class Configuration {
       enableExpressionEvaluation: enableExpressionEvaluation,
       verbose: verbose,
       nullSafety: nullSafety,
+      experiments: experiments,
     );
   }
 }

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -58,6 +58,11 @@ void addSharedArgs(ArgParser argParser,
         defaultsTo: true,
         negatable: true,
         help: 'Enable expression evaluation features in the debugger.')
+    ..addMultiOption(enableExperimentOption,
+        abbr: 'x',
+        defaultsTo: null,
+        hide: true,
+        help: 'Enable experiment features in the debugger.')
     ..addFlag(verboseFlag,
         abbr: 'v',
         defaultsTo: false,
@@ -89,6 +94,10 @@ List<String> buildRunnerArgs(
       ..add('--define')
       ..add('build_web_compilers:entrypoint=sound_null_safety='
           '${configuration.nullSafety == nullSafetySound}');
+  }
+
+  for (var experiment in configuration.experiments) {
+    arguments.add('--enable-experiment=$experiment');
   }
 
   return arguments;

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -129,6 +129,7 @@ class WebDevServer {
           options.configuration.hostname,
           options.port,
           verbose: options.configuration.verbose,
+          experiments: options.configuration.experiments,
         );
       }
       var shouldServeDevTools =


### PR DESCRIPTION
Add `--enable-experiment` flag to webdev commands and pass it to the expression compiler worker.

Closes: https://github.com/dart-lang/webdev/issues/1790
Replaces: https://github.com/dart-lang/webdev/pull/1792