### PR TITLE
Fix flaky CI tests

### DIFF
--- a/dwds/test/build/ensure_version_test.dart
+++ b/dwds/test/build/ensure_version_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@TestOn('vm')
 import 'dart:io';
 
 import 'package:dwds/src/version.dart';

--- a/dwds/test/build/ensure_version_test.dart
+++ b/dwds/test/build/ensure_version_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('vm')
 import 'dart:io';
 
 import 'package:dwds/src/version.dart';

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -5,7 +5,7 @@
 // When run locally this test may require a manifest key. This makes it easy to
 // just skip it.
 @Tags(['extension'])
-@Timeout(Duration(seconds: 60))
+@Timeout(Duration(minutes: 2))
 @OnPlatform({
   'windows': Skip('https://github.com/dart-lang/webdev/issues/711'),
 })

--- a/dwds/test/devtools_test.dart
+++ b/dwds/test/devtools_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @Skip('https://github.com/dart-lang/webdev/issues/1845 - Move to cron job.')
+@Skip('https://github.com/dart-lang/webdev/issues/1845 - Move to cron job.')
 @Timeout(Duration(minutes: 5))
 @TestOn('vm')
 import 'dart:io';

--- a/dwds/test/devtools_test.dart
+++ b/dwds/test/devtools_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @Skip('https://github.com/dart-lang/webdev/issues/1845 - Move to cron job.')
 @Timeout(Duration(minutes: 5))
 @TestOn('vm')
 import 'dart:io';

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -114,6 +114,8 @@ class TestContext {
 
   NullSafety nullSafety;
 
+  late String dwdsDirectory;
+
   TestContext({
     String? directory,
     String? entry,
@@ -121,14 +123,19 @@ class TestContext {
     this.path = 'hello_world/index.html',
     this.pathToServe = 'example',
   }) {
+    final pathParts = p.split(p.current);
+    assert(pathParts.contains('dwds'));
+    dwdsDirectory = p.joinAll(
+      pathParts.sublist(0, pathParts.indexOf('dwds') + 1),
+    );
     final defaultPackage =
         nullSafety == NullSafety.sound ? '_testSound' : '_test';
     final defaultDirectory = p.join('..', 'fixtures', defaultPackage);
     final defaultEntry = p.join('..', 'fixtures', defaultPackage, 'example',
         'append_body', 'main.dart');
 
-    workingDirectory = p.normalize(
-        p.absolute(p.relative(directory ?? defaultDirectory, from: p.current)));
+    workingDirectory = p.normalize(p.absolute(
+        p.relative(directory ?? defaultDirectory, from: dwdsDirectory)));
 
     DartUri.currentDirectory = workingDirectory;
 
@@ -138,7 +145,7 @@ class TestContext {
         p.toUri(p.join(workingDirectory, '.dart_tool/package_config.json'));
 
     final entryFilePath = p.normalize(
-        p.absolute(p.relative(entry ?? defaultEntry, from: p.current)));
+        p.absolute(p.relative(entry ?? defaultEntry, from: dwdsDirectory)));
 
     _logger.info('Serving: $pathToServe/$path');
     _logger.info('Project: $_projectDirectory');
@@ -422,6 +429,12 @@ class TestContext {
       rethrow;
     }
   }
+
+  String absoluteDwdsPath(String relativePath) =>
+      p.normalize(p.absolute(p.relative(
+        relativePath,
+        from: dwdsDirectory,
+      )));
 
   Future<void> startDebugging() async {
     debugConnection = await testServer.dwds.debugConnection(appConnection);

--- a/dwds/test/package_uri_mapper_test.dart
+++ b/dwds/test/package_uri_mapper_test.dart
@@ -11,6 +11,10 @@ import 'package:file/local.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+import 'fixtures/context.dart';
+
+final testContext = TestContext();
+
 void main() {
   for (final useDebuggerModuleNames in [true, false]) {
     group(
@@ -28,11 +32,11 @@ void main() {
       final resolvedPath =
           '/webdev/fixtures/_testPackageSound/lib/test_library.dart';
 
-      final testPackageSoundPath = p.normalize(p.absolute(p.join(
+      final testPackageSoundPath = testContext.absoluteDwdsPath(p.join(
         '..',
         'fixtures',
         '_testPackageSound',
-      )));
+      ));
 
       final packageConfigFile = Uri.file(p.join(
         testPackageSoundPath,


### PR DESCRIPTION
**Work towards https://github.com/dart-lang/webdev/issues/1846 (flakiness caused by test timeouts):**

* Our `devtools_test` keeps timing out during CI testing. It already has a timeout limit of 5 minutes, so instead of increasing the timeout, this PR skips it with follow up work to schedule it on a cron job. 

* The `debug_extension_test` also keeps timing out, this PR increases the timeout to 2 minutes.

**Work towards https://github.com/dart-lang/webdev/issues/1842 (flakiness cause by file path issues):**

* Instead of assuming the current directory is the `dwds` directory in `TestContext`, determine the `dwds` directory and use that to create the various test directory paths. 