### PR TITLE
Set a debug key for the injected client and Dart Debug Extension SSE clients

### DIFF
--- a/dwds/debug_extension_mv3/web/debug_session.dart
+++ b/dwds/debug_extension_mv3/web/debug_session.dart
@@ -196,7 +196,7 @@ Future<bool> _connectToDwds({
   // Start the client connection with DWDS:
   final client = uri.isScheme('ws') || uri.isScheme('wss')
       ? WebSocketClient(WebSocketChannel.connect(uri))
-      : SseSocketClient(SseClient(uri.toString()));
+      : SseSocketClient(SseClient(uri.toString(), debugKey: 'DebugExtension'));
   final trigger = _tabIdToTrigger[dartAppTabId];
   final debugSession = _DebugSession(
     client: client,

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   shelf_web_socket: ^1.0.1
   source_maps: ^0.10.10
   stack_trace: ^1.10.0
-  sse: ^4.1.0
+  sse: ^4.1.2
   uuid: ^3.0.6
   vm_service: ^9.0.0
   web_socket_channel: ^2.2.0

--- a/dwds/web/client.dart
+++ b/dwds/web/client.dart
@@ -52,7 +52,7 @@ Future<void>? main() {
     final fixedUri = Uri.parse(fixedPath);
     final client = fixedUri.isScheme('ws') || fixedUri.isScheme('wss')
         ? WebSocketClient(WebSocketChannel.connect(fixedUri))
-        : SseSocketClient(SseClient(fixedPath));
+        : SseSocketClient(SseClient(fixedPath, debugKey: 'InjectedClient'));
 
     Restarter restarter;
     if (dartModuleStrategy == 'require-js') {


### PR DESCRIPTION
The ability to provide an optional debug key was added in https://github.com/dart-lang/sse/pull/67

This debug key identifies the SSE connection and can be used to debug SSE connection issues.