### PR TITLE
Allow dart SDK <4.0.0

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add back `ChromeProxyService.setExceptionPauseMode()` without override.
 - Make hot restart atomic to prevent races on simultaneous execution.
 - Return error on expression evaluation if expression evaluator stopped.
+- Update SDK constraint to `>=3.0.0-134.0.dev <4.0.0`.
 
 **Breaking changes**
 - Include an optional param to `Dwds.start` to indicate whether it is running
@@ -29,7 +30,6 @@
   - Enable frontend server null safe tests.
   - Update `build_web_compilers` constraint to `^4.0.0`.
   - Update `build_runner` constraint to `^2.4.0`.
-  - Update min dart SDK constraint to `3.0.0-134.0.dev`
   - Support changes in the SDK layout for dart 3.0.
 
 ## 16.0.1

--- a/dwds/debug_extension/pubspec.yaml
+++ b/dwds/debug_extension/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   A chrome extension for Dart debugging.
 
 environment:
-  sdk: '>=3.0.0-134.0.dev <3.0.0'
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   async: ^2.3.0

--- a/dwds/debug_extension_mv3/pubspec.yaml
+++ b/dwds/debug_extension_mv3/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   A Chrome extension for Dart debugging.
 
 environment:
-  sdk: '>=3.0.0-134.0.dev <3.0.0'
+  sdk: sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   built_value: ^8.3.0

--- a/dwds/debug_extension_mv3/pubspec.yaml
+++ b/dwds/debug_extension_mv3/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   A Chrome extension for Dart debugging.
 
 environment:
-  sdk: sdk: ">=3.0.0-134.0.dev <4.0.0"
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   built_value: ^8.3.0

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -7,7 +7,7 @@ description: >-
 repository: https://github.com/dart-lang/webdev/tree/master/dwds
 
 environment:
-  sdk: ">=3.0.0-134.0.dev <3.0.0"
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   async: ^2.9.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: A web app example for webdev CLI.
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0-134.0.dev <3.0.0"
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/fixtures/_test/pubspec.yaml
+++ b/fixtures/_test/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0-134.0.dev <3.0.0"
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   intl: ^0.17.0

--- a/fixtures/_testCircular1/pubspec.yaml
+++ b/fixtures/_testCircular1/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0-134.0.dev <3.0.0"
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   intl: ^0.17.0

--- a/fixtures/_testCircular1Sound/pubspec.yaml
+++ b/fixtures/_testCircular1Sound/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0-134.0.dev <3.0.0'
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   intl: ^0.17.0

--- a/fixtures/_testCircular2/pubspec.yaml
+++ b/fixtures/_testCircular2/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0-134.0.dev <3.0.0"
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   _test_circular1:

--- a/fixtures/_testCircular2Sound/pubspec.yaml
+++ b/fixtures/_testCircular2Sound/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0-134.0.dev <3.0.0'
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   _test_circular1_sound:

--- a/fixtures/_testPackage/pubspec.yaml
+++ b/fixtures/_testPackage/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0-134.0.dev<3.0.0"
+  sdk: ">=3.0.0-134.0.dev<4.0.0"
 
 dependencies:
   _test:

--- a/fixtures/_testPackageSound/pubspec.yaml
+++ b/fixtures/_testPackageSound/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0-134.0.dev <3.0.0'
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   _test_sound:

--- a/fixtures/_testSound/pubspec.yaml
+++ b/fixtures/_testSound/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0-134.0.dev <3.0.0'
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   intl: ^0.17.0

--- a/fixtures/_webdevSmoke/pubspec.yaml
+++ b/fixtures/_webdevSmoke/pubspec.yaml
@@ -13,7 +13,7 @@ description:
 # and build_web_compilers constraint should match those defined
 # in pubspec.dart.
 environment:
-  sdk: '>=3.0.0-134.0.dev <3.0.0'
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dev_dependencies:
   build_runner: '>=1.6.2 <3.0.0'

--- a/fixtures/_webdevSoundSmoke/pubspec.yaml
+++ b/fixtures/_webdevSoundSmoke/pubspec.yaml
@@ -2,7 +2,7 @@ name: _webdev_smoke
 description: A test fixture for webdev testing with sound support.
 
 environment:
-  sdk: '>=3.0.0-134.0.dev <3.0.0'
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/frontend_server_client/CHANGELOG.md
+++ b/frontend_server_client/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.3.0-dev
 
-- Require min dart SDK version of `3.0.0-134.0.dev`.
+- Update SDK constraint to `>=3.0.0-134.0.dev <4.0.0`.
 - Support changes in the SDK layout for Dart 3.0.
 
 ## 3.2.0

--- a/frontend_server_client/pubspec.yaml
+++ b/frontend_server_client/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 repository: https://github.com/dart-lang/webdev/tree/master/frontend_server_client
 
 environment:
-  sdk: ">=3.0.0-134.0.dev <3.0.0"
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   async: ^2.5.0

--- a/frontend_server_client/test/frontend_sever_client_test.dart
+++ b/frontend_server_client/test/frontend_sever_client_test.dart
@@ -28,7 +28,7 @@ dependencies:
   path: ^1.0.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">3.0.0-134.0.dev <4.0.0"
       '''),
       d.dir('bin', [
         d.file('main.dart', '''

--- a/frontend_server_common/pubspec.yaml
+++ b/frontend_server_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: >-
   Frontend server integration code to use for dwds tests. Mimics flutter code.
 environment:
-  sdk: ">=3.0.0-134.0.dev <3.0.0"
+  sdk: "4.0.0"
 
 dependencies:
   dwds:

--- a/frontend_server_common/pubspec.yaml
+++ b/frontend_server_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: >-
   Frontend server integration code to use for dwds tests. Mimics flutter code.
 environment:
-  sdk: "4.0.0"
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   dwds:

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add `--enable-experiment` flag to webdev commands and pass it
   to the build runner and the expression compiler service.
+- Update SDK constraint to `>=3.0.0-134.0.dev <4.0.0`.
 
 **Breaking changes**
 
@@ -9,7 +10,6 @@
   - Do not pass `--(no)-sound-null-safety` flag to build daemon.
   - Update `build_web_compilers` constraint to `^4.0.0`.
   - Update `build_runner` constraint to `^2.4.0`.
-  - Update min dart SDK constraint to `3.0.0-134.0.dev`.
   - Support changes in the SDK layout for Dart 3.0.
 
 ## 2.7.12

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
 repository: https://github.com/dart-lang/webdev/tree/master/webdev
 
 environment:
-  sdk: ">=3.0.0-134.0.dev <3.0.0"
+  sdk: ">=3.0.0-134.0.dev <4.0.0"
 
 dependencies:
   args: ^2.3.1


### PR DESCRIPTION
Update max dart SDK constraint to <4.0.0.

Towards: https://github.com/dart-lang/webdev/issues/1878