### PR TITLE
Update tests that are incompatible with `3.0.0`

### DIFF
--- a/dwds/test/build_daemon_breakpoint_test.dart
+++ b/dwds/test/build_daemon_breakpoint_test.dart
@@ -15,8 +15,8 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 import 'fixtures/context.dart';
 
 final context = TestContext(
-    directory: p.join('..', 'fixtures', '_testPackage'),
-    entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
+    directory: p.join('..', 'fixtures', '_testPackageSound'),
+    entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
     path: 'index.html',
     pathToServe: 'web');
 

--- a/dwds/test/build_daemon_callstack_test.dart
+++ b/dwds/test/build_daemon_callstack_test.dart
@@ -45,269 +45,287 @@ class TestSetup {
 }
 
 void main() {
-  group('shared context |', () {
-    // Enable verbose logging for debugging.
-    final debug = false;
+  group(
+    'shared context |',
+    () {
+      // Enable verbose logging for debugging.
+      final debug = false;
 
-    for (var nullSafety in supportedNullSafetyModes) {
-      final soundNullSafety = nullSafety == NullSafety.sound;
-      final setup = soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
-      final context = setup.context;
+      for (var nullSafety in NullSafety.values) {
+        group(
+          '${nullSafety.name} null safety |',
+          () {
+            final soundNullSafety = nullSafety == NullSafety.sound;
+            final setup =
+                soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
+            final context = setup.context;
 
-      group('${nullSafety.name} null safety |', () {
-        setUpAll(() async {
-          setCurrentLogWriter(debug: debug);
-          await context.setUp(
-            compilationMode: CompilationMode.buildDaemon,
-            enableExpressionEvaluation: true,
-            verboseCompiler: debug,
-          );
-        });
+            setUpAll(() async {
+              setCurrentLogWriter(debug: debug);
+              await context.setUp(
+                compilationMode: CompilationMode.buildDaemon,
+                enableExpressionEvaluation: true,
+                verboseCompiler: debug,
+              );
+            });
 
-        tearDownAll(() async {
-          await context.tearDown();
-        });
+            tearDownAll(() async {
+              await context.tearDown();
+            });
 
-        group('callStack |', () {
-          late ChromeProxyService service;
-          VM vm;
-          late Isolate isolate;
-          ScriptList scripts;
-          late ScriptRef mainScript;
-          late ScriptRef testLibraryScript;
-          late Stream<Event> stream;
+            group('callStack |', () {
+              late ChromeProxyService service;
+              VM vm;
+              late Isolate isolate;
+              ScriptList scripts;
+              late ScriptRef mainScript;
+              late ScriptRef testLibraryScript;
+              late Stream<Event> stream;
 
-          setUp(() async {
-            setCurrentLogWriter(debug: debug);
-            service = setup.service;
-            vm = await service.getVM();
-            isolate = await service.getIsolate(vm.isolates!.first.id!);
-            scripts = await service.getScripts(isolate.id!);
+              setUp(() async {
+                setCurrentLogWriter(debug: debug);
+                service = setup.service;
+                vm = await service.getVM();
+                isolate = await service.getIsolate(vm.isolates!.first.id!);
+                scripts = await service.getScripts(isolate.id!);
 
-            await service.streamListen('Debug');
-            stream = service.onEvent('Debug');
+                await service.streamListen('Debug');
+                stream = service.onEvent('Debug');
 
-            final testPackage =
-                soundNullSafety ? '_test_package_sound' : '_test_package';
+                final testPackage =
+                    soundNullSafety ? '_test_package_sound' : '_test_package';
 
-            mainScript = scripts.scripts!
-                .firstWhere((each) => each.uri!.contains('main.dart'));
-            testLibraryScript = scripts.scripts!.firstWhere((each) =>
-                each.uri!.contains('package:$testPackage/test_library.dart'));
-          });
+                mainScript = scripts.scripts!
+                    .firstWhere((each) => each.uri!.contains('main.dart'));
+                testLibraryScript = scripts.scripts!.firstWhere((each) => each
+                    .uri!
+                    .contains('package:$testPackage/test_library.dart'));
+              });
 
-          tearDown(() async {
-            await service.resume(isolate.id!);
-          });
+              tearDown(() async {
+                await service.resume(isolate.id!);
+              });
 
-          Future<void> onBreakPoint(BreakpointTestData breakpoint,
-              Future<void> Function() body) async {
-            Breakpoint? bp;
-            try {
-              final bpId = breakpoint.bpId;
-              final script = breakpoint.script;
-              final line =
-                  await context.findBreakpointLine(bpId, isolate.id!, script);
-              bp = await setup.service
-                  .addBreakpointWithScriptUri(isolate.id!, script.uri!, line);
+              Future<void> onBreakPoint(BreakpointTestData breakpoint,
+                  Future<void> Function() body) async {
+                Breakpoint? bp;
+                try {
+                  final bpId = breakpoint.bpId;
+                  final script = breakpoint.script;
+                  final line = await context.findBreakpointLine(
+                      bpId, isolate.id!, script);
+                  bp = await setup.service.addBreakpointWithScriptUri(
+                      isolate.id!, script.uri!, line);
 
-              expect(bp, isNotNull);
-              expect(bp.location, _matchBpLocation(script, line, 0));
+                  expect(bp, isNotNull);
+                  expect(bp.location, _matchBpLocation(script, line, 0));
 
-              await stream.firstWhere(
-                  (Event event) => event.kind == EventKind.kPauseBreakpoint);
+                  await stream.firstWhere((Event event) =>
+                      event.kind == EventKind.kPauseBreakpoint);
 
-              await body();
-            } finally {
-              // Remove breakpoint so it doesn't impact other tests or retries.
-              if (bp != null) {
-                await setup.service.removeBreakpoint(isolate.id!, bp.id!);
+                  await body();
+                } finally {
+                  // Remove breakpoint so it doesn't impact other tests or retries.
+                  if (bp != null) {
+                    await setup.service.removeBreakpoint(isolate.id!, bp.id!);
+                  }
+                }
               }
-            }
-          }
 
-          Future<void> testCallStack(List<BreakpointTestData> breakpoints,
-              {int frameIndex = 1}) async {
-            // Find lines the breakpoints are located on.
-            final lines = await Future.wait(breakpoints.map((frame) => context
-                .findBreakpointLine(frame.bpId, isolate.id!, frame.script)));
+              Future<void> testCallStack(List<BreakpointTestData> breakpoints,
+                  {int frameIndex = 1}) async {
+                // Find lines the breakpoints are located on.
+                final lines = await Future.wait(breakpoints.map((frame) =>
+                    context.findBreakpointLine(
+                        frame.bpId, isolate.id!, frame.script)));
 
-            // Get current stack.
-            final stack = await service.getStack(isolate.id!);
+                // Get current stack.
+                final stack = await service.getStack(isolate.id!);
 
-            // Verify the stack is correct.
-            expect(stack.frames!.length, greaterThanOrEqualTo(lines.length));
-            final expected = [
-              for (var i = 0; i < lines.length; i++)
-                _matchFrame(
-                    breakpoints[i].script, breakpoints[i].function, lines[i])
-            ];
-            expect(stack.frames, containsAll(expected));
+                // Verify the stack is correct.
+                expect(
+                    stack.frames!.length, greaterThanOrEqualTo(lines.length));
+                final expected = [
+                  for (var i = 0; i < lines.length; i++)
+                    _matchFrame(breakpoints[i].script, breakpoints[i].function,
+                        lines[i])
+                ];
+                expect(stack.frames, containsAll(expected));
 
-            // Verify that expression evaluation is not failing.
-            final instance =
-                await service.evaluateInFrame(isolate.id!, frameIndex, 'true');
-            expect(instance, isA<InstanceRef>());
-          }
+                // Verify that expression evaluation is not failing.
+                final instance = await service.evaluateInFrame(
+                    isolate.id!, frameIndex, 'true');
+                expect(instance, isA<InstanceRef>());
+              }
 
-          test('breakpoint succeeds with correct callstack', () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'printEnclosingObject',
-                'printEnclosingObject',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'printEnclosingFunctionMultiLine',
-                'printNestedObjectsMultiLine',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintEnclosingFunctionMultiLine',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            await onBreakPoint(
-                breakpoints[0], () => testCallStack(breakpoints));
-          });
+              test('breakpoint succeeds with correct callstack', () async {
+                // Expected breakpoints on the stack
+                final breakpoints = [
+                  BreakpointTestData(
+                    'printEnclosingObject',
+                    'printEnclosingObject',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    'printEnclosingFunctionMultiLine',
+                    'printNestedObjectsMultiLine',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    'callPrintEnclosingFunctionMultiLine',
+                    '<closure>',
+                    mainScript,
+                  ),
+                ];
+                await onBreakPoint(
+                    breakpoints[0], () => testCallStack(breakpoints));
+              });
 
-          test('expression evaluation succeeds on parent frame', () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'testLibraryClassConstructor',
-                'new',
-                testLibraryScript,
-              ),
-              BreakpointTestData(
-                'createLibraryObject',
-                'printFieldFromLibraryClass',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintFieldFromLibraryClass',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            await onBreakPoint(breakpoints[0],
-                () => testCallStack(breakpoints, frameIndex: 2));
-          });
+              test('expression evaluation succeeds on parent frame', () async {
+                // Expected breakpoints on the stack
+                final breakpoints = [
+                  BreakpointTestData(
+                    'testLibraryClassConstructor',
+                    'new',
+                    testLibraryScript,
+                  ),
+                  BreakpointTestData(
+                    'createLibraryObject',
+                    'printFieldFromLibraryClass',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    'callPrintFieldFromLibraryClass',
+                    '<closure>',
+                    mainScript,
+                  ),
+                ];
+                await onBreakPoint(breakpoints[0],
+                    () => testCallStack(breakpoints, frameIndex: 2));
+              });
 
-          test('breakpoint inside a line gives correct callstack', () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'newEnclosedClass',
-                'new',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'printNestedObjectMultiLine',
-                'printNestedObjectsMultiLine',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintEnclosingFunctionMultiLine',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            await onBreakPoint(
-                breakpoints[0], () => testCallStack(breakpoints));
-          });
+              test('breakpoint inside a line gives correct callstack',
+                  () async {
+                // Expected breakpoints on the stack
+                final breakpoints = [
+                  BreakpointTestData(
+                    'newEnclosedClass',
+                    'new',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    'printNestedObjectMultiLine',
+                    'printNestedObjectsMultiLine',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    'callPrintEnclosingFunctionMultiLine',
+                    '<closure>',
+                    mainScript,
+                  ),
+                ];
+                await onBreakPoint(
+                    breakpoints[0], () => testCallStack(breakpoints));
+              });
 
-          test('breakpoint gives correct callstack after step out', () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'newEnclosedClass',
-                'new',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'printEnclosingObjectMultiLine',
-                'printNestedObjectsMultiLine',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintEnclosingFunctionMultiLine',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            await onBreakPoint(breakpoints[0], () async {
-              await service.resume(isolate.id!, step: 'Out');
-              await stream.firstWhere(
-                  (Event event) => event.kind == EventKind.kPauseInterrupted);
-              return testCallStack([breakpoints[1], breakpoints[2]]);
+              test('breakpoint gives correct callstack after step out',
+                  () async {
+                // Expected breakpoints on the stack
+                final breakpoints = [
+                  BreakpointTestData(
+                    'newEnclosedClass',
+                    'new',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    'printEnclosingObjectMultiLine',
+                    'printNestedObjectsMultiLine',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    'callPrintEnclosingFunctionMultiLine',
+                    '<closure>',
+                    mainScript,
+                  ),
+                ];
+                await onBreakPoint(breakpoints[0], () async {
+                  await service.resume(isolate.id!, step: 'Out');
+                  await stream.firstWhere((Event event) =>
+                      event.kind == EventKind.kPauseInterrupted);
+                  return testCallStack([breakpoints[1], breakpoints[2]]);
+                });
+              });
+
+              test('breakpoint gives correct callstack after step in',
+                  () async {
+                // Expected breakpoints on the stack
+                final breakpoints = [
+                  BreakpointTestData(
+                    'newEnclosedClass',
+                    'new',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    'printNestedObjectMultiLine',
+                    'printNestedObjectsMultiLine',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    'callPrintEnclosingFunctionMultiLine',
+                    '<closure>',
+                    mainScript,
+                  ),
+                ];
+                await onBreakPoint(breakpoints[1], () async {
+                  await service.resume(isolate.id!, step: 'Into');
+                  await stream.firstWhere((Event event) =>
+                      event.kind == EventKind.kPauseInterrupted);
+                  return testCallStack(breakpoints);
+                });
+              });
+
+              test(
+                  'breakpoint gives correct callstack after step into chain calls',
+                  () async {
+                // Expected breakpoints on the stack
+                final breakpoints = [
+                  BreakpointTestData(
+                    'createObjectWithMethod',
+                    'createObject',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    // This is currently incorrect, should be printObjectMultiLine.
+                    // See issue: https://github.com/dart-lang/sdk/issues/48874
+                    'printMultiLine',
+                    'printObjectMultiLine',
+                    mainScript,
+                  ),
+                  BreakpointTestData(
+                    'callPrintObjectMultiLine',
+                    '<closure>',
+                    mainScript,
+                  ),
+                ];
+                final bp = BreakpointTestData(
+                    'printMultiLine', 'printObjectMultiLine', mainScript);
+                await onBreakPoint(bp, () async {
+                  await service.resume(isolate.id!, step: 'Into');
+                  await stream.firstWhere((Event event) =>
+                      event.kind == EventKind.kPauseInterrupted);
+                  return testCallStack(breakpoints);
+                });
+              });
             });
-          });
-
-          test('breakpoint gives correct callstack after step in', () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'newEnclosedClass',
-                'new',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'printNestedObjectMultiLine',
-                'printNestedObjectsMultiLine',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintEnclosingFunctionMultiLine',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            await onBreakPoint(breakpoints[1], () async {
-              await service.resume(isolate.id!, step: 'Into');
-              await stream.firstWhere(
-                  (Event event) => event.kind == EventKind.kPauseInterrupted);
-              return testCallStack(breakpoints);
-            });
-          });
-
-          test('breakpoint gives correct callstack after step into chain calls',
-              () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'createObjectWithMethod',
-                'createObject',
-                mainScript,
-              ),
-              BreakpointTestData(
-                // This is currently incorrect, should be printObjectMultiLine.
-                // See issue: https://github.com/dart-lang/sdk/issues/48874
-                'printMultiLine',
-                'printObjectMultiLine',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintObjectMultiLine',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            final bp = BreakpointTestData(
-                'printMultiLine', 'printObjectMultiLine', mainScript);
-            await onBreakPoint(bp, () async {
-              await service.resume(isolate.id!, step: 'Into');
-              await stream.firstWhere(
-                  (Event event) => event.kind == EventKind.kPauseInterrupted);
-              return testCallStack(breakpoints);
-            });
-          });
-        });
-      });
-    }
-  });
+          },
+          skip: !supportedMode(
+            compilationMode: CompilationMode.buildDaemon,
+            nullSafetyMode: nullSafety,
+          ),
+        );
+      }
+    },
+  );
 }
 
 Matcher _matchFrame(ScriptRef script, String function, int line) => isA<Frame>()

--- a/dwds/test/build_daemon_callstack_test.dart
+++ b/dwds/test/build_daemon_callstack_test.dart
@@ -20,13 +20,17 @@ class TestSetup {
       directory: p.join('..', 'fixtures', '_testPackage'),
       entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
       path: 'index.html',
-      pathToServe: 'web');
+    pathToServe: 'web',
+    nullSafety: NullSafety.weak,
+  );
 
   static final contextSound = TestContext(
       directory: p.join('..', 'fixtures', '_testPackageSound'),
       entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
       path: 'index.html',
-      pathToServe: 'web');
+    pathToServe: 'web',
+    nullSafety: NullSafety.sound,
+  );
 
   TestContext context;
 
@@ -54,7 +58,6 @@ void main() {
           setCurrentLogWriter(debug: debug);
           await context.setUp(
             compilationMode: CompilationMode.buildDaemon,
-            nullSafety: nullSafety,
             enableExpressionEvaluation: true,
             verboseCompiler: debug,
           );

--- a/dwds/test/build_daemon_callstack_test.dart
+++ b/dwds/test/build_daemon_callstack_test.dart
@@ -17,17 +17,17 @@ import 'fixtures/logging.dart';
 
 class TestSetup {
   static final contextUnsound = TestContext(
-      directory: p.join('..', 'fixtures', '_testPackage'),
-      entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
-      path: 'index.html',
+    directory: p.join('..', 'fixtures', '_testPackage'),
+    entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
+    path: 'index.html',
     pathToServe: 'web',
     nullSafety: NullSafety.weak,
   );
 
   static final contextSound = TestContext(
-      directory: p.join('..', 'fixtures', '_testPackageSound'),
-      entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
-      path: 'index.html',
+    directory: p.join('..', 'fixtures', '_testPackageSound'),
+    entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
+    path: 'index.html',
     pathToServe: 'web',
     nullSafety: NullSafety.sound,
   );

--- a/dwds/test/build_daemon_callstack_test.dart
+++ b/dwds/test/build_daemon_callstack_test.dart
@@ -14,6 +14,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
+import 'utils/version_compatibility.dart';
 
 class TestSetup {
   static final contextUnsound = TestContext(
@@ -48,7 +49,7 @@ void main() {
     // Enable verbose logging for debugging.
     final debug = false;
 
-    for (var nullSafety in NullSafety.values) {
+    for (var nullSafety in supportedNullSafetyModes()) {
       final soundNullSafety = nullSafety == NullSafety.sound;
       final setup = soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
       final context = setup.context;

--- a/dwds/test/build_daemon_callstack_test.dart
+++ b/dwds/test/build_daemon_callstack_test.dart
@@ -318,6 +318,7 @@ void main() {
               });
             });
           },
+          // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
           skip: !supportedMode(
             compilationMode: CompilationMode.buildDaemon,
             nullSafetyMode: nullSafety,

--- a/dwds/test/build_daemon_callstack_test.dart
+++ b/dwds/test/build_daemon_callstack_test.dart
@@ -49,7 +49,7 @@ void main() {
     // Enable verbose logging for debugging.
     final debug = false;
 
-    for (var nullSafety in supportedNullSafetyModes()) {
+    for (var nullSafety in supportedNullSafetyModes) {
       final soundNullSafety = nullSafety == NullSafety.sound;
       final setup = soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
       final context = setup.context;

--- a/dwds/test/build_daemon_circular_evaluate_test.dart
+++ b/dwds/test/build_daemon_circular_evaluate_test.dart
@@ -3,23 +3,19 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
-import 'dart:io';
 
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import 'fixtures/context.dart';
 import 'evaluate_circular_common.dart';
 
+import 'utils/version_compatibility.dart';
+
 void main() async {
   // Enable verbose logging for debugging.
   final debug = false;
-  final sdkVersion = Version.parse(Platform.version.split(' ')[0]);
-  final nullSafetyValues = (sdkVersion.major >= 3)
-      ? [NullSafety.sound]
-      : [NullSafety.sound, NullSafety.weak];
 
-  for (var nullSafety in nullSafetyValues) {
+  for (var nullSafety in supportedNullSafetyModes()) {
     group('${nullSafety.name} null safety |', () {
       testAll(
         compilationMode: CompilationMode.buildDaemon,

--- a/dwds/test/build_daemon_circular_evaluate_test.dart
+++ b/dwds/test/build_daemon_circular_evaluate_test.dart
@@ -15,7 +15,7 @@ void main() async {
   // Enable verbose logging for debugging.
   final debug = false;
 
-  for (var nullSafety in supportedNullSafetyModes()) {
+  for (var nullSafety in supportedNullSafetyModes) {
     group('${nullSafety.name} null safety |', () {
       testAll(
         compilationMode: CompilationMode.buildDaemon,

--- a/dwds/test/build_daemon_circular_evaluate_test.dart
+++ b/dwds/test/build_daemon_circular_evaluate_test.dart
@@ -3,7 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+import 'dart:io';
 
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import 'fixtures/context.dart';
@@ -12,8 +14,12 @@ import 'evaluate_circular_common.dart';
 void main() async {
   // Enable verbose logging for debugging.
   final debug = false;
+  final sdkVersion = Version.parse(Platform.version.split(' ')[0]);
+  final nullSafetyValues = (sdkVersion.major >= 3)
+      ? [NullSafety.sound]
+      : [NullSafety.sound, NullSafety.weak];
 
-  for (var nullSafety in NullSafety.values) {
+  for (var nullSafety in nullSafetyValues) {
     group('${nullSafety.name} null safety |', () {
       testAll(
         compilationMode: CompilationMode.buildDaemon,

--- a/dwds/test/build_daemon_circular_evaluate_test.dart
+++ b/dwds/test/build_daemon_circular_evaluate_test.dart
@@ -15,13 +15,21 @@ void main() async {
   // Enable verbose logging for debugging.
   final debug = false;
 
-  for (var nullSafety in supportedNullSafetyModes) {
-    group('${nullSafety.name} null safety |', () {
-      testAll(
+  for (var nullSafety in NullSafety.values) {
+    group(
+      '${nullSafety.name} null safety |',
+      () {
+        testAll(
+          compilationMode: CompilationMode.buildDaemon,
+          nullSafety: nullSafety,
+          debug: debug,
+        );
+      },
+      // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+      skip: !supportedMode(
         compilationMode: CompilationMode.buildDaemon,
-        nullSafety: nullSafety,
-        debug: debug,
-      );
-    });
+        nullSafetyMode: nullSafety,
+      ),
+    );
   }
 }

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -14,7 +14,7 @@ void main() async {
   // Enable verbose logging for debugging.
   final debug = false;
 
-  for (var nullSafety in supportedNullSafetyModes()) {
+  for (var nullSafety in supportedNullSafetyModes) {
     group('${nullSafety.name} null safety |', () {
       testAll(
         compilationMode: CompilationMode.buildDaemon,

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -8,12 +8,13 @@ import 'package:test/test.dart';
 
 import 'fixtures/context.dart';
 import 'evaluate_common.dart';
+import 'utils/version_compatibility.dart';
 
 void main() async {
   // Enable verbose logging for debugging.
   final debug = false;
 
-  for (var nullSafety in NullSafety.values) {
+  for (var nullSafety in supportedNullSafetyModes()) {
     group('${nullSafety.name} null safety |', () {
       testAll(
         compilationMode: CompilationMode.buildDaemon,

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -14,13 +14,21 @@ void main() async {
   // Enable verbose logging for debugging.
   final debug = false;
 
-  for (var nullSafety in supportedNullSafetyModes) {
-    group('${nullSafety.name} null safety |', () {
-      testAll(
+  for (var nullSafety in NullSafety.values) {
+    group(
+      '${nullSafety.name} null safety |',
+      () {
+        testAll(
+          compilationMode: CompilationMode.buildDaemon,
+          nullSafety: nullSafety,
+          debug: debug,
+        );
+      },
+      // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+      skip: !supportedMode(
         compilationMode: CompilationMode.buildDaemon,
-        nullSafety: nullSafety,
-        debug: debug,
-      );
-    });
+        nullSafetyMode: nullSafety,
+      ),
+    );
   }
 }

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -13,7 +13,6 @@ import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
-import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -20,6 +20,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
+import 'utils/version_compatibility.dart';
 
 final context = TestContext();
 
@@ -126,7 +127,7 @@ void main() {
 
       test('addBreakpointWithScriptUri absolute file URI', () async {
         final current = context.workingDirectory;
-        final test = path.join(path.dirname(current), '_test');
+        final test = path.join(path.dirname(current), '_testSound');
         final scriptPath = Uri.parse(mainScript.uri!).path.substring(1);
         final fullPath = path.join(test, scriptPath);
         final fileUri = Uri.file(fullPath);
@@ -471,7 +472,7 @@ void main() {
               isolate.id!, rootLibrary!.classes!.first.id!) as Class;
           expect(
               testClass.functions,
-              unorderedEquals([
+              containsAll([
                 predicate(
                     (FuncRef f) => f.name == 'staticHello' && f.isStatic!),
                 predicate((FuncRef f) => f.name == 'message' && !f.isStatic!),
@@ -610,15 +611,6 @@ void main() {
         expect(obj.kind, InstanceKind.kDouble);
         expect(obj.classRef!.name, 'Double');
         expect(obj.valueAsString, '42');
-      });
-
-      test('null', () async {
-        final ref = await service.evaluate(
-            isolate.id!, bootstrap!.id!, 'helloNum(null)') as InstanceRef;
-        final obj = await service.getObject(isolate.id!, ref.id!) as Instance;
-        expect(obj.kind, InstanceKind.kNull);
-        expect(obj.classRef!.name, 'Null');
-        expect(obj.valueAsString, 'null');
       });
 
       test('Scripts', () async {
@@ -860,8 +852,8 @@ void main() {
 
       // Containts part files as well.
       expect(scriptUris, contains(endsWith('part.dart')));
-      expect(scriptUris,
-          contains('package:intl/src/intl/date_format_helpers.dart'));
+      expect(
+          scriptUris, contains('package:intl/src/date_format_internal.dart'));
     });
 
     group('getSourceReport', () {
@@ -1368,7 +1360,7 @@ void main() {
       expect(
           resolvedUris.uris,
           containsAll([
-            contains('/_test/example/hello_world/main.dart'),
+            contains('/_testSound/example/hello_world/main.dart'),
             contains('/lib/path.dart'),
             contains('/lib/src/path_set.dart'),
           ]));

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -1116,7 +1116,8 @@ void main() {
             .firstWhere((event) => event.kind == EventKind.kPauseException);
         expect(event.exception, isNotNull);
         // Check that the exception stack trace has been mapped to Dart source files.
-        expect(event.exception!.valueAsString, contains('main.dart'));
+        // TODO(https://github.com/dart-lang/webdev/issues/1821) Uncomment.
+        // expect(event.exception!.valueAsString, contains('main.dart'));
 
         final stack = await service.getStack(isolateId!);
         expect(stack, isNotNull);

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -504,7 +504,7 @@ void main() {
                   !f.isFinal!),
             ]));
         // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
-      }, skip: !versionSupportsWeakNullSafety);
+      }, skip: true);
 
       test('Runtime classes', () async {
         final testClass = await service.getObject(
@@ -768,7 +768,7 @@ void main() {
                     !f.isFinal!),
               ]));
           // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
-        }, skip: !versionSupportsWeakNullSafety);
+        }, skip: true);
 
         test('offset/count parameters are ignored for bools', () async {
           final ref = await service.evaluate(
@@ -810,7 +810,7 @@ void main() {
           expect(obj.kind, InstanceKind.kNull);
           expect(obj.classRef!.name, 'Null');
           expect(obj.valueAsString, 'null');
-        }, skip: !versionSupportsWeakNullSafety);
+        }, skip: true);
       });
     });
 

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -502,8 +502,7 @@ void main() {
                   !f.isConst! &&
                   !f.isFinal!),
             ]));
-        // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
-      }, skip: true);
+      }, skip: 'https://github.com/dart-lang/webdev/issues/1818');
 
       test('Runtime classes', () async {
         final testClass = await service.getObject(
@@ -766,8 +765,7 @@ void main() {
                     !f.isConst! &&
                     !f.isFinal!),
               ]));
-          // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
-        }, skip: true);
+        }, skip: 'https://github.com/dart-lang/webdev/issues/1818');
 
         test('offset/count parameters are ignored for bools', () async {
           final ref = await service.evaluate(
@@ -809,7 +807,7 @@ void main() {
           expect(obj.kind, InstanceKind.kNull);
           expect(obj.classRef!.name, 'Null');
           expect(obj.valueAsString, 'null');
-        }, skip: true);
+        }, skip: 'https://github.com/dart-lang/webdev/issues/1818');
       });
     });
 

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -20,6 +20,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
+import 'utils/version_compatibility.dart';
 
 final context = TestContext();
 
@@ -464,56 +465,47 @@ void main() {
         expect(library1, equals(library2));
       });
 
-      test(
-        'Classes',
-        () async {
-          final testClass = await service.getObject(
-              isolate.id!, rootLibrary!.classes!.first.id!) as Class;
-          expect(
-              testClass.functions,
-              containsAll([
-                predicate(
-                    (FuncRef f) => f.name == 'staticHello' && f.isStatic!),
-                predicate((FuncRef f) => f.name == 'message' && !f.isStatic!),
-                predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic!),
-                predicate((FuncRef f) => f.name == 'hello' && !f.isStatic!),
-                predicate((FuncRef f) => f.name == '_equals' && !f.isStatic!),
-                predicate((FuncRef f) => f.name == 'hashCode' && !f.isStatic!),
-                predicate((FuncRef f) => f.name == 'toString' && !f.isStatic!),
-                predicate(
-                    (FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic!),
-                predicate(
-                    (FuncRef f) => f.name == 'runtimeType' && !f.isStatic!),
-              ]));
-          expect(
-              testClass.fields,
-              unorderedEquals([
-                predicate((FieldRef f) =>
-                    f.name == 'message' &&
-                    f.declaredType != null &&
-                    !f.isStatic! &&
-                    !f.isConst! &&
-                    f.isFinal!),
-                predicate((FieldRef f) =>
-                    f.name == 'notFinal' &&
-                    f.declaredType != null &&
-                    !f.isStatic! &&
-                    !f.isConst! &&
-                    !f.isFinal!),
-                predicate((FieldRef f) =>
-                    f.name == 'staticMessage' &&
-                    f.declaredType != null &&
-                    f.isStatic! &&
-                    !f.isConst! &&
-                    !f.isFinal!),
-              ]));
-        },
-        // TODO(elliette): Remove once 2.15.0 is the stable release.
-        skip: semver.Version.parse(Platform.version.split(' ').first) >=
-                semver.Version.parse('2.15.0-268.18.beta')
-            ? null
-            : 'SDK does not expose static member information.',
-      );
+      test('Classes', () async {
+        final testClass = await service.getObject(
+            isolate.id!, rootLibrary!.classes!.first.id!) as Class;
+        expect(
+            testClass.functions,
+            unorderedEquals([
+              predicate((FuncRef f) => f.name == 'staticHello' && f.isStatic!),
+              predicate((FuncRef f) => f.name == 'message' && !f.isStatic!),
+              predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic!),
+              predicate((FuncRef f) => f.name == 'hello' && !f.isStatic!),
+              predicate((FuncRef f) => f.name == '_equals' && !f.isStatic!),
+              predicate((FuncRef f) => f.name == 'hashCode' && !f.isStatic!),
+              predicate((FuncRef f) => f.name == 'toString' && !f.isStatic!),
+              predicate(
+                  (FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic!),
+              predicate((FuncRef f) => f.name == 'runtimeType' && !f.isStatic!),
+            ]));
+        expect(
+            testClass.fields,
+            unorderedEquals([
+              predicate((FieldRef f) =>
+                  f.name == 'message' &&
+                  f.declaredType != null &&
+                  !f.isStatic! &&
+                  !f.isConst! &&
+                  f.isFinal!),
+              predicate((FieldRef f) =>
+                  f.name == 'notFinal' &&
+                  f.declaredType != null &&
+                  !f.isStatic! &&
+                  !f.isConst! &&
+                  !f.isFinal!),
+              predicate((FieldRef f) =>
+                  f.name == 'staticMessage' &&
+                  f.declaredType != null &&
+                  f.isStatic! &&
+                  !f.isConst! &&
+                  !f.isFinal!),
+            ]));
+        // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+      }, skip: !versionSupportsWeakNullSafety);
 
       test('Runtime classes', () async {
         final testClass = await service.getObject(
@@ -731,63 +723,53 @@ void main() {
           expect(world.offset, 3);
         });
 
-        test(
-          'offset/count parameters are ignored for Classes',
-          () async {
-            final testClass = await service.getObject(
-              isolate.id!,
-              rootLibrary!.classes!.first.id!,
-              offset: 100,
-              count: 100,
-            ) as Class;
-            expect(
-                testClass.functions,
-                unorderedEquals([
-                  predicate(
-                      (FuncRef f) => f.name == 'staticHello' && f.isStatic!),
-                  predicate((FuncRef f) => f.name == 'message' && !f.isStatic!),
-                  predicate(
-                      (FuncRef f) => f.name == 'notFinal' && !f.isStatic!),
-                  predicate((FuncRef f) => f.name == 'hello' && !f.isStatic!),
-                  predicate((FuncRef f) => f.name == '_equals' && !f.isStatic!),
-                  predicate(
-                      (FuncRef f) => f.name == 'hashCode' && !f.isStatic!),
-                  predicate(
-                      (FuncRef f) => f.name == 'toString' && !f.isStatic!),
-                  predicate(
-                      (FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic!),
-                  predicate(
-                      (FuncRef f) => f.name == 'runtimeType' && !f.isStatic!),
-                ]));
-            expect(
-                testClass.fields,
-                unorderedEquals([
-                  predicate((FieldRef f) =>
-                      f.name == 'message' &&
-                      f.declaredType != null &&
-                      !f.isStatic! &&
-                      !f.isConst! &&
-                      f.isFinal!),
-                  predicate((FieldRef f) =>
-                      f.name == 'notFinal' &&
-                      f.declaredType != null &&
-                      !f.isStatic! &&
-                      !f.isConst! &&
-                      !f.isFinal!),
-                  predicate((FieldRef f) =>
-                      f.name == 'staticMessage' &&
-                      f.declaredType != null &&
-                      f.isStatic! &&
-                      !f.isConst! &&
-                      !f.isFinal!),
-                ]));
-          },
-          // TODO(elliette): Remove once 2.15.0 is the stable release.
-          skip: semver.Version.parse(Platform.version.split(' ').first) >=
-                  semver.Version.parse('2.15.0-268.18.beta')
-              ? null
-              : 'SDK does not expose static member information.',
-        );
+        test('offset/count parameters are ignored for Classes', () async {
+          final testClass = await service.getObject(
+            isolate.id!,
+            rootLibrary!.classes!.first.id!,
+            offset: 100,
+            count: 100,
+          ) as Class;
+          expect(
+              testClass.functions,
+              unorderedEquals([
+                predicate(
+                    (FuncRef f) => f.name == 'staticHello' && f.isStatic!),
+                predicate((FuncRef f) => f.name == 'message' && !f.isStatic!),
+                predicate((FuncRef f) => f.name == 'notFinal' && !f.isStatic!),
+                predicate((FuncRef f) => f.name == 'hello' && !f.isStatic!),
+                predicate((FuncRef f) => f.name == '_equals' && !f.isStatic!),
+                predicate((FuncRef f) => f.name == 'hashCode' && !f.isStatic!),
+                predicate((FuncRef f) => f.name == 'toString' && !f.isStatic!),
+                predicate(
+                    (FuncRef f) => f.name == 'noSuchMethod' && !f.isStatic!),
+                predicate(
+                    (FuncRef f) => f.name == 'runtimeType' && !f.isStatic!),
+              ]));
+          expect(
+              testClass.fields,
+              unorderedEquals([
+                predicate((FieldRef f) =>
+                    f.name == 'message' &&
+                    f.declaredType != null &&
+                    !f.isStatic! &&
+                    !f.isConst! &&
+                    f.isFinal!),
+                predicate((FieldRef f) =>
+                    f.name == 'notFinal' &&
+                    f.declaredType != null &&
+                    !f.isStatic! &&
+                    !f.isConst! &&
+                    !f.isFinal!),
+                predicate((FieldRef f) =>
+                    f.name == 'staticMessage' &&
+                    f.declaredType != null &&
+                    f.isStatic! &&
+                    !f.isConst! &&
+                    !f.isFinal!),
+              ]));
+          // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+        }, skip: !versionSupportsWeakNullSafety);
 
         test('offset/count parameters are ignored for bools', () async {
           final ref = await service.evaluate(
@@ -829,7 +811,7 @@ void main() {
           expect(obj.kind, InstanceKind.kNull);
           expect(obj.classRef!.name, 'Null');
           expect(obj.valueAsString, 'null');
-        });
+        }, skip: !versionSupportsWeakNullSafety);
       });
     });
 

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -20,7 +20,6 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
-import 'utils/version_compatibility.dart';
 
 final context = TestContext();
 

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -19,7 +19,6 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
-import 'utils/version_compatibility.dart';
 
 final context = TestContext();
 

--- a/dwds/test/dart_uri_file_uri_test.dart
+++ b/dwds/test/dart_uri_file_uri_test.dart
@@ -33,61 +33,68 @@ final testPackageDir = context.workingDirectory;
 //
 // These tests are separated out because we need a running isolate in order to
 // look up packages.
+// TODO(https://github.com/dart-lang/webdev/issues/1818): Switch test over for
+// testing sound null-safety.
 void main() {
   for (final compilationMode in CompilationMode.values) {
-    group('$compilationMode |', () {
-      for (final useDebuggerModuleNames in [false, true]) {
-        group('Debugger module names: $useDebuggerModuleNames |', () {
-          final appServerPath =
-              compilationMode == CompilationMode.frontendServer
-                  ? 'web/main.dart'
-                  : 'main.dart';
+    group(
+      '$compilationMode |',
+      () {
+        for (final useDebuggerModuleNames in [false, true]) {
+          group('Debugger module names: $useDebuggerModuleNames |', () {
+            final appServerPath =
+                compilationMode == CompilationMode.frontendServer
+                    ? 'web/main.dart'
+                    : 'main.dart';
 
-          final serverPath =
-              compilationMode == CompilationMode.frontendServer &&
-                      useDebuggerModuleNames
-                  ? 'packages/_testPackage/lib/test_library.dart'
-                  : 'packages/_test_package/test_library.dart';
+            final serverPath =
+                compilationMode == CompilationMode.frontendServer &&
+                        useDebuggerModuleNames
+                    ? 'packages/_testPackage/lib/test_library.dart'
+                    : 'packages/_test_package/test_library.dart';
 
-          final anotherServerPath =
-              compilationMode == CompilationMode.frontendServer &&
-                      useDebuggerModuleNames
-                  ? 'packages/_test/lib/library.dart'
-                  : 'packages/_test/library.dart';
+            final anotherServerPath =
+                compilationMode == CompilationMode.frontendServer &&
+                        useDebuggerModuleNames
+                    ? 'packages/_test/lib/library.dart'
+                    : 'packages/_test/library.dart';
 
-          setUpAll(() async {
-            await context.setUp(
-              compilationMode: compilationMode,
-              useDebuggerModuleNames: useDebuggerModuleNames,
-            );
+            setUpAll(() async {
+              await context.setUp(
+                compilationMode: compilationMode,
+                useDebuggerModuleNames: useDebuggerModuleNames,
+              );
+            });
+
+            tearDownAll(() async {
+              await context.tearDown();
+            });
+
+            test('file path to org-dartlang-app', () {
+              final webMain =
+                  Uri.file(p.join(testPackageDir, 'web', 'main.dart'));
+              final uri = DartUri('$webMain');
+              expect(uri.serverPath, appServerPath);
+            });
+
+            test('file path to this package', () {
+              final testPackageLib =
+                  Uri.file(p.join(testPackageDir, 'lib', 'test_library.dart'));
+              final uri = DartUri('$testPackageLib');
+              expect(uri.serverPath, serverPath);
+            });
+
+            test('file path to another package', () {
+              final testLib = Uri.file(p.join(testDir, 'lib', 'library.dart'));
+              final dartUri = DartUri('$testLib');
+              expect(dartUri.serverPath, anotherServerPath);
+            });
           });
-
-          tearDownAll(() async {
-            await context.tearDown();
-          });
-
-          test('file path to org-dartlang-app', () {
-            final webMain =
-                Uri.file(p.join(testPackageDir, 'web', 'main.dart'));
-            final uri = DartUri('$webMain');
-            expect(uri.serverPath, appServerPath);
-          });
-
-          test('file path to this package', () {
-            final testPackageLib =
-                Uri.file(p.join(testPackageDir, 'lib', 'test_library.dart'));
-            final uri = DartUri('$testPackageLib');
-            expect(uri.serverPath, serverPath);
-          });
-
-          test('file path to another package', () {
-            final testLib = Uri.file(p.join(testDir, 'lib', 'library.dart'));
-            final dartUri = DartUri('$testLib');
-            expect(dartUri.serverPath, anotherServerPath);
-          });
-        });
-      }
+        }
+      },
       // TODO(https://github.com/dart-lang/webdev/issues/1818): Re-enable.
-    }, skip: !versionSupportsWeakNullSafety);
+      skip: !supportedMode(
+          compilationMode: compilationMode, nullSafetyMode: NullSafety.weak),
+    );
   }
 }

--- a/dwds/test/dart_uri_file_uri_test.dart
+++ b/dwds/test/dart_uri_file_uri_test.dart
@@ -33,7 +33,7 @@ final testPackageDir = context.workingDirectory;
 // These tests are separated out because we need a running isolate in order to
 // look up packages.
 void main() {
-  for (final nullSafetyMode in supportedNullSafetyModes()) {
+  for (final nullSafetyMode in supportedNullSafetyModes) {
     for (final compilationMode in supportedCompilationModes(nullSafetyMode)) {
       group('$compilationMode |', () {
         for (final useDebuggerModuleNames in [false, true]) {

--- a/dwds/test/dart_uri_file_uri_test.dart
+++ b/dwds/test/dart_uri_file_uri_test.dart
@@ -87,7 +87,7 @@ void main() {
           });
         });
       }
-    // TODO(https://github.com/dart-lang/webdev/issues/1818): Re-enable.
+      // TODO(https://github.com/dart-lang/webdev/issues/1818): Re-enable.
     }, skip: !versionSupportsWeakNullSafety);
   }
 }

--- a/dwds/test/dart_uri_file_uri_test.dart
+++ b/dwds/test/dart_uri_file_uri_test.dart
@@ -12,15 +12,15 @@ import 'package:test/test.dart';
 import 'fixtures/context.dart';
 
 final context = TestContext(
-    directory: p.join('..', 'fixtures', '_testPackage'),
-    entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
+    directory: p.join('..', 'fixtures', '_testPackageSound'),
+    entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
     path: 'index.html',
     pathToServe: 'web');
 
 final dwdsDir = Directory.current.absolute.path;
 
 /// The directory for the general _test package.
-final testDir = p.join(p.dirname(dwdsDir), 'fixtures', '_test');
+final testDir = p.join(p.dirname(dwdsDir), 'fixtures', '_testSound');
 
 /// The directory for the _testPackage package (contained within dwds), which
 /// imports _test.
@@ -43,14 +43,14 @@ void main() {
           final serverPath =
               compilationMode == CompilationMode.frontendServer &&
                       useDebuggerModuleNames
-                  ? 'packages/_testPackage/lib/test_library.dart'
-                  : 'packages/_test_package/test_library.dart';
+                  ? 'packages/_testPackageSound/lib/test_library.dart'
+                  : 'packages/_test_package_sound/test_library.dart';
 
           final anotherServerPath =
               compilationMode == CompilationMode.frontendServer &&
                       useDebuggerModuleNames
-                  ? 'packages/_test/lib/library.dart'
-                  : 'packages/_test/library.dart';
+                  ? 'packages/_testSound/lib/library.dart'
+                  : 'packages/_test_sound/library.dart';
 
           setUpAll(() async {
             await context.setUp(

--- a/dwds/test/dart_uri_file_uri_test.dart
+++ b/dwds/test/dart_uri_file_uri_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
-@Timeout(Duration(seconds: 60))
 import 'dart:io';
 
 import 'package:dwds/src/utilities/dart_uri.dart';
@@ -14,15 +13,17 @@ import 'fixtures/context.dart';
 import 'utils/version_compatibility.dart';
 
 final context = TestContext(
-    directory: p.join('..', 'fixtures', '_testPackageSound'),
-    entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
-    path: 'index.html',
-    pathToServe: 'web');
+  directory: p.join('..', 'fixtures', '_testPackage'),
+  entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
+  path: 'index.html',
+  pathToServe: 'web',
+  nullSafety: NullSafety.weak,
+);
 
 final dwdsDir = Directory.current.absolute.path;
 
 /// The directory for the general _test package.
-final testDir = p.join(p.dirname(dwdsDir), 'fixtures', '_testSound');
+final testDir = p.join(p.dirname(dwdsDir), 'fixtures', '_test');
 
 /// The directory for the _testPackage package (contained within dwds), which
 /// imports _test.
@@ -33,73 +34,60 @@ final testPackageDir = context.workingDirectory;
 // These tests are separated out because we need a running isolate in order to
 // look up packages.
 void main() {
-  for (final nullSafetyMode in supportedNullSafetyModes) {
-    for (final compilationMode in supportedCompilationModes(nullSafetyMode)) {
-      group('$compilationMode |', () {
-        for (final useDebuggerModuleNames in [false, true]) {
-          group('Debugger module names: $useDebuggerModuleNames |', () {
-            final appServerPath =
-                compilationMode == CompilationMode.frontendServer
-                    ? 'web/main.dart'
-                    : 'main.dart';
+  for (final compilationMode in CompilationMode.values) {
+    group('$compilationMode |', () {
+      for (final useDebuggerModuleNames in [false, true]) {
+        group('Debugger module names: $useDebuggerModuleNames |', () {
+          final appServerPath =
+              compilationMode == CompilationMode.frontendServer
+                  ? 'web/main.dart'
+                  : 'main.dart';
 
-            final packageNameForFrontendServer =
-                nullSafetyMode == NullSafety.sound
-                    ? '_testPackageSound'
-                    : '_testPackage';
-            final packageNameForBuildDaemon = nullSafetyMode == NullSafety.sound
-                ? '_test_package_sound'
-                : '_test_package';
-            final anotherPackageNameForFrontendServer =
-                nullSafetyMode == NullSafety.sound ? '_testSound' : '_test';
-            final anotherPackageNameForBuildDaemon =
-                nullSafetyMode == NullSafety.sound ? '_test_sound' : '_test';
+          final serverPath =
+              compilationMode == CompilationMode.frontendServer &&
+                      useDebuggerModuleNames
+                  ? 'packages/_testPackage/lib/test_library.dart'
+                  : 'packages/_test_package/test_library.dart';
 
-            final serverPath = compilationMode ==
-                        CompilationMode.frontendServer &&
-                    useDebuggerModuleNames
-                ? 'packages/$packageNameForFrontendServer/lib/test_library.dart'
-                : 'packages/$packageNameForBuildDaemon/test_library.dart';
+          final anotherServerPath =
+              compilationMode == CompilationMode.frontendServer &&
+                      useDebuggerModuleNames
+                  ? 'packages/_test/lib/library.dart'
+                  : 'packages/_test/library.dart';
 
-            final anotherServerPath = compilationMode ==
-                        CompilationMode.frontendServer &&
-                    useDebuggerModuleNames
-                ? 'packages/$anotherPackageNameForFrontendServer/lib/library.dart'
-                : 'packages/$anotherPackageNameForBuildDaemon/library.dart';
-
-            setUpAll(() async {
-              await context.setUp(
-                compilationMode: compilationMode,
-                useDebuggerModuleNames: useDebuggerModuleNames,
-              );
-            });
-
-            tearDownAll(() async {
-              await context.tearDown();
-            });
-
-            test('file path to org-dartlang-app', () {
-              final webMain =
-                  Uri.file(p.join(testPackageDir, 'web', 'main.dart'));
-              final uri = DartUri('$webMain');
-              expect(uri.serverPath, appServerPath);
-            });
-
-            test('file path to this package', () {
-              final testPackageLib =
-                  Uri.file(p.join(testPackageDir, 'lib', 'test_library.dart'));
-              final uri = DartUri('$testPackageLib');
-              expect(uri.serverPath, serverPath);
-            });
-
-            test('file path to another package', () {
-              final testLib = Uri.file(p.join(testDir, 'lib', 'library.dart'));
-              final dartUri = DartUri('$testLib');
-              expect(dartUri.serverPath, anotherServerPath);
-            });
+          setUpAll(() async {
+            await context.setUp(
+              compilationMode: compilationMode,
+              useDebuggerModuleNames: useDebuggerModuleNames,
+            );
           });
-        }
-      });
-    }
+
+          tearDownAll(() async {
+            await context.tearDown();
+          });
+
+          test('file path to org-dartlang-app', () {
+            final webMain =
+                Uri.file(p.join(testPackageDir, 'web', 'main.dart'));
+            final uri = DartUri('$webMain');
+            expect(uri.serverPath, appServerPath);
+          });
+
+          test('file path to this package', () {
+            final testPackageLib =
+                Uri.file(p.join(testPackageDir, 'lib', 'test_library.dart'));
+            final uri = DartUri('$testPackageLib');
+            expect(uri.serverPath, serverPath);
+          });
+
+          test('file path to another package', () {
+            final testLib = Uri.file(p.join(testDir, 'lib', 'library.dart'));
+            final dartUri = DartUri('$testLib');
+            expect(dartUri.serverPath, anotherServerPath);
+          });
+        });
+      }
+    // TODO(https://github.com/dart-lang/webdev/issues/1818): Re-enable.
+    }, skip: !versionSupportsWeakNullSafety);
   }
 }

--- a/dwds/test/dart_uri_file_uri_test.dart
+++ b/dwds/test/dart_uri_file_uri_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(seconds: 60))
 import 'dart:io';
 
 import 'package:dwds/src/utilities/dart_uri.dart';
@@ -10,6 +11,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'fixtures/context.dart';
+import 'utils/version_compatibility.dart';
 
 final context = TestContext(
     directory: p.join('..', 'fixtures', '_testPackageSound'),
@@ -31,59 +33,73 @@ final testPackageDir = context.workingDirectory;
 // These tests are separated out because we need a running isolate in order to
 // look up packages.
 void main() {
-  for (final compilationMode in CompilationMode.values) {
-    group('$compilationMode |', () {
-      for (final useDebuggerModuleNames in [false, true]) {
-        group('Debugger module names: $useDebuggerModuleNames |', () {
-          final appServerPath =
-              compilationMode == CompilationMode.frontendServer
-                  ? 'web/main.dart'
-                  : 'main.dart';
+  for (final nullSafetyMode in supportedNullSafetyModes()) {
+    for (final compilationMode in supportedCompilationModes(nullSafetyMode)) {
+      group('$compilationMode |', () {
+        for (final useDebuggerModuleNames in [false, true]) {
+          group('Debugger module names: $useDebuggerModuleNames |', () {
+            final appServerPath =
+                compilationMode == CompilationMode.frontendServer
+                    ? 'web/main.dart'
+                    : 'main.dart';
 
-          final serverPath =
-              compilationMode == CompilationMode.frontendServer &&
-                      useDebuggerModuleNames
-                  ? 'packages/_testPackageSound/lib/test_library.dart'
-                  : 'packages/_test_package_sound/test_library.dart';
+            final packageNameForFrontendServer =
+                nullSafetyMode == NullSafety.sound
+                    ? '_testPackageSound'
+                    : '_testPackage';
+            final packageNameForBuildDaemon = nullSafetyMode == NullSafety.sound
+                ? '_test_package_sound'
+                : '_test_package';
+            final anotherPackageNameForFrontendServer =
+                nullSafetyMode == NullSafety.sound ? '_testSound' : '_test';
+            final anotherPackageNameForBuildDaemon =
+                nullSafetyMode == NullSafety.sound ? '_test_sound' : '_test';
 
-          final anotherServerPath =
-              compilationMode == CompilationMode.frontendServer &&
-                      useDebuggerModuleNames
-                  ? 'packages/_testSound/lib/library.dart'
-                  : 'packages/_test_sound/library.dart';
+            final serverPath = compilationMode ==
+                        CompilationMode.frontendServer &&
+                    useDebuggerModuleNames
+                ? 'packages/$packageNameForFrontendServer/lib/test_library.dart'
+                : 'packages/$packageNameForBuildDaemon/test_library.dart';
 
-          setUpAll(() async {
-            await context.setUp(
-              compilationMode: compilationMode,
-              useDebuggerModuleNames: useDebuggerModuleNames,
-            );
+            final anotherServerPath = compilationMode ==
+                        CompilationMode.frontendServer &&
+                    useDebuggerModuleNames
+                ? 'packages/$anotherPackageNameForFrontendServer/lib/library.dart'
+                : 'packages/$anotherPackageNameForBuildDaemon/library.dart';
+
+            setUpAll(() async {
+              await context.setUp(
+                compilationMode: compilationMode,
+                useDebuggerModuleNames: useDebuggerModuleNames,
+              );
+            });
+
+            tearDownAll(() async {
+              await context.tearDown();
+            });
+
+            test('file path to org-dartlang-app', () {
+              final webMain =
+                  Uri.file(p.join(testPackageDir, 'web', 'main.dart'));
+              final uri = DartUri('$webMain');
+              expect(uri.serverPath, appServerPath);
+            });
+
+            test('file path to this package', () {
+              final testPackageLib =
+                  Uri.file(p.join(testPackageDir, 'lib', 'test_library.dart'));
+              final uri = DartUri('$testPackageLib');
+              expect(uri.serverPath, serverPath);
+            });
+
+            test('file path to another package', () {
+              final testLib = Uri.file(p.join(testDir, 'lib', 'library.dart'));
+              final dartUri = DartUri('$testLib');
+              expect(dartUri.serverPath, anotherServerPath);
+            });
           });
-
-          tearDownAll(() async {
-            await context.tearDown();
-          });
-
-          test('file path to org-dartlang-app', () {
-            final webMain =
-                Uri.file(p.join(testPackageDir, 'web', 'main.dart'));
-            final uri = DartUri('$webMain');
-            expect(uri.serverPath, appServerPath);
-          });
-
-          test('file path to this package', () {
-            final testPackageLib =
-                Uri.file(p.join(testPackageDir, 'lib', 'test_library.dart'));
-            final uri = DartUri('$testPackageLib');
-            expect(uri.serverPath, serverPath);
-          });
-
-          test('file path to another package', () {
-            final testLib = Uri.file(p.join(testDir, 'lib', 'library.dart'));
-            final dartUri = DartUri('$testLib');
-            expect(dartUri.serverPath, anotherServerPath);
-          });
-        });
-      }
-    });
+        }
+      });
+    }
   }
 }

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -99,9 +99,9 @@ void main() async {
               scripts.values.map((s) => s.url),
               containsAllInOrder([
                 contains('stack_trace_mapper.dart.js'),
-                contains('hello_world/main.unsound.ddc.js'),
-                contains('packages/path/path.unsound.ddc.js'),
-                contains('dev_compiler/dart_sdk.js'),
+                contains('hello_world/main.sound.ddc.js'),
+                contains('packages/path/path.sound.ddc.js'),
+                contains('dev_compiler/dart_sdk.sound.js'),
                 contains('dwds/src/injected/client.js'),
               ]));
         });

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -191,9 +191,9 @@ void main() async {
               scripts.values.map((s) => s.url),
               containsAllInOrder([
                 contains('stack_trace_mapper.dart.js'),
-                contains('hello_world/main.unsound.ddc.js'),
-                contains('packages/path/path.unsound.ddc.js'),
-                contains('dev_compiler/dart_sdk.js'),
+                contains('hello_world/main.sound.ddc.js'),
+                contains('packages/path/path.sound.ddc.js'),
+                contains('dev_compiler/dart_sdk.sound.js'),
                 contains('dwds/src/injected/client.js'),
               ]));
         });

--- a/dwds/test/evaluate_circular_common.dart
+++ b/dwds/test/evaluate_circular_common.dart
@@ -16,18 +16,21 @@ import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
 
 class TestSetup {
-  static TestContext createContext(String index, String packageRoot) =>
+  static TestContext createContext(
+          String index, String packageRoot, NullSafety nullSafety) =>
       TestContext(
-          directory: p.join('..', 'fixtures', packageRoot),
-          entry: p.join('..', 'fixtures', packageRoot, 'web', 'main.dart'),
-          path: index,
-          pathToServe: 'web');
+        directory: p.join('..', 'fixtures', packageRoot),
+        entry: p.join('..', 'fixtures', packageRoot, 'web', 'main.dart'),
+        path: index,
+        pathToServe: 'web',
+        nullSafety: nullSafety,
+      );
 
   static TestContext contextUnsound(String index) =>
-      createContext(index, '_testCircular2');
+      createContext(index, '_testCircular2', NullSafety.weak);
 
   static TestContext contextSound(String index) =>
-      createContext(index, '_testCircular2Sound');
+      createContext(index, '_testCircular2Sound', NullSafety.sound);
 
   TestContext context;
 
@@ -87,7 +90,6 @@ void testAll({
       setCurrentLogWriter(debug: debug);
       await context.setUp(
         compilationMode: compilationMode,
-        nullSafety: nullSafety,
         enableExpressionEvaluation: true,
         useDebuggerModuleNames: useDebuggerModuleNames,
         verboseCompiler: debug,

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -634,7 +634,6 @@ void testAll({
       setCurrentLogWriter(debug: debug);
       await context.setUp(
         compilationMode: compilationMode,
-        nullSafety: nullSafety,
         enableExpressionEvaluation: false,
         verboseCompiler: debug,
       );

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -16,18 +16,20 @@ import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
 
 class TestSetup {
-  static TestContext createContext(String index, String packageRoot) =>
+  static TestContext createContext(
+          String index, String packageRoot, NullSafety nullSafety) =>
       TestContext(
           directory: p.join('..', 'fixtures', packageRoot),
           entry: p.join('..', 'fixtures', packageRoot, 'web', 'main.dart'),
           path: index,
-          pathToServe: 'web');
+          pathToServe: 'web',
+          nullSafety: nullSafety);
 
   static TestContext contextUnsound(String index) =>
-      createContext(index, '_testPackage');
+      createContext(index, '_testPackage', NullSafety.weak);
 
   static TestContext contextSound(String index) =>
-      createContext(index, '_testPackageSound');
+      createContext(index, '_testPackageSound', NullSafety.sound);
 
   TestContext context;
 
@@ -87,7 +89,6 @@ void testAll({
       setCurrentLogWriter(debug: debug);
       await context.setUp(
         compilationMode: compilationMode,
-        nullSafety: nullSafety,
         enableExpressionEvaluation: true,
         useDebuggerModuleNames: useDebuggerModuleNames,
         verboseCompiler: debug,

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart = 2.9
-
+@Skip('Migrate to null-safety: https://github.com/dart-lang/webdev/issues/1818')
 import 'dart:async';
 import 'dart:io';
 

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -156,7 +156,7 @@ class TestContext {
     bool waitToDebug = false,
     UrlEncoder? urlEncoder,
     CompilationMode compilationMode = CompilationMode.buildDaemon,
-    NullSafety nullSafety = NullSafety.weak,
+    NullSafety nullSafety = NullSafety.sound,
     bool enableExpressionEvaluation = false,
     bool verboseCompiler = false,
     SdkConfigurationProvider? sdkConfigurationProvider,

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -112,15 +112,20 @@ class TestContext {
   /// The path part of the application URL.
   String path;
 
-  TestContext(
-      {String? directory,
-      String? entry,
-      this.path = 'hello_world/index.html',
-      this.pathToServe = 'example'}) {
-    final relativeDirectory = p.join('..', 'fixtures', '_testSound');
+  NullSafety nullSafety;
+
+  TestContext({
+    String? directory,
+    String? entry,
+    this.nullSafety = NullSafety.sound,
+    this.path = 'hello_world/index.html',
+    this.pathToServe = 'example',
+  }) {
+    final packageName = nullSafety == NullSafety.sound ? '_testSound' : '_test';
+    final relativeDirectory = p.join('..', 'fixtures', packageName);
 
     final relativeEntry = p.join(
-        '..', 'fixtures', '_testSound', 'example', 'append_body', 'main.dart');
+        '..', 'fixtures', packageName, 'example', 'append_body', 'main.dart');
 
     workingDirectory = p.normalize(p
         .absolute(directory ?? p.relative(relativeDirectory, from: p.current)));
@@ -156,7 +161,6 @@ class TestContext {
     bool waitToDebug = false,
     UrlEncoder? urlEncoder,
     CompilationMode compilationMode = CompilationMode.buildDaemon,
-    NullSafety nullSafety = NullSafety.sound,
     bool enableExpressionEvaluation = false,
     bool verboseCompiler = false,
     SdkConfigurationProvider? sdkConfigurationProvider,
@@ -165,6 +169,14 @@ class TestContext {
     bool isFlutterApp = false,
     bool isInternalBuild = false,
   }) async {
+    // TODO(https://github.com/dart-lang/webdev/issues/1591): Support compiling
+    // with sound null-safety in Frontend Server.
+    if (compilationMode == CompilationMode.frontendServer &&
+        nullSafety == NullSafety.sound) {
+      throw Exception(
+          'Frontend Server compilation does not support sound null-safety. See https://github.com/dart-lang/webdev/issues/1591');
+    }
+
     sdkConfigurationProvider ??= DefaultSdkConfigurationProvider();
 
     try {

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -117,10 +117,10 @@ class TestContext {
       String? entry,
       this.path = 'hello_world/index.html',
       this.pathToServe = 'example'}) {
-    final relativeDirectory = p.join('..', 'fixtures', '_test');
+    final relativeDirectory = p.join('..', 'fixtures', '_testSound');
 
     final relativeEntry = p.join(
-        '..', 'fixtures', '_test', 'example', 'append_body', 'main.dart');
+        '..', 'fixtures', '_testSound', 'example', 'append_body', 'main.dart');
 
     workingDirectory = p.normalize(p
         .absolute(directory ?? p.relative(relativeDirectory, from: p.current)));

--- a/dwds/test/frontend_server_breakpoint_test.dart
+++ b/dwds/test/frontend_server_breakpoint_test.dart
@@ -38,11 +38,9 @@ void main() {
   // currently redirected to a logger. As a result, it will be printed
   // regardless of the logger settings.
   final verboseCompiler = false;
-
-  // TODO(https://github.com/dart-lang/webdev/issues/1591): Frontend server
-  // compilation is currently incompatible with sound null safety.
-  if (supportedNullSafetyModes.contains(NullSafety.weak)) {
-    group('shared context', () {
+  group(
+    'shared context',
+    () {
       setUpAll(() async {
         setCurrentLogWriter(debug: debug);
         await context.setUp(
@@ -136,6 +134,11 @@ void main() {
           await service.removeBreakpoint(isolateId, bp.id!);
         });
       });
-    });
-  }
+    },
+    // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+    skip: !supportedMode(
+      compilationMode: CompilationMode.frontendServer,
+      nullSafetyMode: NullSafety.weak,
+    ),
+  );
 }

--- a/dwds/test/frontend_server_breakpoint_test.dart
+++ b/dwds/test/frontend_server_breakpoint_test.dart
@@ -14,12 +14,15 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
+import 'utils/version_compatibility.dart';
 
 final context = TestContext(
-    directory: p.join('..', 'fixtures', '_testPackageSound'),
-    entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
-    path: 'index.html',
-    pathToServe: 'web');
+  directory: p.join('..', 'fixtures', '_testSound'),
+  entry: p.join('..', 'fixtures', '_testSound', 'web', 'main.dart'),
+  path: 'index.html',
+  pathToServe: 'web',
+  nullSafety: NullSafety.weak,
+);
 
 ChromeProxyService get service =>
     fetchChromeProxyService(context.debugConnection);
@@ -36,99 +39,103 @@ void main() {
   // regardless of the logger settings.
   final verboseCompiler = false;
 
-  group('shared context', () {
-    setUpAll(() async {
-      setCurrentLogWriter(debug: debug);
-      await context.setUp(
-        compilationMode: CompilationMode.frontendServer,
-        verboseCompiler: verboseCompiler,
-      );
-    });
-
-    tearDownAll(() async {
-      await context.tearDown();
-    });
-
-    group('breakpoint', () {
-      VM vm;
-      late Isolate isolate;
-      late String isolateId;
-      ScriptList scripts;
-      late ScriptRef mainScript;
-      late String mainScriptUri;
-      late Stream<Event> stream;
-
-      setUp(() async {
+  // TODO(https://github.com/dart-lang/webdev/issues/1591): Frontend server
+  // compilation is currently incompatible with sound null safety.
+  if (supportedNullSafetyModes().contains(NullSafety.weak)) {
+    group('shared context', () {
+      setUpAll(() async {
         setCurrentLogWriter(debug: debug);
-        vm = await service.getVM();
-        isolate = await service.getIsolate(vm.isolates!.first.id!);
-        isolateId = isolate.id!;
-        scripts = await service.getScripts(isolateId);
-
-        await service.streamListen('Debug');
-        stream = service.onEvent('Debug');
-
-        mainScript = scripts.scripts!
-            .firstWhere((each) => each.uri!.contains('main.dart'));
-        mainScriptUri = mainScript.uri!;
+        await context.setUp(
+          compilationMode: CompilationMode.frontendServer,
+          verboseCompiler: verboseCompiler,
+        );
       });
 
-      tearDown(() async {
-        await service.resume(isolateId);
+      tearDownAll(() async {
+        await context.tearDown();
       });
 
-      test('set breakpoint', () async {
-        final line = await context.findBreakpointLine(
-            'printLocal', isolateId, mainScript);
-        final bp = await service.addBreakpointWithScriptUri(
-            isolateId, mainScriptUri, line);
+      group('breakpoint', () {
+        VM vm;
+        late Isolate isolate;
+        late String isolateId;
+        ScriptList scripts;
+        late ScriptRef mainScript;
+        late String mainScriptUri;
+        late Stream<Event> stream;
 
-        await stream.firstWhere(
-            (Event event) => event.kind == EventKind.kPauseBreakpoint);
+        setUp(() async {
+          setCurrentLogWriter(debug: debug);
+          vm = await service.getVM();
+          isolate = await service.getIsolate(vm.isolates!.first.id!);
+          isolateId = isolate.id!;
+          scripts = await service.getScripts(isolateId);
 
-        expect(bp, isNotNull);
+          await service.streamListen('Debug');
+          stream = service.onEvent('Debug');
 
-        // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolateId, bp.id!);
-      });
+          mainScript = scripts.scripts!
+              .firstWhere((each) => each.uri!.contains('main.dart'));
+          mainScriptUri = mainScript.uri!;
+        });
 
-      test('set breakpoint again', () async {
-        final line = await context.findBreakpointLine(
-            'printLocal', isolateId, mainScript);
-        final bp = await service.addBreakpointWithScriptUri(
-            isolateId, mainScriptUri, line);
+        tearDown(() async {
+          await service.resume(isolateId);
+        });
 
-        await stream.firstWhere(
-            (Event event) => event.kind == EventKind.kPauseBreakpoint);
+        test('set breakpoint', () async {
+          final line = await context.findBreakpointLine(
+              'printLocal', isolateId, mainScript);
+          final bp = await service.addBreakpointWithScriptUri(
+              isolateId, mainScriptUri, line);
 
-        expect(bp, isNotNull);
+          await stream.firstWhere(
+              (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
-        // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolateId, bp.id!);
-      });
+          expect(bp, isNotNull);
 
-      test('set breakpoint inside a JavaScript line succeeds', () async {
-        final line = await context.findBreakpointLine(
-            'printNestedObjectMultiLine', isolateId, mainScript);
-        final column = 0;
-        final bp = await service.addBreakpointWithScriptUri(
-            isolateId, mainScriptUri, line,
-            column: column);
+          // Remove breakpoint so it doesn't impact other tests.
+          await service.removeBreakpoint(isolateId, bp.id!);
+        });
 
-        await stream.firstWhere(
-            (Event event) => event.kind == EventKind.kPauseBreakpoint);
+        test('set breakpoint again', () async {
+          final line = await context.findBreakpointLine(
+              'printLocal', isolateId, mainScript);
+          final bp = await service.addBreakpointWithScriptUri(
+              isolateId, mainScriptUri, line);
 
-        expect(bp, isNotNull);
-        expect(
-            bp.location,
-            isA<SourceLocation>()
-                .having((loc) => loc.script, 'script', equals(mainScript))
-                .having((loc) => loc.line, 'line', equals(line))
-                .having((loc) => loc.column, 'column', greaterThan(column)));
+          await stream.firstWhere(
+              (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
-        // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolateId, bp.id!);
+          expect(bp, isNotNull);
+
+          // Remove breakpoint so it doesn't impact other tests.
+          await service.removeBreakpoint(isolateId, bp.id!);
+        });
+
+        test('set breakpoint inside a JavaScript line succeeds', () async {
+          final line = await context.findBreakpointLine(
+              'printNestedObjectMultiLine', isolateId, mainScript);
+          final column = 0;
+          final bp = await service.addBreakpointWithScriptUri(
+              isolateId, mainScriptUri, line,
+              column: column);
+
+          await stream.firstWhere(
+              (Event event) => event.kind == EventKind.kPauseBreakpoint);
+
+          expect(bp, isNotNull);
+          expect(
+              bp.location,
+              isA<SourceLocation>()
+                  .having((loc) => loc.script, 'script', equals(mainScript))
+                  .having((loc) => loc.line, 'line', equals(line))
+                  .having((loc) => loc.column, 'column', greaterThan(column)));
+
+          // Remove breakpoint so it doesn't impact other tests.
+          await service.removeBreakpoint(isolateId, bp.id!);
+        });
       });
     });
-  });
+  }
 }

--- a/dwds/test/frontend_server_breakpoint_test.dart
+++ b/dwds/test/frontend_server_breakpoint_test.dart
@@ -16,8 +16,8 @@ import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
 
 final context = TestContext(
-    directory: p.join('..', 'fixtures', '_testPackage'),
-    entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
+    directory: p.join('..', 'fixtures', '_testPackageSound'),
+    entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
     path: 'index.html',
     pathToServe: 'web');
 

--- a/dwds/test/frontend_server_breakpoint_test.dart
+++ b/dwds/test/frontend_server_breakpoint_test.dart
@@ -41,7 +41,7 @@ void main() {
 
   // TODO(https://github.com/dart-lang/webdev/issues/1591): Frontend server
   // compilation is currently incompatible with sound null safety.
-  if (supportedNullSafetyModes().contains(NullSafety.weak)) {
+  if (supportedNullSafetyModes.contains(NullSafety.weak)) {
     group('shared context', () {
       setUpAll(() async {
         setCurrentLogWriter(debug: debug);

--- a/dwds/test/frontend_server_breakpoint_test.dart
+++ b/dwds/test/frontend_server_breakpoint_test.dart
@@ -17,8 +17,8 @@ import 'fixtures/logging.dart';
 import 'utils/version_compatibility.dart';
 
 final context = TestContext(
-  directory: p.join('..', 'fixtures', '_testSound'),
-  entry: p.join('..', 'fixtures', '_testSound', 'web', 'main.dart'),
+  directory: p.join('..', 'fixtures', '_testPackage'),
+  entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
   path: 'index.html',
   pathToServe: 'web',
   nullSafety: NullSafety.weak,

--- a/dwds/test/frontend_server_callstack_test.dart
+++ b/dwds/test/frontend_server_callstack_test.dart
@@ -17,16 +17,20 @@ import 'fixtures/logging.dart';
 
 class TestSetup {
   static final contextUnsound = TestContext(
-      directory: p.join('..', 'fixtures', '_testPackage'),
-      entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
-      path: 'index.html',
-      pathToServe: 'web');
+    directory: p.join('..', 'fixtures', '_testPackage'),
+    entry: p.join('..', 'fixtures', '_testPackage', 'web', 'main.dart'),
+    path: 'index.html',
+    pathToServe: 'web',
+    nullSafety: NullSafety.weak,
+  );
 
   static final contextSound = TestContext(
-      directory: p.join('..', 'fixtures', '_testPackageSound'),
-      entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
-      path: 'index.html',
-      pathToServe: 'web');
+    directory: p.join('..', 'fixtures', '_testPackageSound'),
+    entry: p.join('..', 'fixtures', '_testPackageSound', 'web', 'main.dart'),
+    path: 'index.html',
+    pathToServe: 'web',
+    nullSafety: NullSafety.sound,
+  );
 
   TestContext context;
 
@@ -54,7 +58,6 @@ void main() {
           setCurrentLogWriter(debug: debug);
           await context.setUp(
               compilationMode: CompilationMode.frontendServer,
-              nullSafety: nullSafety,
               enableExpressionEvaluation: true,
               verboseCompiler: debug);
         });

--- a/dwds/test/frontend_server_callstack_test.dart
+++ b/dwds/test/frontend_server_callstack_test.dart
@@ -49,265 +49,274 @@ void main() {
     // Enable verbose logging for debugging.
     final debug = false;
 
-    for (var nullSafety in supportedNullSafetyModes) {
-      final soundNullSafety = nullSafety == NullSafety.sound;
-      final setup = soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
-      final context = setup.context;
+    for (var nullSafety in NullSafety.values) {
+      group(
+        '${nullSafety.name} null safety |',
+        () {
+          final soundNullSafety = nullSafety == NullSafety.sound;
+          final setup =
+              soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
+          final context = setup.context;
 
-      group('${nullSafety.name} null safety |', () {
-        setUpAll(() async {
-          setCurrentLogWriter(debug: debug);
-          await context.setUp(
-              compilationMode: CompilationMode.frontendServer,
-              enableExpressionEvaluation: true,
-              verboseCompiler: debug);
-        });
-
-        tearDownAll(() async {
-          await context.tearDown();
-        });
-
-        group('callStack |', () {
-          late ChromeProxyService service;
-          VM vm;
-          late Isolate isolate;
-          late String isolateId;
-          ScriptList scripts;
-          late ScriptRef mainScript;
-          late ScriptRef testLibraryScript;
-          late Stream<Event> stream;
-
-          setUp(() async {
+          setUpAll(() async {
             setCurrentLogWriter(debug: debug);
-            service = setup.service;
-            vm = await service.getVM();
-            isolate = await service.getIsolate(vm.isolates!.first.id!);
-            isolateId = isolate.id!;
-            scripts = await service.getScripts(isolateId);
-
-            await service.streamListen('Debug');
-            stream = service.onEvent('Debug');
-
-            final testPackage =
-                soundNullSafety ? '_test_package_sound' : '_test_package';
-
-            mainScript = scripts.scripts!
-                .firstWhere((each) => each.uri!.contains('main.dart'));
-            testLibraryScript = scripts.scripts!.firstWhere((each) =>
-                each.uri!.contains('package:$testPackage/test_library.dart'));
+            await context.setUp(
+                compilationMode: CompilationMode.frontendServer,
+                enableExpressionEvaluation: true,
+                verboseCompiler: debug);
           });
 
-          tearDown(() async {
-            await service.resume(isolateId);
+          tearDownAll(() async {
+            await context.tearDown();
           });
 
-          Future<void> onBreakPoint(BreakpointTestData breakpoint,
-              Future<void> Function() body) async {
-            Breakpoint? bp;
-            try {
-              final bpId = breakpoint.bpId;
-              final script = breakpoint.script;
-              final line =
-                  await context.findBreakpointLine(bpId, isolateId, script);
-              bp = await setup.service
-                  .addBreakpointWithScriptUri(isolateId, script.uri!, line);
+          group('callStack |', () {
+            late ChromeProxyService service;
+            VM vm;
+            late Isolate isolate;
+            late String isolateId;
+            ScriptList scripts;
+            late ScriptRef mainScript;
+            late ScriptRef testLibraryScript;
+            late Stream<Event> stream;
 
-              expect(bp, isNotNull);
-              expect(bp.location, _matchBpLocation(script, line, 0));
+            setUp(() async {
+              setCurrentLogWriter(debug: debug);
+              service = setup.service;
+              vm = await service.getVM();
+              isolate = await service.getIsolate(vm.isolates!.first.id!);
+              isolateId = isolate.id!;
+              scripts = await service.getScripts(isolateId);
 
-              await stream.firstWhere(
-                  (Event event) => event.kind == EventKind.kPauseBreakpoint);
+              await service.streamListen('Debug');
+              stream = service.onEvent('Debug');
 
-              await body();
-            } finally {
-              // Remove breakpoint so it doesn't impact other tests or retries.
-              if (bp != null) {
-                await setup.service.removeBreakpoint(isolateId, bp.id!);
+              final testPackage =
+                  soundNullSafety ? '_test_package_sound' : '_test_package';
+
+              mainScript = scripts.scripts!
+                  .firstWhere((each) => each.uri!.contains('main.dart'));
+              testLibraryScript = scripts.scripts!.firstWhere((each) =>
+                  each.uri!.contains('package:$testPackage/test_library.dart'));
+            });
+
+            tearDown(() async {
+              await service.resume(isolateId);
+            });
+
+            Future<void> onBreakPoint(BreakpointTestData breakpoint,
+                Future<void> Function() body) async {
+              Breakpoint? bp;
+              try {
+                final bpId = breakpoint.bpId;
+                final script = breakpoint.script;
+                final line =
+                    await context.findBreakpointLine(bpId, isolateId, script);
+                bp = await setup.service
+                    .addBreakpointWithScriptUri(isolateId, script.uri!, line);
+
+                expect(bp, isNotNull);
+                expect(bp.location, _matchBpLocation(script, line, 0));
+
+                await stream.firstWhere(
+                    (Event event) => event.kind == EventKind.kPauseBreakpoint);
+
+                await body();
+              } finally {
+                // Remove breakpoint so it doesn't impact other tests or retries.
+                if (bp != null) {
+                  await setup.service.removeBreakpoint(isolateId, bp.id!);
+                }
               }
             }
-          }
 
-          Future<void> testCallStack(List<BreakpointTestData> breakpoints,
-              {int frameIndex = 1}) async {
-            // Find lines the breakpoints are located on.
-            final lines = await Future.wait(breakpoints.map((frame) => context
-                .findBreakpointLine(frame.bpId, isolateId, frame.script)));
+            Future<void> testCallStack(List<BreakpointTestData> breakpoints,
+                {int frameIndex = 1}) async {
+              // Find lines the breakpoints are located on.
+              final lines = await Future.wait(breakpoints.map((frame) => context
+                  .findBreakpointLine(frame.bpId, isolateId, frame.script)));
 
-            // Get current stack.
-            final stack = await service.getStack(isolateId);
+              // Get current stack.
+              final stack = await service.getStack(isolateId);
 
-            // Verify the stack is correct.
-            expect(stack.frames!.length, greaterThanOrEqualTo(lines.length));
-            final expected = [
-              for (var i = 0; i < lines.length; i++)
-                _matchFrame(
-                    breakpoints[i].script, breakpoints[i].function, lines[i])
-            ];
-            expect(stack.frames, containsAll(expected));
+              // Verify the stack is correct.
+              expect(stack.frames!.length, greaterThanOrEqualTo(lines.length));
+              final expected = [
+                for (var i = 0; i < lines.length; i++)
+                  _matchFrame(
+                      breakpoints[i].script, breakpoints[i].function, lines[i])
+              ];
+              expect(stack.frames, containsAll(expected));
 
-            // Verify that expression evaluation is not failing.
-            final instance =
-                await service.evaluateInFrame(isolateId, frameIndex, 'true');
-            expect(instance, isA<InstanceRef>());
-          }
+              // Verify that expression evaluation is not failing.
+              final instance =
+                  await service.evaluateInFrame(isolateId, frameIndex, 'true');
+              expect(instance, isA<InstanceRef>());
+            }
 
-          test('breakpoint succeeds with correct callstack', () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'printEnclosingObject',
-                'printEnclosingObject',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'printEnclosingFunctionMultiLine',
-                'printNestedObjectsMultiLine',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintEnclosingFunctionMultiLine',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            await onBreakPoint(
-                breakpoints[0], () => testCallStack(breakpoints));
-          });
+            test('breakpoint succeeds with correct callstack', () async {
+              // Expected breakpoints on the stack
+              final breakpoints = [
+                BreakpointTestData(
+                  'printEnclosingObject',
+                  'printEnclosingObject',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  'printEnclosingFunctionMultiLine',
+                  'printNestedObjectsMultiLine',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  'callPrintEnclosingFunctionMultiLine',
+                  '<closure>',
+                  mainScript,
+                ),
+              ];
+              await onBreakPoint(
+                  breakpoints[0], () => testCallStack(breakpoints));
+            });
 
-          test('expression evaluation succeeds on parent frame', () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'testLibraryClassConstructor',
-                'new',
-                testLibraryScript,
-              ),
-              BreakpointTestData(
-                'createLibraryObject',
-                'printFieldFromLibraryClass',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintFieldFromLibraryClass',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            await onBreakPoint(breakpoints[0],
-                () => testCallStack(breakpoints, frameIndex: 2));
-          });
+            test('expression evaluation succeeds on parent frame', () async {
+              // Expected breakpoints on the stack
+              final breakpoints = [
+                BreakpointTestData(
+                  'testLibraryClassConstructor',
+                  'new',
+                  testLibraryScript,
+                ),
+                BreakpointTestData(
+                  'createLibraryObject',
+                  'printFieldFromLibraryClass',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  'callPrintFieldFromLibraryClass',
+                  '<closure>',
+                  mainScript,
+                ),
+              ];
+              await onBreakPoint(breakpoints[0],
+                  () => testCallStack(breakpoints, frameIndex: 2));
+            });
 
-          test('breakpoint inside a line gives correct callstack', () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'newEnclosedClass',
-                'new',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'printNestedObjectMultiLine',
-                'printNestedObjectsMultiLine',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintEnclosingFunctionMultiLine',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            await onBreakPoint(
-                breakpoints[0], () => testCallStack(breakpoints));
-          });
+            test('breakpoint inside a line gives correct callstack', () async {
+              // Expected breakpoints on the stack
+              final breakpoints = [
+                BreakpointTestData(
+                  'newEnclosedClass',
+                  'new',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  'printNestedObjectMultiLine',
+                  'printNestedObjectsMultiLine',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  'callPrintEnclosingFunctionMultiLine',
+                  '<closure>',
+                  mainScript,
+                ),
+              ];
+              await onBreakPoint(
+                  breakpoints[0], () => testCallStack(breakpoints));
+            });
 
-          test('breakpoint gives correct callstack after step out', () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'newEnclosedClass',
-                'new',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'printEnclosingObjectMultiLine',
-                'printNestedObjectsMultiLine',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintEnclosingFunctionMultiLine',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            await onBreakPoint(breakpoints[0], () async {
-              await service.resume(isolateId, step: 'Out');
-              await stream.firstWhere(
-                  (Event event) => event.kind == EventKind.kPauseInterrupted);
-              return testCallStack([breakpoints[1], breakpoints[2]]);
+            test('breakpoint gives correct callstack after step out', () async {
+              // Expected breakpoints on the stack
+              final breakpoints = [
+                BreakpointTestData(
+                  'newEnclosedClass',
+                  'new',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  'printEnclosingObjectMultiLine',
+                  'printNestedObjectsMultiLine',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  'callPrintEnclosingFunctionMultiLine',
+                  '<closure>',
+                  mainScript,
+                ),
+              ];
+              await onBreakPoint(breakpoints[0], () async {
+                await service.resume(isolateId, step: 'Out');
+                await stream.firstWhere(
+                    (Event event) => event.kind == EventKind.kPauseInterrupted);
+                return testCallStack([breakpoints[1], breakpoints[2]]);
+              });
+            });
+
+            test('breakpoint gives correct callstack after step in', () async {
+              // Expected breakpoints on the stack
+              final breakpoints = [
+                BreakpointTestData(
+                  'newEnclosedClass',
+                  'new',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  'printNestedObjectMultiLine',
+                  'printNestedObjectsMultiLine',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  'callPrintEnclosingFunctionMultiLine',
+                  '<closure>',
+                  mainScript,
+                ),
+              ];
+              await onBreakPoint(breakpoints[1], () async {
+                await service.resume(isolateId, step: 'Into');
+                await stream.firstWhere(
+                    (Event event) => event.kind == EventKind.kPauseInterrupted);
+                return testCallStack(breakpoints);
+              });
+            });
+
+            test(
+                'breakpoint gives correct callstack after step into chain calls',
+                () async {
+              // Expected breakpoints on the stack
+              final breakpoints = [
+                BreakpointTestData(
+                  'createObjectWithMethod',
+                  'createObject',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  // This is currently incorrect, should be printObjectMultiLine.
+                  // See issue: https://github.com/dart-lang/sdk/issues/48874
+                  'printMultiLine',
+                  'printObjectMultiLine',
+                  mainScript,
+                ),
+                BreakpointTestData(
+                  'callPrintObjectMultiLine',
+                  '<closure>',
+                  mainScript,
+                ),
+              ];
+              final bp = BreakpointTestData(
+                  'printMultiLine', 'printObjectMultiLine', mainScript);
+              await onBreakPoint(bp, () async {
+                await service.resume(isolateId, step: 'Into');
+                await stream.firstWhere(
+                    (Event event) => event.kind == EventKind.kPauseInterrupted);
+                return testCallStack(breakpoints);
+              });
             });
           });
-
-          test('breakpoint gives correct callstack after step in', () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'newEnclosedClass',
-                'new',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'printNestedObjectMultiLine',
-                'printNestedObjectsMultiLine',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintEnclosingFunctionMultiLine',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            await onBreakPoint(breakpoints[1], () async {
-              await service.resume(isolateId, step: 'Into');
-              await stream.firstWhere(
-                  (Event event) => event.kind == EventKind.kPauseInterrupted);
-              return testCallStack(breakpoints);
-            });
-          });
-
-          test('breakpoint gives correct callstack after step into chain calls',
-              () async {
-            // Expected breakpoints on the stack
-            final breakpoints = [
-              BreakpointTestData(
-                'createObjectWithMethod',
-                'createObject',
-                mainScript,
-              ),
-              BreakpointTestData(
-                // This is currently incorrect, should be printObjectMultiLine.
-                // See issue: https://github.com/dart-lang/sdk/issues/48874
-                'printMultiLine',
-                'printObjectMultiLine',
-                mainScript,
-              ),
-              BreakpointTestData(
-                'callPrintObjectMultiLine',
-                '<closure>',
-                mainScript,
-              ),
-            ];
-            final bp = BreakpointTestData(
-                'printMultiLine', 'printObjectMultiLine', mainScript);
-            await onBreakPoint(bp, () async {
-              await service.resume(isolateId, step: 'Into');
-              await stream.firstWhere(
-                  (Event event) => event.kind == EventKind.kPauseInterrupted);
-              return testCallStack(breakpoints);
-            });
-          });
-        });
-      }, // https://github.com/dart-lang/webdev/issues/1591
-          skip: soundNullSafety);
+        },
+        // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+        skip: !supportedMode(
+          compilationMode: CompilationMode.frontendServer,
+          nullSafetyMode: nullSafety,
+        ),
+      );
     }
   });
 }

--- a/dwds/test/frontend_server_callstack_test.dart
+++ b/dwds/test/frontend_server_callstack_test.dart
@@ -14,6 +14,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
+import 'utils/version_compatibility.dart';
 
 class TestSetup {
   static final contextUnsound = TestContext(
@@ -48,7 +49,7 @@ void main() {
     // Enable verbose logging for debugging.
     final debug = false;
 
-    for (var nullSafety in NullSafety.values) {
+    for (var nullSafety in supportedNullSafetyModes) {
       final soundNullSafety = nullSafety == NullSafety.sound;
       final setup = soundNullSafety ? TestSetup.sound() : TestSetup.unsound();
       final context = setup.context;

--- a/dwds/test/frontend_server_circular_evaluate_test.dart
+++ b/dwds/test/frontend_server_circular_evaluate_test.dart
@@ -11,6 +11,7 @@ import 'package:test/test.dart';
 
 import 'fixtures/context.dart';
 import 'evaluate_circular_common.dart';
+import 'utils/version_compatibility.dart';
 
 void main() async {
   // Enable verbose logging for debugging.
@@ -20,13 +21,9 @@ void main() async {
   final debuggerModuleNamesSupported =
       Version.parse(Platform.version.split(' ').first) >=
           Version.parse('2.19.0-150.0.dev');
-  final sdkVersion = Version.parse(Platform.version.split(' ')[0]);
-  final nullSafetyValues = (sdkVersion.major >= 3)
-      ? [NullSafety.sound]
-      : [NullSafety.sound, NullSafety.weak];
 
   group('Context with circular dependencies |', () {
-    for (var nullSafety in nullSafetyValues) {
+    for (var nullSafety in supportedNullSafetyModes()) {
       group('${nullSafety.name} null safety |', () {
         for (var indexBaseMode in IndexBaseMode.values) {
           group(

--- a/dwds/test/frontend_server_circular_evaluate_test.dart
+++ b/dwds/test/frontend_server_circular_evaluate_test.dart
@@ -20,9 +20,13 @@ void main() async {
   final debuggerModuleNamesSupported =
       Version.parse(Platform.version.split(' ').first) >=
           Version.parse('2.19.0-150.0.dev');
+  final sdkVersion = Version.parse(Platform.version.split(' ')[0]);
+  final nullSafetyValues = (sdkVersion.major >= 3)
+      ? [NullSafety.sound]
+      : [NullSafety.sound, NullSafety.weak];
 
   group('Context with circular dependencies |', () {
-    for (var nullSafety in NullSafety.values) {
+    for (var nullSafety in nullSafetyValues) {
       group('${nullSafety.name} null safety |', () {
         for (var indexBaseMode in IndexBaseMode.values) {
           group(

--- a/dwds/test/frontend_server_circular_evaluate_test.dart
+++ b/dwds/test/frontend_server_circular_evaluate_test.dart
@@ -23,7 +23,7 @@ void main() async {
           Version.parse('2.19.0-150.0.dev');
 
   group('Context with circular dependencies |', () {
-    for (var nullSafety in supportedNullSafetyModes()) {
+    for (var nullSafety in supportedNullSafetyModes) {
       group('${nullSafety.name} null safety |', () {
         for (var indexBaseMode in IndexBaseMode.values) {
           group(

--- a/dwds/test/frontend_server_circular_evaluate_test.dart
+++ b/dwds/test/frontend_server_circular_evaluate_test.dart
@@ -23,28 +23,30 @@ void main() async {
           Version.parse('2.19.0-150.0.dev');
 
   group('Context with circular dependencies |', () {
-    for (var nullSafety in supportedNullSafetyModes) {
+    for (var nullSafety in NullSafety.values) {
       group('${nullSafety.name} null safety |', () {
         for (var indexBaseMode in IndexBaseMode.values) {
-          group(
-            'with ${indexBaseMode.name} |',
-            () {
-              testAll(
-                compilationMode: CompilationMode.frontendServer,
-                indexBaseMode: indexBaseMode,
-                nullSafety: nullSafety,
-                useDebuggerModuleNames: true,
-                debug: debug,
-              );
-            },
-            skip:
-                // https://github.com/dart-lang/sdk/issues/49277
-                indexBaseMode == IndexBaseMode.base && Platform.isWindows ||
-                    // https://github.com/dart-lang/webdev/issues/1591);
-                    nullSafety == NullSafety.sound ||
-                    // Needs debugger module names change in the SDK to work.
-                    !debuggerModuleNamesSupported,
-          );
+          group('with ${indexBaseMode.name} |', () {
+            testAll(
+              compilationMode: CompilationMode.frontendServer,
+              indexBaseMode: indexBaseMode,
+              nullSafety: nullSafety,
+              useDebuggerModuleNames: true,
+              debug: debug,
+            );
+          },
+              skip:
+                  // https://github.com/dart-lang/sdk/issues/49277
+                  indexBaseMode == IndexBaseMode.base && Platform.isWindows ||
+                      // https://github.com/dart-lang/webdev/issues/1591);
+                      nullSafety == NullSafety.sound ||
+                      // Needs debugger module names change in the SDK to work.
+                      !debuggerModuleNamesSupported ||
+                      // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+                      !supportedMode(
+                        compilationMode: CompilationMode.frontendServer,
+                        nullSafetyMode: nullSafety,
+                      ));
         }
       });
     }

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -24,7 +24,7 @@ void main() async {
 
   for (var useDebuggerModuleNames in [false, true]) {
     group('Debugger module names: $useDebuggerModuleNames |', () {
-      for (var nullSafety in supportedNullSafetyModes) {
+      for (var nullSafety in NullSafety.values) {
         group('${nullSafety.name} null safety |', () {
           for (var indexBaseMode in IndexBaseMode.values) {
             group(
@@ -44,7 +44,13 @@ void main() async {
                       // https://github.com/dart-lang/webdev/issues/1591
                       (nullSafety == NullSafety.sound) ||
                       // Needs debugger module names feature in SDK.
-                      (useDebuggerModuleNames && !debuggerModuleNamesSupported),
+                      (useDebuggerModuleNames &&
+                          !debuggerModuleNamesSupported) ||
+                      // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+                      !supportedMode(
+                        compilationMode: CompilationMode.frontendServer,
+                        nullSafetyMode: nullSafety,
+                      ),
             );
           }
         });

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -11,6 +11,7 @@ import 'package:test/test.dart';
 
 import 'fixtures/context.dart';
 import 'evaluate_common.dart';
+import 'utils/version_compatibility.dart';
 
 void main() async {
   // Enable verbose logging for debugging.
@@ -23,7 +24,7 @@ void main() async {
 
   for (var useDebuggerModuleNames in [false, true]) {
     group('Debugger module names: $useDebuggerModuleNames |', () {
-      for (var nullSafety in NullSafety.values) {
+      for (var nullSafety in supportedNullSafetyModes) {
         group('${nullSafety.name} null safety |', () {
           for (var indexBaseMode in IndexBaseMode.values) {
             group(

--- a/dwds/test/package_uri_mapper_test.dart
+++ b/dwds/test/package_uri_mapper_test.dart
@@ -17,19 +17,19 @@ void main() {
       final fileSystem = LocalFileSystem();
 
       final packageUri =
-          Uri(scheme: 'package', path: '_test_package/test_library.dart');
+          Uri(scheme: 'package', path: '_test_package_sound/test_library.dart');
 
       final serverPath = useDebuggerModuleNames
-          ? 'packages/_testPackage/lib/test_library.dart'
-          : '/packages/_test_package/test_library.dart';
+          ? 'packages/_testPackageSound/lib/test_library.dart'
+          : '/packages/_test_package_sound/test_library.dart';
 
       final resolvedPath =
-          '/webdev/fixtures/_testPackage/lib/test_library.dart';
+          '/webdev/fixtures/_testPackageSound/lib/test_library.dart';
 
       final packageConfigFile = Uri.file(p.normalize(p.absolute(p.join(
         '..',
         'fixtures',
-        '_testPackage',
+        '_testPackageSound',
         '.dart_tool',
         'package_config.json',
       ))));

--- a/dwds/test/readers/frontend_server_asset_reader_test.dart
+++ b/dwds/test/readers/frontend_server_asset_reader_test.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../fixtures/utilities.dart';
+import '../utils/version_compatibility.dart';
 
 final packagesDir = p.relative('../fixtures/_test', from: p.current);
 
@@ -108,5 +109,7 @@ void main() {
         expect(newResult, isNotNull);
       });
     });
-  });
+    // TODO(https://github.com/dart-lang/webdev/issues/1818): Re-enable. Not sure
+    // why this is passing locally but failing during CI tests.
+  }, skip: !versionSupportsWeakNullSafety);
 }

--- a/dwds/test/readers/frontend_server_asset_reader_test.dart
+++ b/dwds/test/readers/frontend_server_asset_reader_test.dart
@@ -9,6 +9,7 @@ import 'package:dwds/src/readers/frontend_server_asset_reader.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+import '../fixtures/context.dart';
 import '../fixtures/utilities.dart';
 import '../utils/version_compatibility.dart';
 
@@ -111,5 +112,9 @@ void main() {
     });
     // TODO(https://github.com/dart-lang/webdev/issues/1818): Re-enable. Not sure
     // why this is passing locally but failing during CI tests.
-  }, skip: !versionSupportsWeakNullSafety);
+  },
+      skip: !supportedMode(
+        compilationMode: CompilationMode.frontendServer,
+        nullSafetyMode: NullSafety.weak,
+      ));
 }

--- a/dwds/test/readers/proxy_server_asset_reader_test.dart
+++ b/dwds/test/readers/proxy_server_asset_reader_test.dart
@@ -9,14 +9,13 @@ import '../fixtures/context.dart';
 import '../utils/version_compatibility.dart';
 
 void main() {
-  final context = TestContext(nullSafety: NullSafety.weak);
-  late ProxyServerAssetReader assetReader;
-  setUpAll(() async {
-    await context.setUp();
-    assetReader = context.testServer.assetReader as ProxyServerAssetReader;
-  });
-
   group('ProxyServerAssetReader', () {
+    final context = TestContext(nullSafety: NullSafety.weak);
+    late ProxyServerAssetReader assetReader;
+    setUpAll(() async {
+      await context.setUp();
+      assetReader = context.testServer.assetReader as ProxyServerAssetReader;
+    });
     test('returns null if the dart path does not exist', () async {
       final result = await assetReader.dartSourceContents('some/path/foo.dart');
       expect(result, isNull);
@@ -32,14 +31,13 @@ void main() {
       final result = await assetReader
           .dartSourceContents('hello_world/main.unsound.ddc.js.map');
       expect(result, isNotNull);
-      // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
-    }, skip: !versionSupportsWeakNullSafety);
+    });
 
     test('returns null if the source map path does not exist', () async {
       final result = await assetReader
           .dartSourceContents('hello_world/foo.unsound.ddc.js.map');
       expect(result, isNull);
-      // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
-    }, skip: !versionSupportsWeakNullSafety);
-  });
+    });
+    // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+  }, skip: !versionSupportsWeakNullSafety);
 }

--- a/dwds/test/readers/proxy_server_asset_reader_test.dart
+++ b/dwds/test/readers/proxy_server_asset_reader_test.dart
@@ -38,6 +38,9 @@ void main() {
           .dartSourceContents('hello_world/foo.unsound.ddc.js.map');
       expect(result, isNull);
     });
-    // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
-  }, skip: !versionSupportsWeakNullSafety);
+  },
+      // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+      skip: !supportedMode(
+          compilationMode: CompilationMode.frontendServer,
+          nullSafetyMode: NullSafety.weak));
 }

--- a/dwds/test/readers/proxy_server_asset_reader_test.dart
+++ b/dwds/test/readers/proxy_server_asset_reader_test.dart
@@ -6,6 +6,7 @@ import 'package:dwds/src/readers/proxy_server_asset_reader.dart';
 import 'package:test/test.dart';
 
 import '../fixtures/context.dart';
+import '../utils/version_compatibility.dart';
 
 void main() {
   final context = TestContext();
@@ -31,12 +32,14 @@ void main() {
       final result = await assetReader
           .dartSourceContents('hello_world/main.unsound.ddc.js.map');
       expect(result, isNotNull);
-    });
+      // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+    }, skip: !versionSupportsWeakNullSafety);
 
     test('returns null if the source map path does not exist', () async {
       final result = await assetReader
           .dartSourceContents('hello_world/foo.unsound.ddc.js.map');
       expect(result, isNull);
-    });
+      // TODO(https://github.com/dart-lang/webdev/issues/1818) Re-enable.
+    }, skip: !versionSupportsWeakNullSafety);
   });
 }

--- a/dwds/test/readers/proxy_server_asset_reader_test.dart
+++ b/dwds/test/readers/proxy_server_asset_reader_test.dart
@@ -9,7 +9,7 @@ import '../fixtures/context.dart';
 import '../utils/version_compatibility.dart';
 
 void main() {
-  final context = TestContext();
+  final context = TestContext(nullSafety: NullSafety.weak);
   late ProxyServerAssetReader assetReader;
   setUpAll(() async {
     await context.setUp();

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -10,6 +10,7 @@ import 'package:vm_service/vm_service.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
+import 'utils/version_compatibility.dart';
 
 final context = TestContext(
   path: 'append_body/index.html',
@@ -207,7 +208,9 @@ void main() {
       final source = await context.webDriver.pageSource;
       // Main is re-invoked which shouldn't clear the state.
       expect(source, contains('Hello World!'));
-    });
+      // TODO(https://github.com/dart-lang/webdev/issues/1818): Re-enable. The
+      // callback passed to registerExtension requires a non-null return type.
+    }, skip: !versionSupportsWeakNullSafety);
 
     test('can refresh the page via the fullReload service extension', () async {
       final client = context.debugConnection.vmService;

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -210,7 +210,7 @@ void main() {
       expect(source, contains('Hello World!'));
       // TODO(https://github.com/dart-lang/webdev/issues/1818): Re-enable. The
       // callback passed to registerExtension requires a non-null return type.
-    }, skip: !versionSupportsWeakNullSafety);
+    }, skip: 'https://github.com/dart-lang/webdev/issues/1818');
 
     test('can refresh the page via the fullReload service extension', () async {
       final client = context.debugConnection.vmService;

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -10,7 +10,6 @@ import 'package:vm_service/vm_service.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/logging.dart';
-import 'utils/version_compatibility.dart';
 
 final context = TestContext(
   path: 'append_body/index.html',

--- a/dwds/test/utils/version_compatibility.dart
+++ b/dwds/test/utils/version_compatibility.dart
@@ -8,26 +8,6 @@ import 'package:pub_semver/pub_semver.dart';
 
 import '../fixtures/context.dart';
 
-bool get versionSupportsWeakNullSafety =>
-    Version.parse(Platform.version.split(' ')[0]).major < 3;
-
-List<NullSafety> get supportedNullSafetyModes {
-  return versionSupportsWeakNullSafety
-      ? [NullSafety.sound, NullSafety.weak]
-      : [NullSafety.sound];
-}
-
-// TODO(https://github.com/dart-lang/webdev/issues/1591): Frontend server
-// compilation is currently incompatible with sound null safety.
-List<CompilationMode> supportedCompilationModes(NullSafety nullSafetyMode) {
-  return nullSafetyMode == NullSafety.sound
-      ? [CompilationMode.buildDaemon]
-      : [
-          CompilationMode.buildDaemon,
-          CompilationMode.frontendServer,
-        ];
-}
-
 bool supportedMode(
     {required CompilationMode compilationMode,
     required NullSafety nullSafetyMode}) {

--- a/dwds/test/utils/version_compatibility.dart
+++ b/dwds/test/utils/version_compatibility.dart
@@ -11,9 +11,11 @@ import '../fixtures/context.dart';
 bool get versionSupportsWeakNullSafety =>
     Version.parse(Platform.version.split(' ')[0]).major < 3;
 
-List<NullSafety> get supportedNullSafetyModes => versionSupportsWeakNullSafety
-    ? [NullSafety.sound]
-    : [NullSafety.sound, NullSafety.weak];
+List<NullSafety> get supportedNullSafetyModes {
+  return versionSupportsWeakNullSafety
+      ? [NullSafety.sound, NullSafety.weak]
+      : [NullSafety.sound];
+}
 
 // TODO(https://github.com/dart-lang/webdev/issues/1591): Frontend server
 // compilation is currently incompatible with sound null safety.

--- a/dwds/test/utils/version_compatibility.dart
+++ b/dwds/test/utils/version_compatibility.dart
@@ -27,3 +27,22 @@ List<CompilationMode> supportedCompilationModes(NullSafety nullSafetyMode) {
           CompilationMode.frontendServer,
         ];
 }
+
+bool supportedMode(
+    {required CompilationMode compilationMode,
+    required NullSafety nullSafetyMode}) {
+  final isDart3 = Version.parse(Platform.version.split(' ')[0]).major == 3;
+  // TODO(https://github.com/dart-lang/webdev/issues/1818): Support compiling to
+  // to weak null-safety for both FrontendServer and BuildDaemon.
+  if (isDart3 && nullSafetyMode == NullSafety.weak) {
+    return false;
+  }
+  // TODO(https://github.com/dart-lang/webdev/issues/1591): Support compiling to
+  // sound null-safety for the FrontendServer.
+  if (compilationMode == CompilationMode.frontendServer &&
+      nullSafetyMode == NullSafety.sound) {
+    return false;
+  }
+  // All other modes are supported.
+  return true;
+}

--- a/dwds/test/utils/version_compatibility.dart
+++ b/dwds/test/utils/version_compatibility.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:pub_semver/pub_semver.dart';
+
+import '../fixtures/context.dart';
+
+List<NullSafety> supportedNullSafetyModes() {
+  final sdkVersion = Version.parse(Platform.version.split(' ')[0]);
+  return (sdkVersion.major >= 3)
+      ? [NullSafety.sound]
+      : [NullSafety.sound, NullSafety.weak];
+}
+
+// TODO(https://github.com/dart-lang/webdev/issues/1591): Frontend server
+// compilation is currently incompatible with sound null safety.
+List<CompilationMode> supportedCompilationModes(NullSafety nullSafetyMode) {
+  return nullSafetyMode == NullSafety.sound
+      ? [CompilationMode.buildDaemon]
+      : [
+          CompilationMode.buildDaemon,
+          CompilationMode.frontendServer,
+        ];
+}

--- a/dwds/test/utils/version_compatibility.dart
+++ b/dwds/test/utils/version_compatibility.dart
@@ -8,12 +8,12 @@ import 'package:pub_semver/pub_semver.dart';
 
 import '../fixtures/context.dart';
 
-List<NullSafety> supportedNullSafetyModes() {
-  final sdkVersion = Version.parse(Platform.version.split(' ')[0]);
-  return (sdkVersion.major >= 3)
-      ? [NullSafety.sound]
-      : [NullSafety.sound, NullSafety.weak];
-}
+bool get versionSupportsWeakNullSafety =>
+    Version.parse(Platform.version.split(' ')[0]).major < 3;
+
+List<NullSafety> get supportedNullSafetyModes => versionSupportsWeakNullSafety
+    ? [NullSafety.sound]
+    : [NullSafety.sound, NullSafety.weak];
 
 // TODO(https://github.com/dart-lang/webdev/issues/1591): Frontend server
 // compilation is currently incompatible with sound null safety.

--- a/fixtures/_testCircular1Sound/pubspec.yaml
+++ b/fixtures/_testCircular1Sound/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  intl: ^0.16.0
+  intl: ^0.17.0
   path: ^1.6.1
   _test_circular2_sound:
     path: ../_testCircular2Sound

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -3,10 +3,12 @@
 // found in the LICENSE file.
 
 // Note: this is a copy from flutter tools, updated to work with dwds tests
+import 'dart:io';
 
 import 'package:dwds/asset_reader.dart';
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 
 import 'asset_server.dart';
 import 'bootstrap.dart';
@@ -85,9 +87,13 @@ class WebDevFS {
 
     assetServer.writeFile('main_module.digests', '{}');
 
-    var sdk = soundNullSafety ? dartSdkSound : dartSdk;
+    final sdkVersion = Version.parse(Platform.version.split(' ')[0]);
+    var sdk =
+        (soundNullSafety && sdkVersion.major < 3) ? dartSdkSound : dartSdk;
     var sdkSourceMap =
-        soundNullSafety ? dartSdkSourcemapSound : dartSdkSourcemap;
+        (soundNullSafety && sdkVersion.major < 3)
+        ? dartSdkSourcemapSound
+        : dartSdkSourcemap;
     assetServer.writeFile('dart_sdk.js', sdk.readAsStringSync());
     assetServer.writeFile('dart_sdk.js.map', sdkSourceMap.readAsStringSync());
 

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -3,12 +3,10 @@
 // found in the LICENSE file.
 
 // Note: this is a copy from flutter tools, updated to work with dwds tests
-import 'dart:io';
 
 import 'package:dwds/asset_reader.dart';
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
-import 'package:pub_semver/pub_semver.dart';
 
 import 'asset_server.dart';
 import 'bootstrap.dart';
@@ -87,12 +85,9 @@ class WebDevFS {
 
     assetServer.writeFile('main_module.digests', '{}');
 
-    final sdkVersion = Version.parse(Platform.version.split(' ')[0]);
-    var sdk =
-        (soundNullSafety && sdkVersion.major < 3) ? dartSdkSound : dartSdk;
-    var sdkSourceMap = (soundNullSafety && sdkVersion.major < 3)
-        ? dartSdkSourcemapSound
-        : dartSdkSourcemap;
+    var sdk = soundNullSafety ? dartSdkSound : dartSdk;
+    var sdkSourceMap =
+        soundNullSafety ? dartSdkSourcemapSound : dartSdkSourcemap;
     assetServer.writeFile('dart_sdk.js', sdk.readAsStringSync());
     assetServer.writeFile('dart_sdk.js.map', sdkSourceMap.readAsStringSync());
 

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -90,8 +90,7 @@ class WebDevFS {
     final sdkVersion = Version.parse(Platform.version.split(' ')[0]);
     var sdk =
         (soundNullSafety && sdkVersion.major < 3) ? dartSdkSound : dartSdk;
-    var sdkSourceMap =
-        (soundNullSafety && sdkVersion.major < 3)
+    var sdkSourceMap = (soundNullSafety && sdkVersion.major < 3)
         ? dartSdkSourcemapSound
         : dartSdkSourcemap;
     assetServer.writeFile('dart_sdk.js', sdk.readAsStringSync());

--- a/frontend_server_common/pubspec.yaml
+++ b/frontend_server_common/pubspec.yaml
@@ -15,4 +15,5 @@ dependencies:
   shelf: ^1.1.4
   package_config: ^2.0.0
   path: ^1.8.0
+  pub_semver: ^2.1.1
   usage: ^4.0.0


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/1818

This addresses the first task, and is primarily to unblock the broken CI tests at head. It fixes what is fairly non-trivial to fix, and disables tests that will take more work. 