### PR TITLE
Updates the `fixture` package `pubspecs` so it is clear what shouldn't be migrated to null-safety

### DIFF
--- a/fixtures/_test/pubspec.yaml
+++ b/fixtures/_test/pubspec.yaml
@@ -1,7 +1,10 @@
+# This code is for testing that the debugger works with weak null-safety
+# so we should not migrate it to null-safety.
+# TODO(elliette): Once Dart 3.0 is released, delete this directory.
 name: _test
 version: 1.0.0
 description: >-
-  A fake package used for testing
+  A fake package used for testing weak null-safety.
 publish_to: none
 
 environment:

--- a/fixtures/_test/pubspec.yaml
+++ b/fixtures/_test/pubspec.yaml
@@ -1,6 +1,7 @@
 # This code is for testing that the debugger works with weak null-safety
 # so we should not migrate it to null-safety.
-# TODO(elliette): Once Dart 3.0 is released, delete this directory.
+# TODO(elliette): Delete this directory post Dart 3.0 (when we no longer
+# support weak null-safety).
 name: _test
 version: 1.0.0
 description: >-

--- a/fixtures/_testCircular1/pubspec.yaml
+++ b/fixtures/_testCircular1/pubspec.yaml
@@ -1,7 +1,10 @@
+# This code is for testing that the debugger works with weak null-safety
+# so we should not migrate it to null-safety.
+# TODO(elliette): Once Dart 3.0 is released, delete this directory.
 name: _test_circular1
 version: 1.0.0
 description: >-
-  A fake package used for testing
+  A fake package used for testing weak null-safety.
 publish_to: none
 
 environment:

--- a/fixtures/_testCircular1/pubspec.yaml
+++ b/fixtures/_testCircular1/pubspec.yaml
@@ -1,6 +1,7 @@
 # This code is for testing that the debugger works with weak null-safety
 # so we should not migrate it to null-safety.
-# TODO(elliette): Once Dart 3.0 is released, delete this directory.
+# TODO(elliette): Delete this directory post Dart 3.0 (when we no longer
+# support weak null-safety).
 name: _test_circular1
 version: 1.0.0
 description: >-

--- a/fixtures/_testCircular1Sound/pubspec.yaml
+++ b/fixtures/_testCircular1Sound/pubspec.yaml
@@ -1,4 +1,3 @@
-# TODO(elliette): Migrate to sound null-safety.
 name: _test_circular1_sound
 version: 1.0.0
 description: >-

--- a/fixtures/_testCircular1Sound/pubspec.yaml
+++ b/fixtures/_testCircular1Sound/pubspec.yaml
@@ -1,7 +1,8 @@
+# TODO(elliette): Migrate to sound null-safety.
 name: _test_circular1_sound
 version: 1.0.0
 description: >-
-  A fake package used for testing
+  A fake package used for testing sound null-safety.
 publish_to: none
 
 environment:

--- a/fixtures/_testCircular1Sound/pubspec.yaml
+++ b/fixtures/_testCircular1Sound/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=2.5.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   intl: ^0.16.0

--- a/fixtures/_testCircular2/pubspec.yaml
+++ b/fixtures/_testCircular2/pubspec.yaml
@@ -1,10 +1,10 @@
+# This code is for testing that the debugger works with weak null-safety
+# so we should not migrate it to null-safety.
+# TODO(elliette): Once Dart 3.0 is released, delete this directory.
 name: _test_circular2
 version: 1.0.0
 description: >-
-  A fake package used for testing imports. Imports _test.
-  This code is for testing that debugger works with weak null safety so we
-  should not migrate it to null safety. Once Dart 3.0 is released, we should
-  delete this directory.
+  A fake package used for testing imports with weak null-safety. Imports _test.
 publish_to: none
 
 environment:

--- a/fixtures/_testCircular2/pubspec.yaml
+++ b/fixtures/_testCircular2/pubspec.yaml
@@ -1,6 +1,7 @@
 # This code is for testing that the debugger works with weak null-safety
 # so we should not migrate it to null-safety.
-# TODO(elliette): Once Dart 3.0 is released, delete this directory.
+# TODO(elliette): Delete this directory post Dart 3.0 (when we no longer
+# support weak null-safety).
 name: _test_circular2
 version: 1.0.0
 description: >-

--- a/fixtures/_testCircular2Sound/pubspec.yaml
+++ b/fixtures/_testCircular2Sound/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   _test_circular1_sound:

--- a/fixtures/_testCircular2Sound/pubspec.yaml
+++ b/fixtures/_testCircular2Sound/pubspec.yaml
@@ -1,10 +1,8 @@
+# TODO(elliette): Migrate to sound null-safety.
 name: _test_circular2_sound
 version: 1.0.0
 description: >-
-  A fake package used for testing imports. Imports _test.
-  This code is for testing that debugger works with weak null safety so we
-  should not migrate it to null safety. Once Dart 3.0 is released, we should
-  delete this directory.
+  A fake package used for testing imports with sound null-safety. Imports _test.
 publish_to: none
 
 environment:

--- a/fixtures/_testCircular2Sound/pubspec.yaml
+++ b/fixtures/_testCircular2Sound/pubspec.yaml
@@ -1,4 +1,3 @@
-# TODO(elliette): Migrate to sound null-safety.
 name: _test_circular2_sound
 version: 1.0.0
 description: >-

--- a/fixtures/_testCircular2Sound/web/main.dart
+++ b/fixtures/_testCircular2Sound/web/main.dart
@@ -15,5 +15,5 @@ void main() {
     testCircularDependencies();
   });
 
-  document.body.appendText(concatenate('Program', ' is running!'));
+  document.body!.appendText(concatenate('Program', ' is running!'));
 }

--- a/fixtures/_testPackage/pubspec.yaml
+++ b/fixtures/_testPackage/pubspec.yaml
@@ -1,10 +1,10 @@
+# This code is for testing that the debugger works with weak null-safety
+# so we should not migrate it to null-safety.
+# TODO(elliette): Once Dart 3.0 is released, delete this directory.
 name: _test_package
 version: 1.0.0
 description: >-
-  A fake package used for testing imports. Imports _test.
-  This code is for testing that debugger works with weak null safety so we
-  should not migrate it to null safety. Once Dart 3.0 is released, we should
-  delete this directory.
+  A fake package used for testing imports with weak null-safety. Imports _test.
 publish_to: none
 
 environment:

--- a/fixtures/_testPackage/pubspec.yaml
+++ b/fixtures/_testPackage/pubspec.yaml
@@ -1,6 +1,7 @@
 # This code is for testing that the debugger works with weak null-safety
 # so we should not migrate it to null-safety.
-# TODO(elliette): Once Dart 3.0 is released, delete this directory.
+# TODO(elliette): Delete this directory post Dart 3.0 (when we no longer
+# support weak null-safety).
 name: _test_package
 version: 1.0.0
 description: >-

--- a/fixtures/_testPackageSound/pubspec.yaml
+++ b/fixtures/_testPackageSound/pubspec.yaml
@@ -1,7 +1,7 @@
 name: _test_package_sound
 version: 1.0.0
 description: >-
-  A fake package used for testing imports. Imports _test.
+  A fake package used for testing imports with sound null-safety. Imports _test.
 publish_to: none
 
 environment:

--- a/fixtures/_testSound/pubspec.yaml
+++ b/fixtures/_testSound/pubspec.yaml
@@ -1,7 +1,7 @@
 name: _test_sound
 version: 1.0.0
 description: >-
-  A fake package used for testing
+  A fake package used for testing sound null-safety.
 publish_to: none
 
 environment:

--- a/fixtures/_webdevSmoke/pubspec.yaml
+++ b/fixtures/_webdevSmoke/pubspec.yaml
@@ -1,9 +1,9 @@
+# This code is for testing that the debugger works with weak null-safety
+# so we should not migrate it to null-safety.
+# TODO(elliette): Once Dart 3.0 is released, delete
 name: _webdev_smoke
 description:
-  A test fixture for webdev testing.
-  This code is for testing that debugger works with weak null safety so we
-  should not migrate it to null safety. Once Dart 3.0 is released, we should
-  delete this directory.
+  A test fixture for webdev testing with weak null-safety.
 
 
 # The versions in this pubspec should match the requirements

--- a/fixtures/_webdevSmoke/pubspec.yaml
+++ b/fixtures/_webdevSmoke/pubspec.yaml
@@ -1,6 +1,6 @@
 # This code is for testing that the debugger works with weak null-safety
 # so we should not migrate it to null-safety.
-# TODO(elliette): Once Dart 3.0 is released, delete
+# TODO(elliette): Once Dart 3.0 is released, delete this directory.
 name: _webdev_smoke
 description:
   A test fixture for webdev testing with weak null-safety.

--- a/fixtures/_webdevSmoke/pubspec.yaml
+++ b/fixtures/_webdevSmoke/pubspec.yaml
@@ -1,6 +1,7 @@
 # This code is for testing that the debugger works with weak null-safety
 # so we should not migrate it to null-safety.
-# TODO(elliette): Once Dart 3.0 is released, delete this directory.
+# TODO(elliette): Delete this directory post Dart 3.0 (when we no longer
+# support weak null-safety).
 name: _webdev_smoke
 description:
   A test fixture for webdev testing with weak null-safety.


### PR DESCRIPTION

Also runs the migration tool on `testCircular1Sound` and `testCircular2Sound` because it was complaining those weren't migrated.