### PR TITLE
Validate only needed summaries in expression_compiler_service

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Return error on expression evaluation if expression evaluator stopped.
 - Update SDK constraint to `>=3.0.0-134.0.dev <4.0.0`.
 - Update `package:vm_service` constraint to `>=10.1.0 <12.0.0`.
+- Fix expression compiler throwing when weak SDK summary is not found.
 
 **Breaking changes**
 - Include an optional param to `Dwds.start` to indicate whether it is running

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -71,7 +71,12 @@ class _Compiler {
     List<String> experiments,
     bool verbose,
   ) async {
-    sdkConfiguration.validate();
+    sdkConfiguration.validateSdkDir();
+    if (soundNullSafety) {
+      sdkConfiguration.validateSoundSummaries();
+    } else {
+      sdkConfiguration.validateWeakSummaries();
+    }
 
     final librariesUri = sdkConfiguration.librariesUri!;
     final workerUri = sdkConfiguration.compilerWorkerUri!;

--- a/fixtures/_webdevSoundSmoke/web/scopes.html
+++ b/fixtures/_webdevSoundSmoke/web/scopes.html
@@ -1,0 +1,7 @@
+<html>
+
+<head>
+  <script defer src="scopes_main.dart.js"></script>
+</head>
+
+</html>

--- a/fixtures/_webdevSoundSmoke/web/scopes_main.dart
+++ b/fixtures/_webdevSoundSmoke/web/scopes_main.dart
@@ -1,0 +1,152 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// An example with more complicated scope
+import 'dart:async';
+import 'dart:collection';
+
+final libraryPublicFinal = MyTestClass();
+
+final _libraryPrivateFinal = 1;
+Object? libraryNull;
+var libraryPublic = <String>['library', 'public', 'variable'];
+var notAList = NotReallyAList();
+
+var _libraryPrivate = ['library', 'private', 'variable'];
+
+var identityMap = <String, int>{};
+
+var map = <Object, Object>{};
+
+void staticFunction(int formal) {
+  print(formal); // Breakpoint: staticFunction
+}
+
+void main() async {
+  print('Initial print from scopes app');
+  var local = 'local in main';
+  var intLocalInMain = 42;
+  var testClass = MyTestClass();
+  Object? localThatsNull;
+  identityMap['a'] = 1;
+  identityMap['b'] = 2;
+  map['a'] = [1, 2, 3];
+  map['b'] = 'something';
+  notAList.add(7);
+
+  String nestedFunction<T>(T parameter, Object aClass) {
+    var another = int.tryParse('$parameter');
+    return '$local: parameter, $another'; // Breakpoint: nestedFunction
+  }
+
+  dynamic nestedWithClosure(String banana) {
+    return () => '$local + $banana';
+  }
+
+  Timer.periodic(const Duration(seconds: 1), (Timer t) {
+    var ticks = t.tick;
+    // ignore: unused_local_variable, prefer_typing_uninitialized_variables
+    var closureLocal;
+    libraryPublicFinal.printCount();
+    staticFunction(1);
+    print('ticking... $ticks (the answer is $intLocalInMain)');
+    print(nestedFunction('$ticks ${testClass.message}', Timer));
+    print(localThatsNull);
+    print(libraryNull);
+    var localList = libraryPublic;
+    print(localList);
+    localList.add('abc');
+    var f = testClass.methodWithVariables();
+    print(f('parameter'));
+  });
+
+  print(_libraryPrivateFinal);
+  print(_libraryPrivate);
+  print(nestedFunction(_libraryPrivate.first, Object));
+  print(nestedWithClosure(_libraryPrivate.first)());
+}
+
+String libraryFunction(String arg) {
+  print('calling a library function with $arg');
+  var concat = 'some constant plus $arg plus whatever';
+  print(concat);
+  return concat;
+}
+
+class MyTestClass<T> {
+  final String message;
+
+  late String notFinal;
+
+  MyTestClass({this.message = 'world'}) {
+    myselfField = this;
+    tornOff = toString;
+  }
+
+  String hello() => message;
+
+  String Function(String) methodWithVariables() {
+    var local = '$message + something';
+    print(local);
+    return (String parameter) {
+      // Be sure to use a field from this, so it isn't entirely optimized away.
+      var closureLocalInsideMethod = '$message/$local/$parameter';
+      print(closureLocalInsideMethod);
+      return closureLocalInsideMethod; // Breakpoint: nestedClosure
+    };
+  }
+
+  //ignore: avoid_returning_this
+  MyTestClass get myselfGetter => this;
+
+  late MyTestClass myselfField;
+
+  var count = 0;
+
+  // An easy location to add a breakpoint.
+  void printCount() {
+    print('The count is ${++count}');
+    libraryFunction('abc'); // Breakpoint: printMethod
+  }
+
+  final _privateField = 'a private field';
+
+  // ignore: unused_element
+  String privateMethod(String s) => '$s : $_privateField';
+
+  @override
+  String toString() => 'A test class with message $message';
+
+  bool equals(Object other) {
+    if (other is MyTestClass) return message == other.hello();
+    return false;
+  }
+
+  Function closure = someFunction;
+
+  late String Function() tornOff;
+}
+
+Function? someFunction() => null;
+
+// ignore: unused_element
+int _libraryPrivateFunction(int a, int b) => a + b;
+
+class NotReallyAList extends ListBase {
+  final List<Object?> _internal;
+
+  NotReallyAList() : _internal = [];
+
+  @override
+  Object? operator [](x) => _internal[x];
+
+  @override
+  operator []=(x, y) => _internal[x] = y as Object?;
+
+  @override
+  int get length => _internal.length;
+
+  @override
+  set length(x) => _internal.length = x;
+}

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -4,6 +4,7 @@
   to the build runner and the expression compiler service.
 - Update SDK constraint to `>=3.0.0-134.0.dev <4.0.0`.
 - Update `package:vm_service` constraint to `>=10.1.0 <12.0.0`.
+- Make all tests use sound null safety fixtures.
 
 **Breaking changes**
 

--- a/webdev/test/daemon/utils.dart
+++ b/webdev/test/daemon/utils.dart
@@ -39,7 +39,7 @@ Future<String> waitForAppId(TestProcess webdev) async {
 
 Future<String> prepareWorkspace() async {
   var exampleDirectory =
-      p.absolute(p.join(p.current, '..', 'fixtures', '_webdevSmoke'));
+      p.absolute(p.join(p.current, '..', 'fixtures', '_webdevSoundSmoke'));
 
   var process = await TestProcess.start(dartPath, ['pub', 'upgrade'],
       workingDirectory: exampleDirectory, environment: getPubEnvironment());


### PR DESCRIPTION
Fixed CI breaks in main channel after the unsound summaries were deleted from the SDK.

See: https://github.com/dart-lang/webdev/pull/1916