### PR TITLE
Tests should serve`main.dart` and `index.html` from the same directory

### DIFF
--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -127,7 +127,7 @@ class TestContext {
         nullSafety == NullSafety.sound ? '_testSound' : '_test';
     final defaultDirectory = p.join('..', 'fixtures', defaultPackage);
     final defaultEntry = p.join('..', 'fixtures', defaultPackage, 'example',
-        'append_body', 'main.dart');
+        'hello_world', 'main.dart');
 
     workingDirectory =
         absolutePath(pathFromDwds: directory ?? defaultDirectory);

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -9,13 +9,23 @@ import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/utilities/conversions.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
 
-final context = TestContext(path: 'scopes/scopes.html');
+final context = TestContext(
+    path: 'scopes/scopes.html',
+    entry: p.join(
+      '..',
+      'fixtures',
+      '_testSound',
+      'example',
+      'scopes',
+      'scopes_main.dart',
+    ));
 
 WipConnection get tabConnection => context.tabConnection;
 

--- a/dwds/test/instance_test.dart
+++ b/dwds/test/instance_test.dart
@@ -8,13 +8,23 @@ import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/loaders/strategy.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
 
-final context = TestContext(path: 'scopes/scopes.html');
+final context = TestContext(
+    path: 'scopes/scopes.html',
+    entry: p.join(
+      '..',
+      'fixtures',
+      '_testSound',
+      'example',
+      'scopes',
+      'scopes_main.dart',
+    ));
 
 WipConnection get tabConnection => context.tabConnection;
 

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -5,6 +5,7 @@
 @TestOn('vm')
 @Timeout(Duration(minutes: 5))
 import 'package:dwds/src/loaders/strategy.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -13,6 +14,8 @@ import 'fixtures/logging.dart';
 
 final context = TestContext(
   path: 'append_body/index.html',
+  entry: p.join(
+      '..', 'fixtures', '_testSound', 'example', 'append_body', 'main.dart'),
 );
 
 void main() {

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -6,13 +6,24 @@
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/debugging/dart_scope.dart';
 import 'package:dwds/src/services/chrome_proxy_service.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';
 
-final context = TestContext(path: 'scopes/scopes.html');
+final context = TestContext(
+    path: 'scopes/scopes.html',
+    entry: p.join(
+      '..',
+      'fixtures',
+      '_testSound',
+      'example',
+      'scopes',
+      'scopes_main.dart',
+    ));
+
 ChromeProxyService get service =>
     fetchChromeProxyService(context.debugConnection);
 WipConnection get tabConnection => context.tabConnection;


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/1845

We have a few tests across DWDS that are serving an `index.html` and a `main.dart` file from different directories. This is confusing and was (I'm guessing) unintentional. This changes those tests so the files are being served from the same directory.