### PR TITLE
File paths in `TestContext` are relative, not absolute

### DIFF
--- a/dwds/test/dart_uri_file_uri_test.dart
+++ b/dwds/test/dart_uri_file_uri_test.dart
@@ -23,7 +23,10 @@ final context = TestContext(
 final dwdsDir = Directory.current.absolute.path;
 
 /// The directory for the general _test package.
-final testDir = p.join(p.dirname(dwdsDir), 'fixtures', '_test');
+final testDir = p.canonicalize(p.relative(
+  p.join('..', 'fixtures', '_test'),
+  from: p.current,
+));
 
 /// The directory for the _testPackage package (contained within dwds), which
 /// imports _test.

--- a/dwds/test/dart_uri_file_uri_test.dart
+++ b/dwds/test/dart_uri_file_uri_test.dart
@@ -23,10 +23,10 @@ final context = TestContext(
 final dwdsDir = Directory.current.absolute.path;
 
 /// The directory for the general _test package.
-final testDir = p.canonicalize(p.relative(
+final testDir = p.normalize(p.absolute(p.relative(
   p.join('..', 'fixtures', '_test'),
   from: p.current,
-));
+)));
 
 /// The directory for the _testPackage package (contained within dwds), which
 /// imports _test.

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -127,8 +127,8 @@ class TestContext {
     final defaultEntry = p.join('..', 'fixtures', defaultPackage, 'example',
         'append_body', 'main.dart');
 
-    workingDirectory = p.canonicalize(
-        p.relative(directory ?? defaultDirectory, from: p.current));
+    workingDirectory = p.normalize(
+        p.absolute(p.relative(directory ?? defaultDirectory, from: p.current)));
 
     DartUri.currentDirectory = workingDirectory;
 
@@ -137,8 +137,8 @@ class TestContext {
     _packageConfigFile =
         p.toUri(p.join(workingDirectory, '.dart_tool/package_config.json'));
 
-    final entryFilePath =
-        p.canonicalize(p.relative(entry ?? defaultEntry, from: p.current));
+    final entryFilePath = p.normalize(
+        p.absolute(p.relative(entry ?? defaultEntry, from: p.current)));
 
     _logger.info('Serving: $pathToServe/$path');
     _logger.info('Project: $_projectDirectory');

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -121,14 +121,14 @@ class TestContext {
     this.path = 'hello_world/index.html',
     this.pathToServe = 'example',
   }) {
-    final packageName = nullSafety == NullSafety.sound ? '_testSound' : '_test';
-    final relativeDirectory = p.join('..', 'fixtures', packageName);
+    final defaultPackage =
+        nullSafety == NullSafety.sound ? '_testSound' : '_test';
+    final defaultDirectory = p.join('..', 'fixtures', defaultPackage);
+    final defaultEntry = p.join('..', 'fixtures', defaultPackage, 'example',
+        'append_body', 'main.dart');
 
-    final relativeEntry = p.join(
-        '..', 'fixtures', packageName, 'example', 'append_body', 'main.dart');
-
-    workingDirectory = p.normalize(p
-        .absolute(directory ?? p.relative(relativeDirectory, from: p.current)));
+    workingDirectory = p.canonicalize(
+        p.relative(directory ?? defaultDirectory, from: p.current));
 
     DartUri.currentDirectory = workingDirectory;
 
@@ -137,8 +137,8 @@ class TestContext {
     _packageConfigFile =
         p.toUri(p.join(workingDirectory, '.dart_tool/package_config.json'));
 
-    final entryFilePath = p.normalize(
-        p.absolute(entry ?? p.relative(relativeEntry, from: p.current)));
+    final entryFilePath =
+        p.canonicalize(p.relative(entry ?? defaultEntry, from: p.current));
 
     _logger.info('Serving: $pathToServe/$path');
     _logger.info('Project: $_projectDirectory');


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/1842

Addresses 2) of the above:

> We are treating the default TestContext directory as a relative directory from the current path. However, we are not doing the same for a directory that is passed in as a parameter (we assume that it is an absolute directory, although none of them are actually absolute. See for example [dart_uri_file_uri_test](https://github.com/dart-lang/webdev/blob/db5ed71d53def2d3642da247cf80dd393ceef2b9/dwds/test/dart_uri_file_uri_test.dart#L16))

This PR treats all directory / file paths in `TestContext` as relative paths. 