### PR TITLE
`DebugSession` listens to events instead of just sending events

### DIFF
--- a/dwds/debug_extension_mv3/web/debug_session.dart
+++ b/dwds/debug_extension_mv3/web/debug_session.dart
@@ -150,7 +150,7 @@ Future<bool> _connectToDwds({
   _debugSessions.add(debugSession);
   final tabUrl = await _getTabUrl(dartAppTabId);
   // Send a DevtoolsRequest to the event stream:
-  debugSession.sendEvent<DevToolsRequest>(DevToolsRequest((b) => b
+  debugSession.sendEvent(DevToolsRequest((b) => b
     ..appId = debugInfo.appId
     ..instanceId = debugInfo.appInstanceId
     ..contextId = dartAppContextId
@@ -208,7 +208,7 @@ void _forwardChromeDebuggerEventToDwds(
   if (method == 'Debugger.scriptParsed') {
     debugSession.sendBatchedEvent(event);
   } else {
-    debugSession.sendEvent<ExtensionEvent>(event);
+    debugSession.sendEvent(event);
   }
 }
 
@@ -265,7 +265,7 @@ void _removeDebugSession(_DebugSession debugSession) {
   // https://github.com/dart-lang/webdev/pull/1595#issuecomment-1116773378
   final event =
       _extensionEventFor('DebugExtension.detached', js_util.jsify({}));
-  debugSession.sendEvent<ExtensionEvent>(event);
+  debugSession.sendEvent(event);
   debugSession.close();
   final removed = _debugSessions.remove(debugSession);
   if (!removed) {

--- a/dwds/debug_extension_mv3/web/debug_session.dart
+++ b/dwds/debug_extension_mv3/web/debug_session.dart
@@ -323,9 +323,9 @@ class _DebugSession {
   _DebugSession({
     required client,
     required this.appTabId,
-    required void onIncoming(String data),
-    required void onDone(),
-    required void onError(dynamic error),
+    required void Function(String data) onIncoming,
+    required void Function() onDone,
+    required void Function(dynamic error) onError,
     required bool cancelOnError,
   }) : _socketClient = client {
     // Collect extension events and send them periodically to the server.


### PR DESCRIPTION
Small refactor of the `DebugSession`:
- it both listens to and sends events to the SSE/WS connection 
- it can send any event, not just `ExtensionEvent`s