### PR TITLE
Add a `logger` to the MV3 debug extension

### DIFF
--- a/dwds/debug_extension_mv3/web/background.dart
+++ b/dwds/debug_extension_mv3/web/background.dart
@@ -15,6 +15,7 @@ import 'package:js/js.dart';
 import 'chrome_api.dart';
 import 'data_types.dart';
 import 'lifeline_ports.dart';
+import 'logger.dart';
 import 'messaging.dart';
 import 'storage.dart';
 import 'web_api.dart';
@@ -68,6 +69,7 @@ Future<bool> _authenticateUser(String extensionUrl, int tabId) async {
   final response = await fetchRequest(authUrl);
   final responseBody = response.body ?? '';
   if (!responseBody.contains(_authSuccessResponse)) {
+    debugWarn('Not authenticated: ${response.status} / $responseBody');
     _showWarningNotification('Please re-authenticate and try again.');
     await _createTab(authUrl, inNewWindow: false);
     return false;
@@ -98,7 +100,7 @@ void _handleRuntimeMessages(
       messageHandler: (DebugInfo debugInfo) async {
         final dartTab = sender.tab;
         if (dartTab == null) {
-          console.warn('Received debug info but tab is missing.');
+          debugWarn('Received debug info but tab is missing.');
           return;
         }
         // Save the debug info for the Dart app in storage:

--- a/dwds/debug_extension_mv3/web/detector.dart
+++ b/dwds/debug_extension_mv3/web/detector.dart
@@ -10,8 +10,8 @@ import 'dart:js_util';
 import 'package:js/js.dart';
 
 import 'chrome_api.dart';
+import 'logger.dart';
 import 'messaging.dart';
-import 'web_api.dart';
 
 void main() {
   _registerListeners();
@@ -24,7 +24,7 @@ void _registerListeners() {
 void _onDartAppReadyEvent(Event event) {
   final debugInfo = getProperty(event, 'detail') as String?;
   if (debugInfo == null) {
-    console.warn('Can\'t debug Dart app without debug info.');
+    debugWarn('Can\'t debug Dart app without debug info.');
     return;
   }
   _sendMessageToBackgroundScript(

--- a/dwds/debug_extension_mv3/web/lifeline_connection.dart
+++ b/dwds/debug_extension_mv3/web/lifeline_connection.dart
@@ -3,15 +3,17 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'chrome_api.dart';
-import 'web_api.dart';
+import 'logger.dart';
 
 void main() async {
   _connectToLifelinePort();
 }
 
 void _connectToLifelinePort() {
-  console.log(
-      '[Dart Debug Extension] Connecting to lifeline port at ${_currentTime()}.');
+  debugLog(
+    'Connecting to lifeline port at ${_currentTime()}.',
+    prefix: 'Dart Debug Extension',
+  );
   chrome.runtime.connect(
     /*extensionId=*/ null,
     ConnectInfo(name: 'keepAlive'),

--- a/dwds/debug_extension_mv3/web/lifeline_ports.dart
+++ b/dwds/debug_extension_mv3/web/lifeline_ports.dart
@@ -12,7 +12,7 @@ import 'dart:async';
 import 'package:js/js.dart';
 
 import 'chrome_api.dart';
-import 'web_api.dart';
+import 'logger.dart';
 
 // Switch to true to enable debug logs.
 // TODO(elliette): Enable / disable with flag while building the extension.
@@ -26,18 +26,18 @@ void maybeCreateLifelinePort(int tabId) {
   // Keep track of current Dart tabs that are being debugged. This way if one of
   // them is closed, we can reconnect the lifeline port to another one:
   dartTabs.add(tabId);
-  _debugLog('Dart tabs are: $dartTabs');
+  debugLog('Dart tabs are: $dartTabs');
   // Don't create a lifeline port if we already have one (meaning another Dart
   // app is currently being debugged):
   if (lifelinePort != null) {
-    _debugWarn('Port already exists.');
+    debugWarn('Port already exists.');
     return;
   }
   // Start the keep-alive logic when the port connects:
   chrome.runtime.onConnect.addListener(allowInterop(_keepLifelinePortAlive));
   // Inject the connection script into the current Dart tab, that way the tab
   // will connect to the port:
-  _debugLog('Creating lifeline port.');
+  debugLog('Creating lifeline port.');
   lifelineTab = tabId;
   chrome.scripting.executeScript(
     InjectDetails(
@@ -52,17 +52,17 @@ void maybeRemoveLifelinePort(int removedTabId) {
   final removedDartTab = dartTabs.remove(removedTabId);
   // If the removed tab was not a Dart tab, return early.
   if (!removedDartTab) return;
-  _debugLog('Removed tab $removedTabId, Dart tabs are now $dartTabs.');
+  debugLog('Removed tab $removedTabId, Dart tabs are now $dartTabs.');
   // If the removed Dart tab hosted the lifeline port connection, see if there
   // are any other Dart tabs to connect to. Otherwise disconnect the port.
   if (lifelineTab == removedTabId) {
     if (dartTabs.isEmpty) {
       lifelineTab = null;
-      _debugLog('No more Dart tabs, disconnecting from lifeline port.');
+      debugLog('No more Dart tabs, disconnecting from lifeline port.');
       _disconnectFromLifelinePort();
     } else {
       lifelineTab = dartTabs.last;
-      _debugLog('Reconnecting lifeline port to a new Dart tab: $lifelineTab.');
+      debugLog('Reconnecting lifeline port to a new Dart tab: $lifelineTab.');
       _reconnectToLifelinePort();
     }
   }
@@ -75,45 +75,33 @@ void _keepLifelinePortAlive(Port port) {
   // Reconnect to the lifeline port every 5 minutes, as per:
   // https://bugs.chromium.org/p/chromium/issues/detail?id=1146434#c6
   Timer(Duration(minutes: 5), () {
-    _debugLog('5 minutes have elapsed, therefore reconnecting.');
+    debugLog('5 minutes have elapsed, therefore reconnecting.');
     _reconnectToLifelinePort();
   });
 }
 
 void _reconnectToLifelinePort() {
-  _debugLog('Reconnecting...');
+  debugLog('Reconnecting...');
   if (lifelinePort == null) {
-    _debugWarn('Could not find a lifeline port.');
+    debugWarn('Could not find a lifeline port.');
     return;
   }
   if (lifelineTab == null) {
-    _debugWarn('Could not find a lifeline tab.');
+    debugWarn('Could not find a lifeline tab.');
     return;
   }
   // Disconnect from the port, and then recreate the connection with the current
   // Dart tab:
   _disconnectFromLifelinePort();
   maybeCreateLifelinePort(lifelineTab!);
-  _debugLog('Reconnection complete.');
+  debugLog('Reconnection complete.');
 }
 
 void _disconnectFromLifelinePort() {
-  _debugLog('Disconnecting...');
+  debugLog('Disconnecting...');
   if (lifelinePort != null) {
     lifelinePort!.disconnect();
     lifelinePort = null;
-    _debugLog('Disconnection complete.');
-  }
-}
-
-void _debugLog(String msg) {
-  if (enableDebugLogging) {
-    console.log(msg);
-  }
-}
-
-void _debugWarn(String msg) {
-  if (enableDebugLogging) {
-    console.warn(msg);
+    debugLog('Disconnection complete.');
   }
 }

--- a/dwds/debug_extension_mv3/web/logger.dart
+++ b/dwds/debug_extension_mv3/web/logger.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@JS()
+library logger;
+
+import 'package:js/js.dart';
+
+import 'web_api.dart';
+
+// Switch to true for debug logging.
+bool _enableDebugLogging = true;
+
+enum _LogLevel {
+  info,
+  warn,
+  error,
+}
+
+debugLog(String msg, {String? prefix}) {
+  _log(msg, prefix: prefix);
+}
+
+debugWarn(String msg, {String? prefix}) {
+  _log(msg, prefix: prefix, level: _LogLevel.warn);
+}
+
+debugError(String msg, {String? prefix}) {
+  _log(msg, prefix: prefix, level: _LogLevel.error);
+}
+
+void _log(String msg, {_LogLevel? level, String? prefix}) {
+  if (!_enableDebugLogging) return;
+  final logMsg = prefix != null ? '[$prefix] $msg' : msg;
+  final logLevel = level ?? _LogLevel.info;
+  switch (logLevel) {
+    case _LogLevel.error:
+      console.error(logMsg);
+      break;
+    case _LogLevel.warn:
+      console.warn(logMsg);
+      break;
+    case _LogLevel.info:
+      console.log(logMsg);
+  }
+}

--- a/dwds/debug_extension_mv3/web/messaging.dart
+++ b/dwds/debug_extension_mv3/web/messaging.dart
@@ -10,7 +10,7 @@ import 'dart:convert';
 import 'package:dwds/data/serializers.dart';
 import 'package:js/js.dart';
 
-import 'web_api.dart';
+import 'logger.dart';
 
 enum Script {
   background,
@@ -85,7 +85,7 @@ void interceptMessage<T>({
     messageHandler(
         serializers.deserialize(jsonDecode(decodedMessage.body)) as T);
   } catch (error) {
-    console.warn(
+    debugError(
         'Error intercepting $expectedType from $expectedSender to $expectedRecipient: $error');
   }
 }

--- a/dwds/debug_extension_mv3/web/storage.dart
+++ b/dwds/debug_extension_mv3/web/storage.dart
@@ -13,10 +13,7 @@ import 'package:js/js.dart';
 
 import 'chrome_api.dart';
 import 'data_serializers.dart';
-import 'web_api.dart';
-
-/// Switch to true for debug logging.
-bool enableDebugLogging = true;
+import 'logger.dart';
 
 enum StorageObject {
   debugInfo,
@@ -46,7 +43,7 @@ Future<bool> setStorageObject<T>({
     if (callback != null) {
       callback();
     }
-    _debugLog(storageKey, 'Set: $json');
+    debugLog('Set: $json', prefix: storageKey);
     completer.complete(true);
   }));
   return completer.future;
@@ -58,11 +55,11 @@ Future<T?> fetchStorageObject<T>({required StorageObject type, int? tabId}) {
   chrome.storage.local.get([storageKey], allowInterop((Object storageObj) {
     final json = getProperty(storageObj, storageKey) as String?;
     if (json == null) {
-      _debugWarn(storageKey, 'Does not exist.');
+      debugWarn('Does not exist.', prefix: storageKey);
       completer.complete(null);
     } else {
       final value = serializers.deserialize(jsonDecode(json)) as T;
-      _debugLog(storageKey, 'Fetched: $json');
+      debugLog('Fetched: $json', prefix: storageKey);
       completer.complete(value);
     }
   }));
@@ -72,16 +69,4 @@ Future<T?> fetchStorageObject<T>({required StorageObject type, int? tabId}) {
 String _createStorageKey(StorageObject type, int? tabId) {
   if (tabId == null) return type.keyName;
   return '$tabId-${type.keyName}';
-}
-
-void _debugLog(String storageKey, String msg) {
-  if (enableDebugLogging) {
-    console.log('[$storageKey] $msg');
-  }
-}
-
-void _debugWarn(String storageKey, String msg) {
-  if (enableDebugLogging) {
-    console.warn('[$storageKey] $msg');
-  }
 }

--- a/dwds/debug_extension_mv3/web/web_api.dart
+++ b/dwds/debug_extension_mv3/web/web_api.dart
@@ -17,6 +17,9 @@ class Console {
 
   external void warn(String header,
       [String style1, String style2, String style3]);
+
+  external void error(String header,
+      [String style1, String style2, String style3]);
 }
 
 // Custom implementation of Fetch API until the Dart implementation supports


### PR DESCRIPTION
Instead of each file separately setting their logger, have a single `logger` that can be used everywhere.