### PR TITLE
[MV3] Fix late initialization error on debugger detach

### DIFF
--- a/dwds/debug_extension_mv3/web/debug_session.dart
+++ b/dwds/debug_extension_mv3/web/debug_session.dart
@@ -425,7 +425,7 @@ class _DebugSession {
 
   // How often to send batched events.
   static const int _batchDelayMilliseconds = 1000;
-  
+
   // The tab ID that contains the corresponding Dart DevTools, if it exists.
   int? devToolsTabId;
 

--- a/dwds/debug_extension_mv3/web/debug_session.dart
+++ b/dwds/debug_extension_mv3/web/debug_session.dart
@@ -420,14 +420,14 @@ class _DebugSession {
   // What triggered the debug session (debugger panel, extension icon, etc.)
   final Trigger? trigger;
 
-  // The tab ID that contains the corresponding Dart DevTools.
-  late final int? devToolsTabId;
-
   // Socket client for communication with dwds extension backend.
   late final SocketClient _socketClient;
 
   // How often to send batched events.
   static const int _batchDelayMilliseconds = 1000;
+  
+  // The tab ID that contains the corresponding Dart DevTools, if it exists.
+  int? devToolsTabId;
 
   // Collect events into batches to be send periodically to the server.
   final _batchController =


### PR DESCRIPTION
Fixes the following error on detaching the debugger if Dart DevTools wasn't opened in a separate tab (eg, if it is open in Chrome DevTools or if we are debugging from an IDE). The field should be nullable and non-final instead of late and final, since it only gets set if we have an open DevTools tab.

```
background.dart.js:4574 Uncaught LateInitializationError: Field 'devToolsTabId' has not been initialized.
    at Object.wrapException (background.dart.js:950:17)
    at Object.throwExpression (background.dart.js:964:15)
    at Object.throwLateFieldNI (background.dart.js:1750:16)
    at background.dart.js:8480:29
    at _wrapJsFunctionForAsync_closure.$protected (background.dart.js:3362:15)
    at _wrapJsFunctionForAsync_closure.call$2 (background.dart.js:11658:12)
    at Object._asyncStartSync (background.dart.js:3326:20)
    at Object._handleDebuggerDetach (background.dart.js:8499:16)
    at _registerDebugEventListeners_closure.call$2 (background.dart.js:22473:16)
    at Object.Primitives_applyFunction (background.dart.js:836:30)
```
