### PR TITLE
Fix global variable `isInternalBuild` in injected client

### DIFF
--- a/dwds/lib/dart_web_debug_service.dart
+++ b/dwds/lib/dart_web_debug_service.dart
@@ -128,6 +128,7 @@ class Dwds {
       extensionUri: extensionUri,
       enableDevtoolsLaunch: enableDevtoolsLaunch,
       emitDebugEvents: emitDebugEvents,
+      isInternalBuild: isInternalBuild,
     );
 
     final devHandler = DevHandler(

--- a/dwds/lib/src/injected/client.js
+++ b/dwds/lib/src/injected/client.js
@@ -25187,7 +25187,7 @@
       b.get$_$this()._appUrl = t2;
       t2 = A._asStringQ(t1.$index(0, "$dartExtensionUri"));
       b.get$_$this()._extensionUrl = t2;
-      t1 = A._asBoolQ(t1.$index(0, "$isInternalDartBuild"));
+      t1 = A._asBoolQ(t1.$index(0, "$isInternalBuild"));
       b.get$_$this()._isInternalBuild = t1;
       return b;
     },

--- a/dwds/test/handlers/injector_test.dart
+++ b/dwds/test/handlers/injector_test.dart
@@ -199,11 +199,10 @@ void main() {
       expect(result.body, contains('\$emitRegisterEvent'));
     });
 
-    test('the injected client contains a global \$isInternalDartBuild',
-        () async {
+    test('the injected client contains a global \$isInternalBuild', () async {
       final result = await http.get(Uri.parse(
           'http://localhost:${server.port}/dwds/src/injected/client.js'));
-      expect(result.body, contains('\$isInternalDartBuild'));
+      expect(result.body, contains('\$isInternalBuild'));
     });
 
     test('serves the injected client', () async {

--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -87,6 +87,7 @@ void main() async {
           expect(debugInfo.appInstanceId, isNotNull);
           expect(debugInfo.appOrigin, isNotNull);
           expect(debugInfo.appUrl, isNotNull);
+          expect(debugInfo.isInternalBuild, isNotNull);
           await appTab.close();
         });
 

--- a/dwds/web/client.dart
+++ b/dwds/web/client.dart
@@ -181,7 +181,7 @@ Future<void>? main() {
       ..appOrigin = window.location.origin
       ..appUrl = window.location.href
       ..extensionUrl = windowContext['\$dartExtensionUri']
-      ..isInternalBuild = windowContext['\$isInternalDartBuild'])));
+      ..isInternalBuild = windowContext['\$isInternalBuild'])));
 
     dispatchEvent(CustomEvent('dart-app-ready', detail: debugInfoJson));
   }, (error, stackTrace) {
@@ -275,7 +275,7 @@ external set emitDebugEvent(void Function(String, String) func);
 @JS(r'$emitRegisterEvent')
 external set emitRegisterEvent(void Function(String) func);
 
-@JS(r'$isInternalDartBuild')
-external bool get isInternalDartBuild;
+@JS(r'$isInternalBuild')
+external bool get isInternalBuild;
 
 bool get _isChromium => window.navigator.vendor.contains('Google');


### PR DESCRIPTION
The global variable was incorrectly called `isInternalDartBuild` not `isInternalBuild`