### PR TITLE
Wait for isolate to be destroyed before creating a new one

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -13,6 +13,7 @@
   or not.
 - Pre-warm expression compiler cache to speed up Flutter Inspector loading.
 - Remove `ChromeProxyService.setExceptionPauseMode()`.
+- Wait for an old isolate to be destroyed before creating a new one.
 
 ## 16.0.1
 

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -118,7 +118,8 @@ class ExpressionEvaluator {
     var result = await _inspector.callFunction(jsCode, scope.values);
     result = await _formatEvaluationError(result);
 
-    _logger.finest('Evaluated "$expression" to "$result"');
+    _logger
+        .finest('Evaluated "$expression" to "$result" for isolate $isolateId');
     return result;
   }
 


### PR DESCRIPTION
We seem to have a race condition where isolate starts without an isolate destruction in the middle. 

See original issue for examples: https://github.com/flutter/flutter/issues/117676

In this change we try to mitigate the issue by waiting for isolate to be destroyed before creating a new one.
