### PR TITLE
Gracefully handle debugger disconnect events

### DIFF
--- a/dwds/debug_extension_mv3/web/chrome_api.dart
+++ b/dwds/debug_extension_mv3/web/chrome_api.dart
@@ -17,6 +17,7 @@ class Chrome {
   external Scripting get scripting;
   external Storage get storage;
   external Tabs get tabs;
+  external WebNavigation get webNavigation;
   external Windows get windows;
 }
 
@@ -53,7 +54,7 @@ class Debugger {
   external void attach(
       Debuggee target, String requiredVersion, Function? callback);
 
-  external void detach(Debuggee target, Function? callback);
+  external Object detach(Debuggee target);
 
   external void sendCommand(Debuggee target, String method,
       Object? commandParams, Function? callback);
@@ -218,6 +219,8 @@ class StorageArea {
   external Object get(List<String> keys, void Function(Object result) callback);
 
   external Object set(Object items, void Function()? callback);
+
+  external Object remove(List<String> keys, void Function()? callback);
 }
 
 /// chrome.tabs APIs
@@ -279,6 +282,30 @@ class QueryInfo {
 @anonymous
 class Tab {
   external int get id;
+  external String get url;
+}
+
+/// chrome.webNavigation APIs
+/// https://developer.chrome.com/docs/extensions/reference/webNavigation
+
+@JS()
+@anonymous
+class WebNavigation {
+  // https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onCommitted
+  external OnCommittedHandler get onCommitted;
+}
+
+@JS()
+@anonymous
+class OnCommittedHandler {
+  external void addListener(void Function(NavigationInfo details) callback);
+}
+
+@JS()
+@anonymous
+class NavigationInfo {
+  external String get transitionType;
+  external int get tabId;
   external String get url;
 }
 

--- a/dwds/debug_extension_mv3/web/manifest.json
+++ b/dwds/debug_extension_mv3/web/manifest.json
@@ -10,7 +10,8 @@
         "notifications",
         "scripting",
         "storage",
-        "tabs"
+        "tabs",
+        "webNavigation"
     ],
     "host_permissions": [
         "<all_urls>"

--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -154,7 +154,8 @@ void main() async {
           await appTab.close();
         });
 
-        test('Navigating away from the Dart app while debugging closes DevTools',
+        test(
+            'Navigating away from the Dart app while debugging closes DevTools',
             () async {
           final appUrl = context.appUrl;
           final devToolsUrlFragment =
@@ -177,8 +178,7 @@ void main() async {
           await devToolsTabTarget.onClose;
         });
 
-        test('Closing the Dart app while debugging closes DevTools',
-            () async {
+        test('Closing the Dart app while debugging closes DevTools', () async {
           final appUrl = context.appUrl;
           final devToolsUrlFragment =
               useSse ? 'debugger?uri=sse' : 'debugger?uri=ws';

--- a/dwds/test/puppeteer/js_functions.js
+++ b/dwds/test/puppeteer/js_functions.js
@@ -1,5 +1,0 @@
-async () => {
-    const targets = await chrome.debugger.getTargets();
-    const tab = targets.filter((target) => target.id == tabId);
-    return tab.attached;
-  }

--- a/dwds/test/puppeteer/js_functions.js
+++ b/dwds/test/puppeteer/js_functions.js
@@ -1,0 +1,5 @@
+async () => {
+    const targets = await chrome.debugger.getTargets();
+    const tab = targets.filter((target) => target.id == tabId);
+    return tab.attached;
+  }


### PR DESCRIPTION
Navigating away from the Dart app or closing the Dart app while it is being debugged detaches the debugger and closes Dart DevTools.