### PR TITLE
[MV3 Debug Extension] Fix lifeline connection logic

### DIFF
--- a/dwds/debug_extension_mv3/web/background.dart
+++ b/dwds/debug_extension_mv3/web/background.dart
@@ -15,7 +15,6 @@ import 'chrome_api.dart';
 import 'cross_extension_communication.dart';
 import 'data_types.dart';
 import 'debug_session.dart';
-import 'lifeline_ports.dart';
 import 'logger.dart';
 import 'messaging.dart';
 import 'storage.dart';
@@ -35,8 +34,6 @@ void _registerListeners() {
   chrome.runtime.onMessageExternal.addListener(
     allowInterop(handleMessagesFromAngularDartDevTools),
   );
-  chrome.tabs.onRemoved
-      .addListener(allowInterop((tabId, _) => maybeRemoveLifelinePort(tabId)));
   // Update the extension icon on tab navigation:
   chrome.tabs.onActivated.addListener(allowInterop((ActiveInfo info) {
     _updateIcon(info.tabId);

--- a/dwds/debug_extension_mv3/web/debug_session.dart
+++ b/dwds/debug_extension_mv3/web/debug_session.dart
@@ -25,6 +25,7 @@ import 'chrome_api.dart';
 import 'cross_extension_communication.dart';
 import 'data_serializers.dart';
 import 'data_types.dart';
+import 'lifeline_ports.dart';
 import 'logger.dart';
 import 'messaging.dart';
 import 'storage.dart';
@@ -97,6 +98,11 @@ enum DebuggerLocation {
     }
   }
 }
+
+bool get existsActiveDebugSession => _debugSessions.isNotEmpty;
+
+int? get latestAppBeingDebugged =>
+    existsActiveDebugSession ? _debugSessions.last.appTabId : null;
 
 void attachDebugger(int dartAppTabId, {required Trigger trigger}) async {
   // Check if a debugger is already attached:
@@ -260,8 +266,10 @@ Future<bool> _connectToDwds({
     cancelOnError: true,
   );
   _debugSessions.add(debugSession);
-  final tabUrl = await _getTabUrl(dartAppTabId);
+  // Create a connection with the lifeline port to keep the debug session alive:
+  maybeCreateLifelinePort(dartAppTabId);
   // Send a DevtoolsRequest to the event stream:
+  final tabUrl = await _getTabUrl(dartAppTabId);
   debugSession.sendEvent(DevToolsRequest((b) => b
     ..appId = debugInfo.appId
     ..instanceId = debugInfo.appInstanceId
@@ -408,7 +416,10 @@ void _removeDebugSession(_DebugSession debugSession) {
   debugSession.sendEvent(event);
   debugSession.close();
   final removed = _debugSessions.remove(debugSession);
-  if (!removed) {
+  if (removed) {
+    // Maybe remove the corresponding lifeline connection:
+    maybeRemoveLifelinePort(debugSession.appTabId);
+  } else {
     debugWarn('Could not remove debug session.');
   }
 }

--- a/dwds/debug_extension_mv3/web/lifeline_ports.dart
+++ b/dwds/debug_extension_mv3/web/lifeline_ports.dart
@@ -12,24 +12,16 @@ import 'dart:async';
 import 'package:js/js.dart';
 
 import 'chrome_api.dart';
+import 'debug_session.dart';
 import 'logger.dart';
 
-// Switch to true to enable debug logs.
-// TODO(elliette): Enable / disable with flag while building the extension.
-final enableDebugLogging = true;
-
-Port? lifelinePort;
-int? lifelineTab;
-final dartTabs = <int>{};
+Port? _lifelinePort;
+int? _lifelineTab;
 
 void maybeCreateLifelinePort(int tabId) {
-  // Keep track of current Dart tabs that are being debugged. This way if one of
-  // them is closed, we can reconnect the lifeline port to another one:
-  dartTabs.add(tabId);
-  debugLog('Dart tabs are: $dartTabs');
   // Don't create a lifeline port if we already have one (meaning another Dart
   // app is currently being debugged):
-  if (lifelinePort != null) {
+  if (_lifelinePort != null) {
     debugWarn('Port already exists.');
     return;
   }
@@ -38,7 +30,7 @@ void maybeCreateLifelinePort(int tabId) {
   // Inject the connection script into the current Dart tab, that way the tab
   // will connect to the port:
   debugLog('Creating lifeline port.');
-  lifelineTab = tabId;
+  _lifelineTab = tabId;
   chrome.scripting.executeScript(
     InjectDetails(
       target: Target(tabId: tabId),
@@ -49,21 +41,17 @@ void maybeCreateLifelinePort(int tabId) {
 }
 
 void maybeRemoveLifelinePort(int removedTabId) {
-  final removedDartTab = dartTabs.remove(removedTabId);
-  // If the removed tab was not a Dart tab, return early.
-  if (!removedDartTab) return;
-  debugLog('Removed tab $removedTabId, Dart tabs are now $dartTabs.');
   // If the removed Dart tab hosted the lifeline port connection, see if there
   // are any other Dart tabs to connect to. Otherwise disconnect the port.
-  if (lifelineTab == removedTabId) {
-    if (dartTabs.isEmpty) {
-      lifelineTab = null;
+  if (_lifelineTab == removedTabId) {
+    if (existsActiveDebugSession) {
+      _lifelineTab = latestAppBeingDebugged;
+      debugLog('Reconnecting lifeline port to a new Dart tab: $_lifelineTab.');
+      _reconnectToLifelinePort();
+    } else {
+      _lifelineTab = null;
       debugLog('No more Dart tabs, disconnecting from lifeline port.');
       _disconnectFromLifelinePort();
-    } else {
-      lifelineTab = dartTabs.last;
-      debugLog('Reconnecting lifeline port to a new Dart tab: $lifelineTab.');
-      _reconnectToLifelinePort();
     }
   }
 }
@@ -71,7 +59,7 @@ void maybeRemoveLifelinePort(int removedTabId) {
 void _keepLifelinePortAlive(Port port) {
   final portName = port.name ?? '';
   if (portName != 'keepAlive') return;
-  lifelinePort = port;
+  _lifelinePort = port;
   // Reconnect to the lifeline port every 5 minutes, as per:
   // https://bugs.chromium.org/p/chromium/issues/detail?id=1146434#c6
   Timer(Duration(minutes: 5), () {
@@ -82,26 +70,26 @@ void _keepLifelinePortAlive(Port port) {
 
 void _reconnectToLifelinePort() {
   debugLog('Reconnecting...');
-  if (lifelinePort == null) {
+  if (_lifelinePort == null) {
     debugWarn('Could not find a lifeline port.');
     return;
   }
-  if (lifelineTab == null) {
+  if (_lifelineTab == null) {
     debugWarn('Could not find a lifeline tab.');
     return;
   }
   // Disconnect from the port, and then recreate the connection with the current
   // Dart tab:
   _disconnectFromLifelinePort();
-  maybeCreateLifelinePort(lifelineTab!);
+  maybeCreateLifelinePort(_lifelineTab!);
   debugLog('Reconnection complete.');
 }
 
 void _disconnectFromLifelinePort() {
   debugLog('Disconnecting...');
-  if (lifelinePort != null) {
-    lifelinePort!.disconnect();
-    lifelinePort = null;
+  if (_lifelinePort != null) {
+    _lifelinePort!.disconnect();
+    _lifelinePort = null;
     debugLog('Disconnection complete.');
   }
 }


### PR DESCRIPTION
I hadn't run the `lifeline_test` in a while, so didn't realize I had regressed the keep-alive connection. This PR updates the logic so the test works again.