### PR TITLE
Change default `main.dart` file in `TextContext`

### DIFF
--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -8,6 +8,7 @@ repository: https://github.com/dart-lang/webdev/tree/master/dwds
 
 environment:
   sdk: ">=2.18.0 <3.0.0"
+
 dependencies:
   async: ^2.9.0
   built_collection: ^5.1.1

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -8,7 +8,6 @@ repository: https://github.com/dart-lang/webdev/tree/master/dwds
 
 environment:
   sdk: ">=2.18.0 <3.0.0"
-
 dependencies:
   async: ^2.9.0
   built_collection: ^5.1.1

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -127,7 +127,7 @@ class TestContext {
         nullSafety == NullSafety.sound ? '_testSound' : '_test';
     final defaultDirectory = p.join('..', 'fixtures', defaultPackage);
     final defaultEntry = p.join('..', 'fixtures', defaultPackage, 'example',
-        'append_body', 'main.dart');
+        'hello_world', 'main.dart');
 
     workingDirectory =
         absolutePath(pathFromDwds: directory ?? defaultDirectory);

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -5,6 +5,7 @@
 @TestOn('vm')
 @Timeout(Duration(minutes: 5))
 import 'package:dwds/src/loaders/strategy.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -13,6 +14,8 @@ import 'fixtures/logging.dart';
 
 final context = TestContext(
   path: 'append_body/index.html',
+  entry: p.join(
+      '..', 'fixtures', '_testSound', 'example', 'append_body', 'main.dart'),
 );
 
 void main() {


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/1845

The default `main.dart` file in `TextContext` is  `append_body/main.dart`, but the default `index.html` file is `hello_world/index.html`. This updates the two default entry files to be in the same directory (`hello_world/index.html` and `hello_world/main.dart`).