### PR TITLE
Small fix to the extension test

### DIFF
--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -133,7 +133,7 @@ void main() async {
           // Verify the extension opened the Dart docs in the same window:
           var devToolsTabTarget = await browser.waitForTarget(
               (target) => target.url.contains(devToolsUrlFragment));
-          final devToolsPage = await devToolsTabTarget.page;
+          var devToolsPage = await devToolsTabTarget.page;
           var devToolsWindowId = await _getWindowId(
             devToolsPage.url!,
             worker: worker,
@@ -164,6 +164,8 @@ void main() async {
           // Verify the extension opened DevTools in a different window:
           devToolsTabTarget = await browser.waitForTarget(
               (target) => target.url.contains(devToolsUrlFragment));
+          devToolsPage = await devToolsTabTarget.page;
+          await devToolsPage.bringToFront();
           devToolsWindowId = await _getWindowId(
             devToolsPage.url!,
             worker: worker,

--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -35,8 +35,6 @@ void main() async {
 
     for (var useSse in [true, false]) {
       group(useSse ? 'with SSE' : 'with WebSockets', () {
-        late Browser browser;
-        late Worker worker;
 
         setUpAll(() async {
           // TODO(elliette): Only start a TestServer, that way we can get rid of

--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -35,7 +35,6 @@ void main() async {
 
     for (var useSse in [true, false]) {
       group(useSse ? 'with SSE' : 'with WebSockets', () {
-
         setUpAll(() async {
           // TODO(elliette): Only start a TestServer, that way we can get rid of
           // the launchChrome parameter: https://github.com/dart-lang/webdev/issues/1779


### PR DESCRIPTION
Fixes the following error when running the extension test locally:

```
  Evaluation failed: TypeError: Cannot read properties of undefined (reading 'windowId')
      at __puppeteer_evaluation_script__:3:18
  package:puppeteer/src/page/execution_context.dart 169:11  ExecutionContext._evaluateInternal
  ===== asynchronous gap ===========================
  package:puppeteer/src/page/execution_context.dart 76:20   ExecutionContext.evaluate
  ===== asynchronous gap ===========================
  test/puppeteer/extension_test.dart 239:11                 _getWindowId
  ===== asynchronous gap ===========================
  test/puppeteer/extension_test.dart 167:30                 main.<fn>.<fn>.<fn>
```