### PR TITLE
Refactor puppeteer tests to use `Worker` type

### DIFF
--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -52,7 +52,7 @@ dev_dependencies:
   js: ^0.6.4
   lints: ^2.0.0
   pubspec_parse: ^1.2.0
-  puppeteer: ^2.17.0
+  puppeteer: ^2.18.0
   stream_channel: ^2.1.0
   test: ^1.21.1
   webdriver: ^3.0.0

--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -27,7 +27,7 @@ final context = TestContext();
 const executionContextDelay = 1;
 
 void main() async {
-  late Target serviceWorkerTarget;
+  late Worker worker;
   late Browser browser;
   late String extensionPath;
 
@@ -57,8 +57,10 @@ void main() async {
             ],
           );
 
-          serviceWorkerTarget = await browser
+          final serviceWorkerTarget = await browser
               .waitForTarget((target) => target.type == 'service_worker');
+          worker = (await serviceWorkerTarget.worker)!;
+          await Future.delayed(Duration(seconds: executionContextDelay));
         });
 
         tearDownAll(() async {
@@ -71,8 +73,6 @@ void main() async {
           // Navigate to the Dart app:
           final appTab =
               await navigateToPage(browser, url: appUrl, isNew: true);
-          final worker = (await serviceWorkerTarget.worker)!;
-          await Future.delayed(Duration(seconds: executionContextDelay));
           // Verify that we have debug info for the Dart app:
           final tabIdForAppJs = _tabIdForTabJs(appUrl);
           final appTabId = (await worker.evaluate(tabIdForAppJs)) as int;
@@ -102,8 +102,6 @@ void main() async {
           final appTab =
               await navigateToPage(browser, url: appUrl, isNew: true);
           // Click on the Dart Debug Extension icon:
-          final worker = (await serviceWorkerTarget.worker)!;
-          await Future.delayed(Duration(seconds: executionContextDelay));
           await worker.evaluate(clickIconJs);
           // Verify the extension opened the Dart docs in the same window:
           var devToolsTabTarget = await browser.waitForTarget(

--- a/dwds/test/puppeteer/test_utils.dart
+++ b/dwds/test/puppeteer/test_utils.dart
@@ -24,6 +24,17 @@ Future<String> buildDebugExtension() async {
   return '$extensionDir/compiled';
 }
 
+Future<void> clickOnExtensionIcon(Worker worker) async {
+  return worker.evaluate(_clickIconJs);
+}
+
+// Note: The following delay is required to reduce flakiness. It makes
+// sure the service worker execution context is ready.
+Future<void> workerEvalDelay() async {
+  await Future.delayed(Duration(seconds: 1));
+  return;
+}
+
 Future<Page> navigateToPage(
   Browser browser, {
   required String url,
@@ -60,7 +71,7 @@ Future<Page> _getPageForUrl(Browser browser, {required String url}) {
   return pageTarget.page;
 }
 
-final clickIconJs = '''
+final _clickIconJs = '''
   async () => {
     const activeTabs = await chrome.tabs.query({ active: true });
     const tab = activeTabs[0];


### PR DESCRIPTION
The `Worker` type is now visible in `package:puppeteer` (https://github.com/xvrh/puppeteer-dart/issues/198)

This PR refactors to the Puppeteer tests to remove some code duplication now that we have access to the `Worker` type.