### PR TITLE
update the readme to use a markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,9 @@
 [![Dart](https://github.com/dart-lang/webdev/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/webdev/actions?query=workflow%3A%22Dart+CI%22+branch%3Amaster)
 
-## dwds [![Pub Package](https://img.shields.io/pub/v/dwds.svg)](https://pub.dev/packages/dwds)
+## Packages
 
-- Package: https://pub.dev/packages/dwds
-- [Source code](dwds)
-
-A service that proxies between the Chrome debug protocol and the Dart VM service
-protocol.
-
-## webdev [![Pub Package](https://img.shields.io/pub/v/webdev.svg)](https://pub.dev/packages/webdev)
-
-- Package: https://pub.dev/packages/webdev
-- [Source code](webdev)
-
-A command-line tool for developing and deploying web applications with Dart.
+| Package | Description | Version |
+|---|---|---|
+| [dwds](dwds/) | A service that proxies between the Chrome debug protocol and the Dart VM service protocol. | [![pub package](https://img.shields.io/pub/v/dwds.svg)](https://pub.dev/packages/dwds) |
+| [frontend_server_client](frontend_server_client/) | Client code to start and interact with the frontend_server compiler from the Dart SDK. | [![pub package](https://img.shields.io/pub/v/frontend_server_client.svg)](https://pub.dev/packages/frontend_server_client) |
+| [webdev](webdev/) | A CLI for Dart web development. Provides an easy and consistent set of features for users and tools to build and deploy web applications with Dart. | [![pub package](https://img.shields.io/pub/v/webdev.svg)](https://pub.dev/packages/webdev) |

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,4 +10,3 @@ dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   webdev: ^2.7.6
-


### PR DESCRIPTION
- update the readme to use a markdown table

This aligns with some of our other monorepos (and will be easier to maintain - it's the output of `mono_repo readme`).