### PR TITLE
Handle case where `list.objectId` is `null` in `batched_expression_evaluator.dart`

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 16.0.2+1
+
+- Handle the case where `list.objectId` is `null` in
+  `batched_expression_evaluator` to fix crash on Flutter 3.7.0:
+  https://github.com/flutter/flutter/issues/119084
+
 ## 16.0.2
 - Don't complete an already completed `Completer` in `ChromeProxyService` to fix
   Flutter tools crash: https://github.com/dart-lang/webdev/pull/1862

--- a/dwds/lib/src/services/batched_expression_evaluator.dart
+++ b/dwds/lib/src/services/batched_expression_evaluator.dart
@@ -121,15 +121,23 @@ class BatchedExpressionEvaluator extends ExpressionEvaluator {
       final request = requests[i];
       if (request.completer.isCompleted) continue;
       _logger.fine('Getting result out of a batch for ${request.expression}');
-      _debugger
-          .getProperties(list.objectId!,
-              offset: i, count: 1, length: requests.length)
-          .then((v) {
-        final result = v.first.value;
-        _logger.fine(
-            'Got result out of a batch for ${request.expression}: $result');
-        request.completer.complete(result);
-      });
+      final listId = list.objectId;
+      if (listId == null) {
+        final error = RemoteObject(<String, String>{
+          'type': '${ErrorKind.internal}',
+          'value': 'No batch result object ID.'
+        });
+        request.completer.complete(error);
+      } else {
+        _debugger
+            .getProperties(listId, offset: i, count: 1, length: requests.length)
+            .then((v) {
+          final result = v.first.value;
+          _logger.fine(
+              'Got result out of a batch for ${request.expression}: $result');
+          request.completer.complete(result);
+        });
+      }
     }
   }
 }

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -558,6 +558,32 @@ void testAll({
                 (instance) => instance.valueAsString, 'valueAsString', '1'));
       });
 
+      test('in parallel (in a batch) handles errors', () async {
+        final library = isolate.rootLib!;
+        final missingLibId = '';
+        final evaluation1 = setup.service
+            .evaluate(isolateId, missingLibId, 'MainClass(0).toString()');
+        final evaluation2 = setup.service
+            .evaluate(isolateId, library.id!, 'MainClass(1).toString()');
+
+        final results = await Future.wait([evaluation1, evaluation2]);
+
+        expect(
+            results[0],
+            isA<ErrorRef>().having(
+              (instance) => instance.message,
+              'message',
+              contains('No batch result object ID'),
+            ));
+        expect(
+            results[1],
+            isA<ErrorRef>().having(
+              (instance) => instance.message,
+              'message',
+              contains('No batch result object ID'),
+            ));
+      });
+
       test('with scope override', () async {
         final library = isolate.rootLib!;
         final object = await setup.service


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/119084

- Handle the case where `list.ObjectId` is `null` in `batched_expression_evaluator.dart` (copies the fix on head, which is https://github.com/dart-lang/webdev/blame/master/dwds/lib/src/services/batched_expression_evaluator.dart#L132-L137)
- Adds a test case for the error handling

FYI @christopherfujino 