### PR TITLE
Can save storage objects in both `session` and `local` storage

### DIFF
--- a/dwds/debug_extension_mv3/web/storage.dart
+++ b/dwds/debug_extension_mv3/web/storage.dart
@@ -28,17 +28,17 @@ enum StorageObject {
     }
   }
 
-  _Persistance get persistance {
+  Persistance get persistance {
     switch (this) {
       case StorageObject.debugInfo:
-        return _Persistance.sessionOnly;
+        return Persistance.sessionOnly;
       case StorageObject.devToolsOpener:
-        return _Persistance.acrossSessions;
+        return Persistance.acrossSessions;
     }
   }
 }
 
-enum _Persistance {
+enum Persistance {
   sessionOnly,
   acrossSessions;
 }
@@ -82,15 +82,15 @@ Future<T?> fetchStorageObject<T>({required StorageObject type, int? tabId}) {
   return completer.future;
 }
 
-StorageArea _getStorageArea(_Persistance persistance) {
+StorageArea _getStorageArea(Persistance persistance) {
   switch (persistance) {
-    case _Persistance.acrossSessions:
+    case Persistance.acrossSessions:
       return chrome.storage.local;
-    case _Persistance.sessionOnly:
+    case Persistance.sessionOnly:
       return chrome.storage.session;
   }
 }
- 
+
 String _createStorageKey(StorageObject type, int? tabId) {
   if (tabId == null) return type.keyName;
   return '$tabId-${type.keyName}';

--- a/dwds/debug_extension_mv3/web/storage.dart
+++ b/dwds/debug_extension_mv3/web/storage.dart
@@ -27,6 +27,20 @@ enum StorageObject {
         return 'devToolsOpener';
     }
   }
+
+  _Persistance get persistance {
+    switch (this) {
+      case StorageObject.debugInfo:
+        return _Persistance.sessionOnly;
+      case StorageObject.devToolsOpener:
+        return _Persistance.acrossSessions;
+    }
+  }
+}
+
+enum _Persistance {
+  sessionOnly,
+  acrossSessions;
 }
 
 Future<bool> setStorageObject<T>({
@@ -39,7 +53,8 @@ Future<bool> setStorageObject<T>({
   final json = jsonEncode(serializers.serialize(value));
   final storageObj = <String, String>{storageKey: json};
   final completer = Completer<bool>();
-  chrome.storage.local.set(jsify(storageObj), allowInterop(() {
+  final storageArea = _getStorageArea(type.persistance);
+  storageArea.set(jsify(storageObj), allowInterop(() {
     if (callback != null) {
       callback();
     }
@@ -52,7 +67,8 @@ Future<bool> setStorageObject<T>({
 Future<T?> fetchStorageObject<T>({required StorageObject type, int? tabId}) {
   final storageKey = _createStorageKey(type, tabId);
   final completer = Completer<T?>();
-  chrome.storage.local.get([storageKey], allowInterop((Object storageObj) {
+  final storageArea = _getStorageArea(type.persistance);
+  storageArea.get([storageKey], allowInterop((Object storageObj) {
     final json = getProperty(storageObj, storageKey) as String?;
     if (json == null) {
       debugWarn('Does not exist.', prefix: storageKey);
@@ -66,6 +82,15 @@ Future<T?> fetchStorageObject<T>({required StorageObject type, int? tabId}) {
   return completer.future;
 }
 
+StorageArea _getStorageArea(_Persistance persistance) {
+  switch (persistance) {
+    case _Persistance.acrossSessions:
+      return chrome.storage.local;
+    case _Persistance.sessionOnly:
+      return chrome.storage.session;
+  }
+}
+ 
 String _createStorageKey(StorageObject type, int? tabId) {
   if (tabId == null) return type.keyName;
   return '$tabId-${type.keyName}';

--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -84,8 +84,7 @@ void main() async {
           final tabIdForAppJs = _tabIdForTabJs(appUrl);
           final appTabId = (await worker.evaluate(tabIdForAppJs)) as int;
           final debugInfoKey = '$appTabId-debugInfo';
-          final storageObj =
-              await worker.evaluate(
+          final storageObj = await worker.evaluate(
               _fetchStorageObjJs(debugInfoKey, storageArea: 'session'));
           final json = storageObj[debugInfoKey];
           final debugInfo =


### PR DESCRIPTION
* `DebugInfo` for an app is saved in `session` storage, so it does not persist across sessions
* `DevToolsOpener` setting is saved in `local` storage, so it persists across sessions

See https://developer.chrome.com/docs/extensions/reference/storage/#type-StorageArea for details on `session` vs `local` storage