### PR TITLE
Ignore `illegal_language_version_override` for non null-safe fixtures

### DIFF
--- a/fixtures/_test/example/append_body/main.dart
+++ b/fixtures/_test/example/append_body/main.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 import 'dart:async';

--- a/fixtures/_test/example/hello_world/main.dart
+++ b/fixtures/_test/example/hello_world/main.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 import 'dart:async';

--- a/fixtures/_test/example/hello_world/part.dart
+++ b/fixtures/_test/example/hello_world/part.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 part of 'main.dart';

--- a/fixtures/_test/lib/deferred_library.dart
+++ b/fixtures/_test/lib/deferred_library.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 /// A library that we can import.

--- a/fixtures/_test/lib/library.dart
+++ b/fixtures/_test/lib/library.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 /// A library that we can import.

--- a/fixtures/_testCircular1/lib/library1.dart
+++ b/fixtures/_testCircular1/lib/library1.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 /// A library that we can import.

--- a/fixtures/_testCircular2/lib/library2.dart
+++ b/fixtures/_testCircular2/lib/library2.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 import 'package:_test_circular1/library1.dart';

--- a/fixtures/_testCircular2/web/main.dart
+++ b/fixtures/_testCircular2/web/main.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 import 'dart:async';

--- a/fixtures/_testPackage/lib/src/test_part.dart
+++ b/fixtures/_testPackage/lib/src/test_part.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 part of '../test_library.dart';

--- a/fixtures/_testPackage/lib/test_library.dart
+++ b/fixtures/_testPackage/lib/test_library.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 part 'src/test_part.dart';

--- a/fixtures/_testPackage/web/main.dart
+++ b/fixtures/_testPackage/web/main.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart=2.9
 
 import 'dart:async';

--- a/fixtures/_webdevSmoke/web/main.dart
+++ b/fixtures/_webdevSmoke/web/main.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart = 2.9
 
 import 'dart:async';

--- a/fixtures/_webdevSmoke/web/scopes_main.dart
+++ b/fixtures/_webdevSmoke/web/scopes_main.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore: illegal_language_version_override
 // @dart = 2.9
 
 /// An example with more complicated scope


### PR DESCRIPTION
New analyzer error was recently added: https://github.com/dart-lang/sdk/issues/50694

We should ignore it for our legacy non null-safe fixtures that we are using to test backwards compatibility. 