### PR TITLE
Replace deprecated implicit-casts option with strict-casts option

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,6 @@
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
   errors:
     dead_code: error
     unused_element: error


### PR DESCRIPTION
The old strong-mode options are deprecated (https://github.com/dart-lang/sdk/commit/166c54b4d94b4fe12849339bfc11e5694d4fe892, https://github.com/dart-lang/sdk/issues/50679) in favor of new strict modes (https://github.com/dart-lang/sdk/issues/33749).