### PR TITLE
Add test timeout of 2 minutes for all tests missing a timeout

### DIFF
--- a/dwds/test/build_daemon_breakpoint_test.dart
+++ b/dwds/test/build_daemon_breakpoint_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';

--- a/dwds/test/build_daemon_callstack_test.dart
+++ b/dwds/test/build_daemon_callstack_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';

--- a/dwds/test/build_daemon_circular_evaluate_test.dart
+++ b/dwds/test/build_daemon_circular_evaluate_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 
 import 'package:test/test.dart';
 

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 
 import 'package:test/test.dart';
 

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dwds/test/dart_uri_file_uri_test.dart
+++ b/dwds/test/dart_uri_file_uri_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 
 import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:path/path.dart' as p;

--- a/dwds/test/dart_uri_test.dart
+++ b/dwds/test/dart_uri_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:io';
 
 import 'package:dwds/src/loaders/strategy.dart';

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -9,6 +9,7 @@
 @OnPlatform({
   'windows': Skip('https://github.com/dart-lang/webdev/issues/711'),
 })
+
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/handlers/injector.dart';
 import 'package:http/http.dart' as http;

--- a/dwds/test/debug_service_test.dart
+++ b/dwds/test/debug_service_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 
 import 'package:dwds/src/debugging/debugger.dart';

--- a/dwds/test/evaluate_circular_common.dart
+++ b/dwds/test/evaluate_circular_common.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 import 'dart:io';
 

--- a/dwds/test/expression_compiler_service_test.dart
+++ b/dwds/test/expression_compiler_service_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dwds/test/extension_backend_test.dart
+++ b/dwds/test/extension_backend_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 
 import 'package:async/src/stream_queue.dart';

--- a/dwds/test/extension_debugger_test.dart
+++ b/dwds/test/extension_debugger_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 import 'dart:convert';
 

--- a/dwds/test/frontend_server_breakpoint_test.dart
+++ b/dwds/test/frontend_server_breakpoint_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';

--- a/dwds/test/frontend_server_callstack_test.dart
+++ b/dwds/test/frontend_server_callstack_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';

--- a/dwds/test/frontend_server_circular_evaluate_test.dart
+++ b/dwds/test/frontend_server_circular_evaluate_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 
 import 'dart:io';
 

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 
 import 'dart:io';
 

--- a/dwds/test/handlers/asset_handler_test.dart
+++ b/dwds/test/handlers/asset_handler_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
+
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 

--- a/dwds/test/handlers/injector_test.dart
+++ b/dwds/test/handlers/injector_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
+
 import 'dart:io';
 
 import 'package:dwds/src/handlers/injector.dart';

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
+
 import 'package:dwds/dwds.dart';
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/debugging/debugger.dart';

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';

--- a/dwds/test/listviews_test.dart
+++ b/dwds/test/listviews_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
+
 import 'package:test/test.dart';
 
 import 'fixtures/context.dart';

--- a/dwds/test/location_test.dart
+++ b/dwds/test/location_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
+
 import 'package:dwds/src/debugging/location.dart';
 import 'package:dwds/src/debugging/modules.dart';
 import 'package:dwds/src/loaders/strategy.dart';

--- a/dwds/test/metadata/class_test.dart
+++ b/dwds/test/metadata/class_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
+
 import 'package:dwds/src/debugging/metadata/class.dart';
 import 'package:test/test.dart';
 

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
+
 import 'package:dwds/src/debugging/metadata/module_metadata.dart';
 import 'package:dwds/src/debugging/metadata/provider.dart';
 import 'package:test/test.dart';

--- a/dwds/test/objects_test.dart
+++ b/dwds/test/objects_test.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
+
 import 'package:dwds/src/utilities/objects.dart';
 import 'package:test/test.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';

--- a/dwds/test/package_uri_mapper_test.dart
+++ b/dwds/test/package_uri_mapper_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 
 import 'dart:io';
 

--- a/dwds/test/readers/frontend_server_asset_reader_test.dart
+++ b/dwds/test/readers/frontend_server_asset_reader_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 import 'dart:io';
 

--- a/dwds/test/readers/proxy_server_asset_reader_test.dart
+++ b/dwds/test/readers/proxy_server_asset_reader_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
+
 import 'package:dwds/src/readers/proxy_server_asset_reader.dart';
 import 'package:test/test.dart';
 

--- a/dwds/test/refresh_test.dart
+++ b/dwds/test/refresh_test.dart
@@ -5,6 +5,7 @@
 /// Tests that require a fresh context to run, and can interfere with other
 /// tests.
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 library refresh_test;
 
 import 'dart:async';

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Skip('https://github.com/dart-lang/webdev/issues/1845 - Move to cron job.')
 @TestOn('vm')
 @Timeout(Duration(minutes: 5))
 import 'package:dwds/src/loaders/strategy.dart';

--- a/dwds/test/restore_breakpoints_test.dart
+++ b/dwds/test/restore_breakpoints_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:async';
 
 import 'package:dwds/src/connections/debug_connection.dart';

--- a/dwds/test/screenshot_test.dart
+++ b/dwds/test/screenshot_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
+
 import 'package:test/test.dart';
 
 import 'fixtures/context.dart';

--- a/dwds/test/sdk_configuration_test.dart
+++ b/dwds/test/sdk_configuration_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'dart:io';
 
 import 'package:dwds/src/utilities/sdk_configuration.dart';

--- a/dwds/test/skip_list_test.dart
+++ b/dwds/test/skip_list_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(minutes: 2))
+
 import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/debugging/location.dart';
 import 'package:dwds/src/debugging/skip_list.dart';

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout(Duration(minutes: 2))
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/debugging/dart_scope.dart';
 import 'package:dwds/src/services/chrome_proxy_service.dart';

--- a/dwds/test/web/batched_stream_test.dart
+++ b/dwds/test/web/batched_stream_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Retry(0)
+@Timeout(Duration(minutes: 2))
 
 import 'dart:async';
 


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/1845: "All tests should have a timeout set"

Work towards https://github.com/dart-lang/webdev/issues/1846: "Long running tests should be moved to a cron job" (the `reload_test` is flaky, often timing out after 5 minutes. Instead of upping the timeout, we should move it to a cron job)