### PR TITLE
Skip flaky `devtools_test` case on Windows

### DIFF
--- a/dwds/test/devtools_test.dart
+++ b/dwds/test/devtools_test.dart
@@ -44,7 +44,8 @@ void main() {
       await context.webDriver.driver.switchTo.window(windows.last);
       expect(await context.webDriver.title, equals('Dart DevTools'));
       expect(await context.webDriver.currentUrl, contains('ide=Dwds'));
-    });
+      // TODO(https://github.com/dart-lang/webdev/issues/1888): Re-enable.
+    }, skip: Platform.isWindows);
 
     test('can not launch devtools for the same app in multiple tabs', () async {
       final appUrl = await context.webDriver.currentUrl;


### PR DESCRIPTION
Follow-up to https://github.com/dart-lang/webdev/pull/1881

One of the recently re-enabled test cases failed for the last 2/3 CI runs on Windows (see https://github.com/dart-lang/webdev/actions/runs/3914484820/jobs/6691618089) This PR disables that test on Windows for now. 