### PR TITLE
Fix `package_uri_file_mapper_test` on Linux

### DIFF
--- a/dwds/test/package_uri_mapper_test.dart
+++ b/dwds/test/package_uri_mapper_test.dart
@@ -42,6 +42,8 @@ void main() {
 
       late final PackageUriMapper packageUriMapper;
       setUpAll(() async {
+        // Note: Run `dart pub upgrade` before the test cases to fix
+        // https://github.com/dart-lang/webdev/issues/1834:
         await Process.run(
           'dart',
           ['pub', 'upgrade'],

--- a/dwds/test/package_uri_mapper_test.dart
+++ b/dwds/test/package_uri_mapper_test.dart
@@ -28,11 +28,11 @@ void main() {
       final resolvedPath =
           '/webdev/fixtures/_testPackageSound/lib/test_library.dart';
 
-      final testPackageSoundDir = Uri.file(p.normalize(p.absolute(p.join(
+      final testPackageSoundPath = p.normalize(p.absolute(p.join(
         '..',
         'fixtures',
         '_testPackageSound',
-      ))));
+      )));
 
       final packageConfigFile = Uri.file(p.normalize(p.absolute(p.join(
         '..',
@@ -47,7 +47,7 @@ void main() {
         await Process.run(
           'dart',
           ['pub', 'upgrade'],
-          workingDirectory: testPackageSoundDir.toFilePath(),
+          workingDirectory: testPackageSoundPath,
         );
 
         packageUriMapper = await PackageUriMapper.create(

--- a/dwds/test/package_uri_mapper_test.dart
+++ b/dwds/test/package_uri_mapper_test.dart
@@ -34,13 +34,11 @@ void main() {
         '_testPackageSound',
       )));
 
-      final packageConfigFile = Uri.file(p.normalize(p.absolute(p.join(
-        '..',
-        'fixtures',
-        '_testPackageSound',
+      final packageConfigFile = Uri.file(p.join(
+        testPackageSoundPath,
         '.dart_tool',
         'package_config.json',
-      ))));
+      ));
 
       late final PackageUriMapper packageUriMapper;
       setUpAll(() async {

--- a/dwds/test/package_uri_mapper_test.dart
+++ b/dwds/test/package_uri_mapper_test.dart
@@ -4,6 +4,8 @@
 
 @TestOn('vm')
 
+import 'dart:io';
+
 import 'package:dwds/dwds.dart';
 import 'package:file/local.dart';
 import 'package:path/path.dart' as p;
@@ -26,6 +28,12 @@ void main() {
       final resolvedPath =
           '/webdev/fixtures/_testPackageSound/lib/test_library.dart';
 
+      final testPackageSoundDir = Uri.file(p.normalize(p.absolute(p.join(
+        '..',
+        'fixtures',
+        '_testPackageSound',
+      ))));
+
       final packageConfigFile = Uri.file(p.normalize(p.absolute(p.join(
         '..',
         'fixtures',
@@ -36,6 +44,12 @@ void main() {
 
       late final PackageUriMapper packageUriMapper;
       setUpAll(() async {
+        await Process.run(
+          'dart',
+          ['pub', 'upgrade'],
+          workingDirectory: testPackageSoundDir.toFilePath(),
+        );
+
         packageUriMapper = await PackageUriMapper.create(
           fileSystem,
           packageConfigFile,


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/1834

Adds running `dart pub upgrade` to the `setUpAll` step to ensure that `.dart_tool/package_config.json` exists.