### PR TITLE
Prepare for dart 3.0 alpha breaking changes

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Pre-warm expression compiler cache to speed up Flutter Inspector loading.
 - Remove `ChromeProxyService.setExceptionPauseMode()`.
 - Display full error on failure to start DDS.
+- Prepare or Dart 3 alpha breaking changes:
+  - Move weak null safety tests to special branch of `build_web_compilers`.
+  - Do not pass `--(no)-sound-null-safety` flag to build daemon.
 
 ## 16.0.1
 

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -141,6 +141,23 @@ void testAll({
         await setup.service.resume(isolateId);
       });
 
+      test('uses correct null safety mode', () async {
+        await onBreakPoint(isolateId, mainScript, 'printLocal', () async {
+          final event = await stream
+              .firstWhere((event) => event.kind == EventKind.kPauseBreakpoint);
+
+          final isNullSafetyEnabled =
+              '() { const sound = !(<Null>[] is List<int>); return sound; } ()';
+          final result = await setup.service.evaluateInFrame(
+              isolateId, event.topFrame!.index!, isNullSafetyEnabled);
+
+          expect(
+              result,
+              isA<InstanceRef>().having((instance) => instance.valueAsString,
+                  'valueAsString', '${nullSafety == NullSafety.sound}'));
+        });
+      });
+
       test('does not crash if class metadata cannot be found', () async {
         await onBreakPoint(isolateId, mainScript, 'printStream', () async {
           final event = await stream

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -266,7 +266,6 @@ class TestContext {
       String basePath = '';
 
       _port = await findUnusedPort();
-      final soundNullSafety = nullSafety == NullSafety.sound;
       switch (compilationMode) {
         case CompilationMode.buildDaemon:
           {
@@ -275,8 +274,6 @@ class TestContext {
                 '--define',
                 'build_web_compilers|ddc=generate-full-dill=true',
               ],
-              '--define',
-              'build_web_compilers:entrypoint=sound_null_safety=$soundNullSafety',
               '--verbose',
             ];
             _daemonClient =

--- a/fixtures/_test/pubspec.yaml
+++ b/fixtures/_test/pubspec.yaml
@@ -19,6 +19,6 @@ dev_dependencies:
   build_runner: '>=1.6.2 <3.0.0'
   build_web_compilers:
     git:
-      url: git@github.com:dart-lang/build.git
+      url: https://github.com/dart-lang/build.git
       ref: legacy_force_opt_out
       path: build_web_compilers

--- a/fixtures/_test/pubspec.yaml
+++ b/fixtures/_test/pubspec.yaml
@@ -17,4 +17,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: '>=1.6.2 <3.0.0'
-  build_web_compilers: '>=2.12.0 <4.0.0'
+  build_web_compilers:
+    git:
+      url: git@github.com:dart-lang/build.git
+      ref: legacy_force_opt_out
+      path: build_web_compilers

--- a/fixtures/_testCircular1/pubspec.yaml
+++ b/fixtures/_testCircular1/pubspec.yaml
@@ -19,4 +19,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  build_web_compilers: ^3.0.0
+  build_web_compilers:
+    git:
+      url: git@github.com:dart-lang/build.git
+      ref: legacy_force_opt_out
+      path: build_web_compilers

--- a/fixtures/_testCircular1/pubspec.yaml
+++ b/fixtures/_testCircular1/pubspec.yaml
@@ -21,6 +21,6 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_web_compilers:
     git:
-      url: git@github.com:dart-lang/build.git
+      url: https://github.com/dart-lang/build.git
       ref: legacy_force_opt_out
       path: build_web_compilers

--- a/fixtures/_testCircular2/pubspec.yaml
+++ b/fixtures/_testCircular2/pubspec.yaml
@@ -17,4 +17,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  build_web_compilers: ^3.0.0
+  build_web_compilers:
+    git:
+      url: git@github.com:dart-lang/build.git
+      ref: legacy_force_opt_out
+      path: build_web_compilers

--- a/fixtures/_testCircular2/pubspec.yaml
+++ b/fixtures/_testCircular2/pubspec.yaml
@@ -19,6 +19,6 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_web_compilers:
     git:
-      url: git@github.com:dart-lang/build.git
+      url: https://github.com/dart-lang/build.git
       ref: legacy_force_opt_out
       path: build_web_compilers

--- a/fixtures/_testPackage/pubspec.yaml
+++ b/fixtures/_testPackage/pubspec.yaml
@@ -17,4 +17,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  build_web_compilers: ^3.0.0
+  build_web_compilers:
+    git:
+      url: git@github.com:dart-lang/build.git
+      ref: legacy_force_opt_out
+      path: build_web_compilers

--- a/fixtures/_testPackage/pubspec.yaml
+++ b/fixtures/_testPackage/pubspec.yaml
@@ -19,6 +19,6 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_web_compilers:
     git:
-      url: git@github.com:dart-lang/build.git
+      url: https://github.com/dart-lang/build.git
       ref: legacy_force_opt_out
       path: build_web_compilers

--- a/fixtures/_webdevSmoke/pubspec.yaml
+++ b/fixtures/_webdevSmoke/pubspec.yaml
@@ -19,6 +19,6 @@ dev_dependencies:
   build_runner: '>=1.6.2 <3.0.0'
   build_web_compilers:
     git:
-      url: git@github.com:dart-lang/build.git
+      url: https://github.com/dart-lang/build.git
       ref: legacy_force_opt_out
       path: build_web_compilers

--- a/fixtures/_webdevSmoke/pubspec.yaml
+++ b/fixtures/_webdevSmoke/pubspec.yaml
@@ -17,4 +17,8 @@ environment:
 
 dev_dependencies:
   build_runner: '>=1.6.2 <3.0.0'
-  build_web_compilers: '>=2.12.0 <4.0.0'
+  build_web_compilers:
+    git:
+      url: git@github.com:dart-lang/build.git
+      ref: legacy_force_opt_out
+      path: build_web_compilers

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Add `--enable-experiment` flag to webdev commands and pass it
   to the build runner and the expression compiler service.
+- Prepare or Dart 3 alpha breaking changes:
+  - Move weak null safety tests to special branch of `build_web_compilers`.
+  - Do not pass `--(no)-sound-null-safety` flag to build daemon.
 
 ## 2.7.12
 

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -89,13 +89,6 @@ List<String> buildRunnerArgs(
       ..add('build_web_compilers|ddc=generate-full-dill=true');
   }
 
-  if (configuration.nullSafety != nullSafetyAuto) {
-    arguments
-      ..add('--define')
-      ..add('build_web_compilers:entrypoint=sound_null_safety='
-          '${configuration.nullSafety == nullSafetySound}');
-  }
-
   for (var experiment in configuration.experiments) {
     arguments.add('--enable-experiment=$experiment');
   }

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -64,9 +64,9 @@ void main() {
   });
 
   test('smoke test is configured properly', () async {
-    var smokeYaml =
-        loadYaml(await File('$exampleDirectory/pubspec.yaml').readAsString())
-            as YamlMap;
+    var smokeYaml = loadYaml(
+            await File('$soundExampleDirectory/pubspec.yaml').readAsString())
+        as YamlMap;
     var webdevYaml =
         loadYaml(await File('pubspec.yaml').readAsString()) as YamlMap;
     expect(smokeYaml['environment']['sdk'],
@@ -168,32 +168,24 @@ void main() {
           : 'SDK does not support sound null safety',
     );
 
-    test(
-      'and --null-safety=unsound',
-      () async {
-        var args = [
-          'build',
-          '-o',
-          'web:${d.sandbox}',
-          '--no-release',
-          '--null-safety=unsound'
-        ];
+    test('and --null-safety=unsound', () async {
+      var args = [
+        'build',
+        '-o',
+        'web:${d.sandbox}',
+        '--no-release',
+        '--null-safety=unsound'
+      ];
 
-        var process =
-            await runWebDev(args, workingDirectory: soundExampleDirectory);
+      var process = await runWebDev(args, workingDirectory: exampleDirectory);
 
-        var expectedItems = <Object>['Succeeded'];
+      var expectedItems = <Object>['Succeeded'];
 
-        await checkProcessStdout(process, expectedItems);
-        await process.shouldExit(0);
+      await checkProcessStdout(process, expectedItems);
+      await process.shouldExit(0);
 
-        await d.file('main.unsound.ddc.js', isNotEmpty).validate();
-      },
-      skip: semver.Version.parse(Platform.version.split(' ').first) >
-              semver.Version.parse('2.11.0')
-          ? null
-          : 'SDK does not support sound null safety',
-    );
+      await d.file('main.unsound.ddc.js', isNotEmpty).validate();
+    });
   });
 
   group('should build with --output=NONE', () {
@@ -344,14 +336,17 @@ void main() {
               await stream.firstWhere(
                   (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
-              var result =
-                  await vmService.evaluateInFrame(isolateId, 0, 'true');
+              final isNullSafetyEnabled =
+                  '() { const sound = !(<Null>[] is List<int>); return sound; } ()';
+              final result = await vmService.evaluateInFrame(
+                  isolateId, 0, isNullSafetyEnabled);
+
               expect(
                   result,
                   const TypeMatcher<InstanceRef>().having(
                       (instance) => instance.valueAsString,
                       'valueAsString',
-                      'true'));
+                      '$soundNullSafety'));
             } finally {
               await vmService?.dispose();
               await exitWebdev(process);


### PR DESCRIPTION
Prepare for dart 3.0 alpha breaking changes:
- Use special branch of build_web_compilers for weak null safety tests.
- Remove passing unneeded `--(no)-sound-null-safety` to build daemon and build_web_compilers.
  - Build daemon detects null safety mode  automatically from the pubspec and dart annotations of the project.
- Add tests to verify that every test suite runs in the intended null safety mode.

Towards: https://github.com/dart-lang/webdev/issues/1878
