### PR TITLE
Support `--native-assets` in `FrontendServerClient`

### DIFF
--- a/frontend_server_client/CHANGELOG.md
+++ b/frontend_server_client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.2.0
+
+- Add `nativeAssets` parameter to `FrontendServerClient`, for passing
+  additional `--native-assets` to the kernel compiler.
+
 ## 3.1.0
 
 - Add `additionalSources` parameter to `FrontendServerClient`, for passing

--- a/frontend_server_client/lib/src/frontend_server_client.dart
+++ b/frontend_server_client/lib/src/frontend_server_client.dart
@@ -58,6 +58,7 @@ class FrontendServerClient {
     bool verbose = false, // Verbose logs, including server/client messages
     bool printIncrementalDependencies = true,
     List<String> additionalSources = const [],
+    String? nativeAssets,
   }) async {
     var feServer = await Process.start(Platform.resolvedExecutable, [
       if (debug) '--observe',
@@ -84,6 +85,10 @@ class FrontendServerClient {
       for (var source in additionalSources) ...[
         '--source',
         source,
+      ],
+      if (nativeAssets != null) ...[
+        '--native-assets',
+        nativeAssets,
       ],
     ]);
     var feServerStdoutLines = StreamQueue(feServer.stdout

--- a/frontend_server_client/pubspec.yaml
+++ b/frontend_server_client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: frontend_server_client
-version: 3.1.0
+version: 3.2.0
 description: >-
   Client code to start and interact with the frontend_server compiler from the
   Dart SDK.


### PR DESCRIPTION
https://dart-review.googlesource.com/c/sdk/+/264842 introduces passing `--native-assets` to `gen_kernel`.

This PR exposes this option in the `FrontendServerClient` so that it can be invoked from pub/dartdev which uses this API.