### PR TITLE
Add and apply lints for imports

### DIFF
--- a/dwds/analysis_options.yaml
+++ b/dwds/analysis_options.yaml
@@ -15,5 +15,7 @@ analyzer:
 
 linter:
   rules:
+    - always_use_package_imports
+    - directives_ordering
     - prefer_final_locals
     - unawaited_futures

--- a/dwds/debug_extension_mv3/web/background.dart
+++ b/dwds/debug_extension_mv3/web/background.dart
@@ -11,10 +11,10 @@ import 'dart:html';
 import 'package:dwds/data/debug_info.dart';
 import 'package:js/js.dart';
 
-import 'data_types.dart';
-import 'debug_session.dart';
 import 'chrome_api.dart';
 import 'cross_extension_communication.dart';
+import 'data_types.dart';
+import 'debug_session.dart';
 import 'lifeline_ports.dart';
 import 'logger.dart';
 import 'messaging.dart';

--- a/dwds/debug_extension_mv3/web/devtools.dart
+++ b/dwds/debug_extension_mv3/web/devtools.dart
@@ -6,8 +6,9 @@
 library devtools;
 
 import 'dart:html';
-import 'package:js/js.dart';
+
 import 'package:dwds/data/debug_info.dart';
+import 'package:js/js.dart';
 
 import 'chrome_api.dart';
 import 'logger.dart';

--- a/dwds/debug_extension_mv3/web/messaging.dart
+++ b/dwds/debug_extension_mv3/web/messaging.dart
@@ -9,8 +9,8 @@ import 'dart:convert';
 
 import 'package:js/js.dart';
 
-import 'data_serializers.dart';
 import 'chrome_api.dart';
+import 'data_serializers.dart';
 import 'logger.dart';
 
 enum Script {

--- a/dwds/debug_extension_mv3/web/web_api.dart
+++ b/dwds/debug_extension_mv3/web/web_api.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:html';
+import 'dart:js_util' as js_util;
 
 import 'package:js/js.dart';
-import 'dart:js_util' as js_util;
 
 @JS()
 // ignore: non_constant_identifier_names

--- a/dwds/lib/dart_web_debug_service.dart
+++ b/dwds/lib/dart_web_debug_service.dart
@@ -4,23 +4,22 @@
 
 import 'dart:async';
 
+import 'package:dwds/data/build_result.dart';
+import 'package:dwds/src/connections/app_connection.dart';
+import 'package:dwds/src/connections/debug_connection.dart';
+import 'package:dwds/src/events.dart';
+import 'package:dwds/src/handlers/dev_handler.dart';
+import 'package:dwds/src/handlers/injector.dart';
+import 'package:dwds/src/handlers/socket_connections.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/servers/devtools.dart';
+import 'package:dwds/src/servers/extension_backend.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import 'data/build_result.dart';
-import 'src/connections/app_connection.dart';
-import 'src/connections/debug_connection.dart';
-import 'src/events.dart';
-import 'src/handlers/dev_handler.dart';
-import 'src/handlers/injector.dart';
-import 'src/handlers/socket_connections.dart';
-import 'src/loaders/strategy.dart';
-import 'src/readers/asset_reader.dart';
-import 'src/servers/devtools.dart';
-import 'src/servers/extension_backend.dart';
-import 'src/services/expression_compiler.dart';
 
 typedef ConnectionProvider = Future<ChromeConnection> Function();
 

--- a/dwds/lib/src/connections/app_connection.dart
+++ b/dwds/lib/src/connections/app_connection.dart
@@ -5,10 +5,10 @@
 import 'dart:async';
 import 'dart:convert';
 
-import '../../data/connect_request.dart';
-import '../../data/run_request.dart';
-import '../../data/serializers.dart';
-import '../handlers/socket_connections.dart';
+import 'package:dwds/data/connect_request.dart';
+import 'package:dwds/data/run_request.dart';
+import 'package:dwds/data/serializers.dart';
+import 'package:dwds/src/handlers/socket_connections.dart';
 
 /// A connection between the application loaded in the browser and DWDS.
 class AppConnection {

--- a/dwds/lib/src/connections/debug_connection.dart
+++ b/dwds/lib/src/connections/debug_connection.dart
@@ -4,10 +4,9 @@
 
 import 'dart:async';
 
+import 'package:dwds/src/services/app_debug_services.dart';
+import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:vm_service/vm_service.dart';
-
-import '../services/app_debug_services.dart';
-import '../services/chrome_proxy_service.dart';
 
 /// A debug connection between the application in the browser and DWDS.
 ///

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -2,14 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
+import 'package:dwds/src/debugging/metadata/class.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/services/chrome_debug_exception.dart';
+import 'package:dwds/src/utilities/domain.dart';
+import 'package:dwds/src/utilities/shared.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../../src/services/chrome_debug_exception.dart';
-import '../loaders/strategy.dart';
-import '../utilities/domain.dart';
-import '../utilities/shared.dart';
-import 'metadata/class.dart';
 
 /// Keeps track of Dart classes available in the running application.
 class ClassHelper extends Domain {

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -2,10 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dwds/src/debugging/debugger.dart';
+import 'package:dwds/src/utilities/objects.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../utilities/objects.dart';
-import 'debugger.dart';
 
 // TODO(sdk/issues/44262) - use an alternative way to identify synthetic
 // variables.

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -5,24 +5,23 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:dwds/src/debugging/dart_scope.dart';
+import 'package:dwds/src/debugging/frame_computer.dart';
+import 'package:dwds/src/debugging/location.dart';
+import 'package:dwds/src/debugging/remote_debugger.dart';
+import 'package:dwds/src/debugging/skip_list.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/services/chrome_debug_exception.dart';
+import 'package:dwds/src/utilities/conversions.dart';
+import 'package:dwds/src/utilities/dart_uri.dart';
+import 'package:dwds/src/utilities/domain.dart';
+import 'package:dwds/src/utilities/objects.dart' show Property;
+import 'package:dwds/src/utilities/shared.dart';
 import 'package:dwds/src/utilities/synchronized.dart';
 import 'package:logging/logging.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     hide StackTrace;
-
-import '../loaders/strategy.dart';
-import '../services/chrome_debug_exception.dart';
-import '../utilities/conversions.dart';
-import '../utilities/dart_uri.dart';
-import '../utilities/domain.dart';
-import '../utilities/objects.dart' show Property;
-import '../utilities/shared.dart';
-import 'dart_scope.dart';
-import 'frame_computer.dart';
-import 'location.dart';
-import 'remote_debugger.dart';
-import 'skip_list.dart';
 
 /// Adds [event] to the stream with [streamId] if there is anybody listening
 /// on that stream.

--- a/dwds/lib/src/debugging/execution_context.dart
+++ b/dwds/lib/src/debugging/execution_context.dart
@@ -5,9 +5,8 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
+import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:logging/logging.dart';
-
-import 'remote_debugger.dart';
 
 abstract class ExecutionContext {
   /// Returns the context ID that contains the running Dart application.

--- a/dwds/lib/src/debugging/frame_computer.dart
+++ b/dwds/lib/src/debugging/frame_computer.dart
@@ -2,11 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dwds/src/debugging/debugger.dart';
 import 'package:dwds/src/utilities/synchronized.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import 'debugger.dart';
 
 class FrameComputer {
   final Debugger debugger;

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -4,24 +4,23 @@
 
 import 'package:async/async.dart';
 import 'package:collection/collection.dart';
+import 'package:dwds/src/connections/app_connection.dart';
+import 'package:dwds/src/debugging/classes.dart';
+import 'package:dwds/src/debugging/debugger.dart';
+import 'package:dwds/src/debugging/execution_context.dart';
+import 'package:dwds/src/debugging/instance.dart';
+import 'package:dwds/src/debugging/libraries.dart';
+import 'package:dwds/src/debugging/location.dart';
+import 'package:dwds/src/debugging/remote_debugger.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/utilities/conversions.dart';
+import 'package:dwds/src/utilities/dart_uri.dart';
+import 'package:dwds/src/utilities/domain.dart';
+import 'package:dwds/src/utilities/shared.dart';
 import 'package:logging/logging.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../connections/app_connection.dart';
-import '../loaders/strategy.dart';
-import '../readers/asset_reader.dart';
-import '../utilities/conversions.dart';
-import '../utilities/dart_uri.dart';
-import '../utilities/domain.dart';
-import '../utilities/shared.dart';
-import 'classes.dart';
-import 'debugger.dart';
-import 'execution_context.dart';
-import 'instance.dart';
-import 'libraries.dart';
-import 'location.dart';
-import 'remote_debugger.dart';
 
 /// An inspector for a running Dart application contained in the
 /// [WipConnection].

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -4,17 +4,16 @@
 
 import 'dart:math';
 
+import 'package:dwds/src/debugging/debugger.dart';
+import 'package:dwds/src/debugging/metadata/class.dart';
+import 'package:dwds/src/debugging/metadata/function.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/utilities/conversions.dart';
+import 'package:dwds/src/utilities/domain.dart';
+import 'package:dwds/src/utilities/objects.dart';
+import 'package:dwds/src/utilities/shared.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../loaders/strategy.dart';
-import '../utilities/conversions.dart';
-import '../utilities/domain.dart';
-import '../utilities/objects.dart';
-import '../utilities/shared.dart';
-import 'debugger.dart';
-import 'metadata/class.dart';
-import 'metadata/function.dart';
 
 /// Contains a set of methods for getting [Instance]s and [InstanceRef]s.
 class InstanceHelper extends Domain {

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -3,14 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:dwds/src/debugging/metadata/class.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/services/chrome_debug_exception.dart';
+import 'package:dwds/src/utilities/domain.dart';
 import 'package:logging/logging.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../loaders/strategy.dart';
-import '../utilities/domain.dart';
-import '../services/chrome_debug_exception.dart';
-import 'metadata/class.dart';
 
 /// Keeps track of Dart libraries available in the running application.
 class LibraryHelper extends Domain {

--- a/dwds/lib/src/debugging/location.dart
+++ b/dwds/lib/src/debugging/location.dart
@@ -3,15 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:async/async.dart';
+import 'package:dwds/src/debugging/modules.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_maps/parser.dart';
 import 'package:source_maps/source_maps.dart';
-
-import '../loaders/strategy.dart';
-import '../readers/asset_reader.dart';
-import '../utilities/dart_uri.dart';
-import 'modules.dart';
 
 var _startTokenId = 1337;
 

--- a/dwds/lib/src/debugging/metadata/class.dart
+++ b/dwds/lib/src/debugging/metadata/class.dart
@@ -2,13 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
+import 'package:dwds/src/debugging/remote_debugger.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/services/chrome_debug_exception.dart';
 import 'package:dwds/src/utilities/domain.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../../debugging/remote_debugger.dart';
-import '../../loaders/strategy.dart';
-import '../../services/chrome_debug_exception.dart';
 
 /// A hard-coded ClassRef for the Closure class.
 final classRefForClosure = classRefFor('dart:core', 'Closure');

--- a/dwds/lib/src/debugging/metadata/function.dart
+++ b/dwds/lib/src/debugging/metadata/function.dart
@@ -2,11 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
+import 'package:dwds/src/debugging/remote_debugger.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/utilities/shared.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../../loaders/strategy.dart';
-import '../../utilities/shared.dart';
-import '../remote_debugger.dart';
 
 /// Meta data for a remote Dart function in Chrome.
 class FunctionMetaData {

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -6,11 +6,10 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:async/async.dart';
+import 'package:dwds/src/debugging/metadata/module_metadata.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
-
-import '../../readers/asset_reader.dart';
-import 'module_metadata.dart';
 
 /// A provider of metadata in which data is collected through DDC outputs.
 class MetadataProvider {

--- a/dwds/lib/src/debugging/modules.dart
+++ b/dwds/lib/src/debugging/modules.dart
@@ -3,10 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:async/async.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:logging/logging.dart';
-
-import '../loaders/strategy.dart';
-import '../utilities/dart_uri.dart';
 
 /// Tracks modules for the compiled application.
 class Modules {

--- a/dwds/lib/src/debugging/skip_list.dart
+++ b/dwds/lib/src/debugging/skip_list.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'location.dart';
+import 'package:dwds/src/debugging/location.dart';
 
 const maxValue = 2147483647;
 

--- a/dwds/lib/src/debugging/webkit_debugger.dart
+++ b/dwds/lib/src/debugging/webkit_debugger.dart
@@ -2,9 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import 'remote_debugger.dart';
 
 /// A remote debugger with a Webkit Inspection Protocol connection.
 class WebkitDebugger implements RemoteDebugger {

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -5,16 +5,15 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:dwds/src/events.dart';
+import 'package:dwds/src/services/chrome_debug_exception.dart';
+import 'package:dwds/src/services/chrome_proxy_service.dart';
+import 'package:dwds/src/services/debug_service.dart';
 import 'package:dwds/src/utilities/synchronized.dart';
 import 'package:logging/logging.dart';
 import 'package:uuid/uuid.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import 'events.dart';
-import 'services/chrome_proxy_service.dart';
-import 'services/chrome_debug_exception.dart';
-import 'services/debug_service.dart';
 
 final _logger = Logger('DwdsVmClient');
 

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -6,37 +6,35 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dwds/data/build_result.dart';
+import 'package:dwds/data/connect_request.dart';
+import 'package:dwds/data/debug_event.dart';
+import 'package:dwds/data/devtools_request.dart';
+import 'package:dwds/data/error_response.dart';
+import 'package:dwds/data/isolate_events.dart';
+import 'package:dwds/data/register_event.dart';
+import 'package:dwds/data/serializers.dart';
+import 'package:dwds/src/connections/app_connection.dart';
+import 'package:dwds/src/connections/debug_connection.dart';
+import 'package:dwds/src/debugging/execution_context.dart';
+import 'package:dwds/src/debugging/remote_debugger.dart';
+import 'package:dwds/src/debugging/webkit_debugger.dart';
+import 'package:dwds/src/dwds_vm_client.dart';
+import 'package:dwds/src/events.dart';
+import 'package:dwds/src/handlers/injector.dart';
+import 'package:dwds/src/handlers/socket_connections.dart';
 import 'package:dwds/src/loaders/require.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/servers/devtools.dart';
+import 'package:dwds/src/servers/extension_backend.dart';
+import 'package:dwds/src/services/app_debug_services.dart';
+import 'package:dwds/src/services/debug_service.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../../data/build_result.dart';
-import '../../data/connect_request.dart';
-import '../../data/debug_event.dart';
-import '../../data/devtools_request.dart';
-import '../../data/error_response.dart';
-import '../../data/isolate_events.dart';
-import '../../data/register_event.dart';
-import '../../data/serializers.dart';
-
-import '../connections/app_connection.dart';
-import '../connections/debug_connection.dart';
-import '../debugging/execution_context.dart';
-import '../debugging/remote_debugger.dart';
-import '../debugging/webkit_debugger.dart';
-import '../dwds_vm_client.dart';
-import '../events.dart';
-import '../handlers/socket_connections.dart';
-import '../loaders/strategy.dart';
-import '../readers/asset_reader.dart';
-import '../servers/devtools.dart';
-import '../servers/extension_backend.dart';
-import '../services/app_debug_services.dart';
-import '../services/debug_service.dart';
-import '../services/expression_compiler.dart';
-import 'injector.dart';
 
 /// When enabled, this logs VM service protocol and Chrome debug protocol
 /// traffic to disk.

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -8,11 +8,10 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:crypto/crypto.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/version.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
-
-import '../loaders/strategy.dart';
-import '../version.dart';
 
 /// File extension that build_web_compilers will place the
 /// [entrypointExtensionMarker] in.

--- a/dwds/lib/src/loaders/build_runner_require.dart
+++ b/dwds/lib/src/loaders/build_runner_require.dart
@@ -5,15 +5,14 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dwds/src/debugging/metadata/provider.dart';
+import 'package:dwds/src/loaders/require.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:shelf/shelf.dart';
-
-import '../debugging/metadata/provider.dart';
-import '../loaders/strategy.dart';
-import '../readers/asset_reader.dart';
-import '../services/expression_compiler.dart';
-import 'require.dart';
 
 /// Provides a [RequireStrategy] suitable for use with `package:build_runner`.
 class BuildRunnerRequireStrategyProvider {

--- a/dwds/lib/src/loaders/frontend_server_require.dart
+++ b/dwds/lib/src/loaders/frontend_server_require.dart
@@ -2,13 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:dwds/src/debugging/metadata/provider.dart';
+import 'package:dwds/src/loaders/require.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
 import 'package:path/path.dart' as p;
-
-import '../debugging/metadata/provider.dart';
-import '../loaders/strategy.dart';
-import '../readers/asset_reader.dart';
-import '../services/expression_compiler.dart';
-import 'require.dart';
 
 /// Provides a [RequireStrategy] suitable for use with Frontend Server.
 class FrontendServerRequireStrategyProvider {

--- a/dwds/lib/src/loaders/legacy.dart
+++ b/dwds/lib/src/loaders/legacy.dart
@@ -2,12 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dwds/src/debugging/metadata/provider.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
 import 'package:shelf/shelf.dart';
-
-import '../debugging/metadata/provider.dart';
-import '../loaders/strategy.dart';
-import '../readers/asset_reader.dart';
-import '../services/expression_compiler.dart';
 
 /// A load strategy for the legacy module system.
 class LegacyStrategy extends LoadStrategy {

--- a/dwds/lib/src/loaders/require.dart
+++ b/dwds/lib/src/loaders/require.dart
@@ -4,13 +4,12 @@
 
 import 'dart:convert';
 
+import 'package:dwds/src/debugging/metadata/provider.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
 import 'package:path/path.dart' as p;
 import 'package:shelf/shelf.dart';
-
-import '../debugging/metadata/provider.dart';
-import '../loaders/strategy.dart';
-import '../readers/asset_reader.dart';
-import '../services/expression_compiler.dart';
 
 /// Find the path we are serving from the url.
 ///

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -2,11 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dwds/src/debugging/metadata/provider.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
 import 'package:shelf/shelf.dart';
-
-import '../debugging/metadata/provider.dart';
-import '../readers/asset_reader.dart';
-import '../services/expression_compiler.dart';
 
 late LoadStrategy _globalLoadStrategy;
 

--- a/dwds/lib/src/readers/frontend_server_asset_reader.dart
+++ b/dwds/lib/src/readers/frontend_server_asset_reader.dart
@@ -5,11 +5,10 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dwds/src/readers/asset_reader.dart';
 import 'package:logging/logging.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
-
-import '../readers/asset_reader.dart';
 
 /// A reader for Dart sources and related source maps provided by the Frontend
 /// Server.

--- a/dwds/lib/src/readers/proxy_server_asset_reader.dart
+++ b/dwds/lib/src/readers/proxy_server_asset_reader.dart
@@ -6,13 +6,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dwds/src/readers/asset_reader.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_proxy/shelf_proxy.dart';
-
-import 'asset_reader.dart';
 
 /// A reader for resources provided by a proxy server.
 class ProxyServerAssetReader implements AssetReader {

--- a/dwds/lib/src/servers/extension_backend.dart
+++ b/dwds/lib/src/servers/extension_backend.dart
@@ -6,14 +6,13 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:async/async.dart';
+import 'package:dwds/data/extension_request.dart';
+import 'package:dwds/src/events.dart';
+import 'package:dwds/src/handlers/socket_connections.dart';
+import 'package:dwds/src/servers/extension_debugger.dart';
+import 'package:dwds/src/utilities/shared.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
-
-import '../../data/extension_request.dart';
-import '../events.dart';
-import '../handlers/socket_connections.dart';
-import '../utilities/shared.dart';
-import 'extension_debugger.dart';
 
 const authenticationResponse = 'Dart Debug Authentication Success!\n\n'
     'You can close this tab and launch the Dart Debug Extension again.';

--- a/dwds/lib/src/servers/extension_debugger.dart
+++ b/dwds/lib/src/servers/extension_debugger.dart
@@ -6,15 +6,14 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:dwds/data/devtools_request.dart';
+import 'package:dwds/data/extension_request.dart';
+import 'package:dwds/data/serializers.dart';
+import 'package:dwds/src/debugging/execution_context.dart';
+import 'package:dwds/src/debugging/remote_debugger.dart';
+import 'package:dwds/src/handlers/socket_connections.dart';
+import 'package:dwds/src/services/chrome_debug_exception.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../../data/devtools_request.dart';
-import '../../data/extension_request.dart';
-import '../../data/serializers.dart';
-import '../debugging/execution_context.dart';
-import '../debugging/remote_debugger.dart';
-import '../handlers/socket_connections.dart';
-import '../services/chrome_debug_exception.dart';
 
 /// A remote debugger backed by the Dart Debug Extension with an SSE connection.
 class ExtensionDebugger implements RemoteDebugger {

--- a/dwds/lib/src/services/app_debug_services.dart
+++ b/dwds/lib/src/services/app_debug_services.dart
@@ -4,10 +4,11 @@
 
 import 'dart:async';
 
-import '../dwds_vm_client.dart';
-import '../events.dart';
-import 'chrome_proxy_service.dart' show ChromeProxyService;
-import 'debug_service.dart';
+import 'package:dwds/src/dwds_vm_client.dart';
+import 'package:dwds/src/events.dart';
+import 'package:dwds/src/services/chrome_proxy_service.dart'
+    show ChromeProxyService;
+import 'package:dwds/src/services/debug_service.dart';
 
 /// A container for all the services required for debugging an application.
 class AppDebugServices {

--- a/dwds/lib/src/services/batched_expression_evaluator.dart
+++ b/dwds/lib/src/services/batched_expression_evaluator.dart
@@ -5,16 +5,15 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:dwds/src/debugging/debugger.dart';
+import 'package:dwds/src/debugging/location.dart';
+import 'package:dwds/src/debugging/modules.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
+import 'package:dwds/src/services/expression_evaluator.dart';
+import 'package:dwds/src/utilities/batched_stream.dart';
 import 'package:dwds/src/utilities/domain.dart';
 import 'package:logging/logging.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../debugging/debugger.dart';
-import '../debugging/location.dart';
-import '../debugging/modules.dart';
-import '../utilities/batched_stream.dart';
-import 'expression_compiler.dart';
-import 'expression_evaluator.dart';
 
 class EvaluateRequest {
   final String isolateId;

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -6,30 +6,29 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dwds/data/debug_event.dart';
+import 'package:dwds/data/register_event.dart';
+import 'package:dwds/src/connections/app_connection.dart';
+import 'package:dwds/src/debugging/debugger.dart';
+import 'package:dwds/src/debugging/execution_context.dart';
+import 'package:dwds/src/debugging/inspector.dart';
+import 'package:dwds/src/debugging/instance.dart';
+import 'package:dwds/src/debugging/location.dart';
+import 'package:dwds/src/debugging/modules.dart';
+import 'package:dwds/src/debugging/remote_debugger.dart';
+import 'package:dwds/src/debugging/skip_list.dart';
+import 'package:dwds/src/events.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/services/batched_expression_evaluator.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
+import 'package:dwds/src/services/expression_evaluator.dart';
+import 'package:dwds/src/utilities/dart_uri.dart';
+import 'package:dwds/src/utilities/shared.dart';
 import 'package:logging/logging.dart' hide LogRecord;
 import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../../data/debug_event.dart';
-import '../../data/register_event.dart';
-import '../connections/app_connection.dart';
-import '../debugging/debugger.dart';
-import '../debugging/execution_context.dart';
-import '../debugging/inspector.dart';
-import '../debugging/instance.dart';
-import '../debugging/location.dart';
-import '../debugging/modules.dart';
-import '../debugging/remote_debugger.dart';
-import '../debugging/skip_list.dart';
-import '../events.dart';
-import '../loaders/strategy.dart';
-import '../readers/asset_reader.dart';
-import '../services/expression_compiler.dart';
-import '../utilities/dart_uri.dart';
-import '../utilities/shared.dart';
-import 'expression_evaluator.dart';
-import 'batched_expression_evaluator.dart';
 
 /// A proxy from the chrome debug protocol to the dart vm service protocol.
 class ChromeProxyService implements VmServiceInterface {

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -9,6 +9,15 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:dds/dds.dart';
+import 'package:dwds/src/connections/app_connection.dart';
+import 'package:dwds/src/debugging/execution_context.dart';
+import 'package:dwds/src/debugging/remote_debugger.dart';
+import 'package:dwds/src/events.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/readers/asset_reader.dart';
+import 'package:dwds/src/services/chrome_proxy_service.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
+import 'package:dwds/src/utilities/shared.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf.dart' hide Response;
@@ -16,16 +25,6 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
-
-import '../connections/app_connection.dart';
-import '../loaders/strategy.dart';
-import '../readers/asset_reader.dart';
-import '../services/expression_compiler.dart';
-import '../debugging/execution_context.dart';
-import '../debugging/remote_debugger.dart';
-import '../events.dart';
-import '../utilities/shared.dart';
-import 'chrome_proxy_service.dart';
 
 bool _acceptNewConnections = true;
 int _clientsConnected = 0;

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -6,10 +6,9 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:async/async.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
+import 'package:dwds/src/utilities/sdk_configuration.dart';
 import 'package:logging/logging.dart';
-
-import '../utilities/sdk_configuration.dart';
-import 'expression_compiler.dart';
 
 class _Compiler {
   static final _logger = Logger('ExpressionCompilerService');

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -2,17 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dwds/src/debugging/dart_scope.dart';
+import 'package:dwds/src/debugging/debugger.dart';
+import 'package:dwds/src/debugging/location.dart';
+import 'package:dwds/src/debugging/modules.dart';
+import 'package:dwds/src/loaders/strategy.dart';
+import 'package:dwds/src/services/expression_compiler.dart';
 import 'package:dwds/src/utilities/domain.dart';
+import 'package:dwds/src/utilities/objects.dart' as chrome;
 import 'package:logging/logging.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../debugging/dart_scope.dart';
-import '../debugging/debugger.dart';
-import '../debugging/location.dart';
-import '../debugging/modules.dart';
-import '../loaders/strategy.dart';
-import '../utilities/objects.dart' as chrome;
-import 'expression_compiler.dart';
 
 class ErrorKind {
   const ErrorKind._(this._kind);

--- a/dwds/lib/src/utilities/dart_uri.dart
+++ b/dwds/lib/src/utilities/dart_uri.dart
@@ -2,11 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:logging/logging.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
-
-import '../loaders/strategy.dart';
 
 /// The URI for a particular Dart file, able to canonicalize from various
 /// different representations.

--- a/dwds/lib/src/utilities/domain.dart
+++ b/dwds/lib/src/utilities/domain.dart
@@ -2,11 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.import 'dart:async';
 
+import 'package:dwds/src/connections/app_connection.dart';
+import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
-
-import '../connections/app_connection.dart';
-import '../debugging/remote_debugger.dart';
 
 abstract class AppInspectorInterface {
   /// Connection to the app running in the browser.

--- a/dwds/lib/src/utilities/shared.dart
+++ b/dwds/lib/src/utilities/shared.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:dwds/src/services/chrome_debug_exception.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart';
@@ -12,8 +13,6 @@ import 'package:stack_trace/stack_trace.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     as wip;
-
-import 'package:dwds/src/services/chrome_debug_exception.dart';
 
 VMRef toVMRef(VM vm) => VMRef(name: vm.name);
 

--- a/dwds/test/build_daemon_circular_evaluate_test.dart
+++ b/dwds/test/build_daemon_circular_evaluate_test.dart
@@ -7,8 +7,8 @@
 
 import 'package:test/test.dart';
 
-import 'fixtures/context.dart';
 import 'evaluate_circular_common.dart';
+import 'fixtures/context.dart';
 
 void main() async {
   // Enable verbose logging for debugging.

--- a/dwds/test/build_daemon_evaluate_test.dart
+++ b/dwds/test/build_daemon_evaluate_test.dart
@@ -7,8 +7,8 @@
 
 import 'package:test/test.dart';
 
-import 'fixtures/context.dart';
 import 'evaluate_common.dart';
+import 'fixtures/context.dart';
 
 void main() async {
   // Enable verbose logging for debugging.

--- a/dwds/test/dart_uri_test.dart
+++ b/dwds/test/dart_uri_test.dart
@@ -9,8 +9,8 @@ import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:test/test.dart';
 
-import 'fixtures/logging.dart';
 import 'fixtures/fakes.dart';
+import 'fixtures/logging.dart';
 
 class TestStrategy extends FakeStrategy {
   @override

--- a/dwds/test/frontend_server_circular_evaluate_test.dart
+++ b/dwds/test/frontend_server_circular_evaluate_test.dart
@@ -10,8 +10,8 @@ import 'dart:io';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
-import 'fixtures/context.dart';
 import 'evaluate_circular_common.dart';
+import 'fixtures/context.dart';
 
 void main() async {
   // Enable verbose logging for debugging.

--- a/dwds/test/frontend_server_evaluate_sound_test.dart
+++ b/dwds/test/frontend_server_evaluate_sound_test.dart
@@ -9,8 +9,8 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 
-import 'fixtures/context.dart';
 import 'evaluate_common.dart';
+import 'fixtures/context.dart';
 
 void main() async {
   // Enable verbose logging for debugging.

--- a/dwds/test/frontend_server_evaluate_weak_test.dart
+++ b/dwds/test/frontend_server_evaluate_weak_test.dart
@@ -9,8 +9,8 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 
-import 'fixtures/context.dart';
 import 'evaluate_common.dart';
+import 'fixtures/context.dart';
 
 void main() async {
   // Enable verbose logging for debugging.

--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -9,9 +9,9 @@
   'linux': Skip('https://github.com/dart-lang/webdev/issues/1787'),
 })
 @Timeout(Duration(minutes: 2))
-import 'dart:io';
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:dwds/data/debug_info.dart';

--- a/dwds/test/skip_list_test.dart
+++ b/dwds/test/skip_list_test.dart
@@ -4,9 +4,9 @@
 
 @Timeout(Duration(minutes: 2))
 
-import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/debugging/location.dart';
 import 'package:dwds/src/debugging/skip_list.dart';
+import 'package:dwds/src/loaders/strategy.dart';
 import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:source_maps/parser.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
Applies the following lints:

- `always_use_package_imports`
- `directives_ordering`