### PR TITLE
Re-enable `reload_tests`

### DIFF
--- a/dwds/test/devtools_test.dart
+++ b/dwds/test/devtools_test.dart
@@ -102,7 +102,11 @@ void main() {
       // https://github.com/dart-lang/webdev/pull/901#issuecomment-586438132
       final client = context.debugConnection.vmService;
       await client.streamListen('Isolate');
-      await context.changeInput();
+      context.makeEditToDartEntryFile(
+        toReplace: 'Hello World!',
+        replaceWith: 'Bonjour le monde!',
+      );
+      await context.waitForSuccessfulBuild(propogateToBrowser: true);
 
       final eventsDone = expectLater(
           client.onIsolateEvent,
@@ -115,6 +119,11 @@ void main() {
       await context.webDriver.driver.refresh();
 
       await eventsDone;
+      // Re-set the edited file:
+      context.makeEditToDartEntryFile(
+        toReplace: 'Bonjour le monde!',
+        replaceWith: 'Hello World!',
+      );
     });
   });
 

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -77,18 +77,13 @@ class TestContext {
     return webCompatiblePath([...pathParts, htmlEntryFileName]);
   }
 
-  /// The entry file is the Dart entry file, e.g,
+  /// The path to the Dart entry file, e.g,
   /// "/workstation/webdev/fixtures/_testSound/example/hello_world/main.dart":
-  File get _entryFile => File(
-        absolutePath(
-          pathFromFixtures: p.joinAll(
-            [packageName, webAssetsPath, dartEntryFileName],
-          ),
+  String get _dartEntryFilePath => absolutePath(
+        pathFromFixtures: p.joinAll(
+          [packageName, webAssetsPath, dartEntryFileName],
         ),
       );
-
-  /// The contents of the Dart entry file:
-  String get _entryContents => _entryFile.readAsStringSync();
 
   /// The URI for the package_config.json is located in:
   /// <project directory>/.dart_tool/package_config
@@ -183,7 +178,7 @@ class TestContext {
     _logger.info('Serving: $directoryToServe/$filePathToServe');
     _logger.info('Project: $workingDirectory');
     _logger.info('Packages: $_packageConfigFile');
-    _logger.info('Entry: ${_entryFile.path}');
+    _logger.info('Entry: $_dartEntryFilePath');
   }
 
   Future<void> setUp({
@@ -291,10 +286,7 @@ class TestContext {
                 DefaultBuildTarget((b) => b..target = directoryToServe));
             daemonClient.startBuild();
 
-            await daemonClient.buildResults
-                .firstWhere((results) => results.results
-                    .any((result) => result.status == BuildStatus.succeeded))
-                .timeout(const Duration(seconds: 60));
+            await waitForSuccessfulBuild();
 
             final assetServerPort = daemonPort(workingDirectory);
             _assetHandler = proxyHandler(
@@ -467,7 +459,6 @@ class TestContext {
     await _webDriver?.quit(closeSession: true);
     _chromeDriver?.kill();
     DartUri.currentDirectory = p.current;
-    _entryFile.writeAsStringSync(_entryContents);
     await _daemonClient?.close();
     await ddcService?.stop();
     await _webRunner?.stop();
@@ -487,20 +478,31 @@ class TestContext {
     _outputDir = null;
   }
 
-  Future<void> changeInput() async {
-    _entryFile.writeAsStringSync(
-        _entryContents.replaceAll('Hello World!', 'Gary is awesome!'));
+  void makeEditToDartEntryFile({
+    required String toReplace,
+    required String replaceWith,
+  }) async {
+    final file = File(_dartEntryFilePath);
+    final fileContents = file.readAsStringSync();
+    file.writeAsStringSync(fileContents.replaceAll(toReplace, replaceWith));
+  }
 
-    // Wait for the build.
-    await _daemonClient?.buildResults.firstWhere((results) => results.results
-        .any((result) => result.status == BuildStatus.succeeded));
+  Future<void> waitForSuccessfulBuild(
+      {Duration? timeout, bool propogateToBrowser = false}) async {
+    // Wait for the build until the timeout is reached:
+    await daemonClient.buildResults
+        .firstWhere((results) => results.results
+            .any((result) => result.status == BuildStatus.succeeded))
+        .timeout(timeout ?? const Duration(seconds: 60));
 
-    // Allow change to propagate to the browser.
-    // Windows, or at least Travis on Windows, seems to need more time.
-    final delay = Platform.isWindows
-        ? const Duration(seconds: 5)
-        : const Duration(seconds: 2);
-    await Future.delayed(delay);
+    if (propogateToBrowser) {
+      // Allow change to propagate to the browser.
+      // Windows, or at least Travis on Windows, seems to need more time.
+      final delay = Platform.isWindows
+          ? const Duration(seconds: 5)
+          : const Duration(seconds: 2);
+      await Future.delayed(delay);
+    }
   }
 
   Future<void> _buildDebugExtension() async {

--- a/dwds/test/reload_test.dart
+++ b/dwds/test/reload_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Skip('https://github.com/dart-lang/webdev/issues/1845 - Move to cron job.')
 @TestOn('vm')
 @Timeout(Duration(minutes: 5))
 import 'package:dwds/src/loaders/strategy.dart';


### PR DESCRIPTION
The `reload_tests` were disabled because they were timing out. This fixes the timeouts by making sure that the file that is edited (to trigger a reload), is reset after each test case.