### PR TITLE
[MV3 Debug Extension] Print `console` messages on test failure

### DIFF
--- a/dwds/debug_extension_mv3/web/chrome_api.dart
+++ b/dwds/debug_extension_mv3/web/chrome_api.dart
@@ -230,7 +230,7 @@ class MessageSender {
 @JS()
 @anonymous
 class Scripting {
-  external executeScript(InjectDetails details, Function? callback);
+  external Object executeScript(InjectDetails details);
 }
 
 @JS()

--- a/dwds/debug_extension_mv3/web/utils.dart
+++ b/dwds/debug_extension_mv3/web/utils.dart
@@ -68,16 +68,12 @@ Future<bool> removeTab(int tabId) {
   return completer.future;
 }
 
-Future<bool> injectScript(String scriptName, {required int tabId}) {
-  final completer = Completer<bool>();
-  chrome.scripting.executeScript(
-      InjectDetails(
-        target: Target(tabId: tabId),
-        files: [scriptName],
-      ), allowInterop(() {
-    completer.complete(true);
-  }));
-  return completer.future;
+Future<bool> injectScript(String scriptName, {required int tabId}) async {
+  await promiseToFuture(chrome.scripting.executeScript(InjectDetails(
+    target: Target(tabId: tabId),
+    files: [scriptName],
+  )));
+  return true;
 }
 
 void onExtensionIconClicked(void Function(Tab) callback) {

--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -431,7 +431,6 @@ void main() async {
 
           tearDown(() async {
             await tearDownHelper(worker: worker);
-
           });
 
           tearDownAll(() async {

--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -58,9 +58,7 @@ void main() async {
         });
 
         tearDown(() async {
-          await workerEvalDelay();
-          await worker.evaluate(_clearStorageJs());
-          await workerEvalDelay();
+          await tearDownHelper(worker: worker);
         });
 
         tearDownAll(() async {
@@ -205,7 +203,6 @@ void main() async {
           // Click on the Dart Debug Extension icon:
           await workerEvalDelay();
           await clickOnExtensionIcon(worker);
-          print('clicked, waiting for devtools');
           // Wait for DevTools to open:
           final devToolsTabTarget = await browser.waitForTarget(
               (target) => target.url.contains(devToolsUrlFragment));
@@ -344,8 +341,7 @@ void main() async {
           });
 
           tearDown(() async {
-            await workerEvalDelay();
-            await worker.evaluate(_clearStorageJs());
+            await tearDownHelper(worker: worker);
           });
 
           tearDownAll(() async {
@@ -424,7 +420,7 @@ void main() async {
 
           setUp(() async {
             for (final page in await browser.pages) {
-              await page.close();
+              await page.close().catchError((_) {});
             }
             appTab = await navigateToPage(
               browser,
@@ -434,9 +430,8 @@ void main() async {
           });
 
           tearDown(() async {
-            await workerEvalDelay();
-            await worker.evaluate(_clearStorageJs());
-            await workerEvalDelay();
+            await tearDownHelper(worker: worker);
+
           });
 
           tearDownAll(() async {
@@ -461,7 +456,7 @@ void main() async {
 
           test('the correct extension panels are added to Chrome DevTools',
               () async {
-            final chromeDevToolsPage = await _getChromeDevToolsPage(browser);
+            final chromeDevToolsPage = await getChromeDevToolsPage(browser);
             // There are no hooks for when a panel is added to Chrome DevTools,
             // therefore we rely on a slight delay:
             await Future.delayed(Duration(seconds: 1));
@@ -494,7 +489,7 @@ void main() async {
 
           test('Dart DevTools is embedded for debug session lifetime',
               () async {
-            final chromeDevToolsPage = await _getChromeDevToolsPage(browser);
+            final chromeDevToolsPage = await getChromeDevToolsPage(browser);
             // There are no hooks for when a panel is added to Chrome DevTools,
             // therefore we rely on a slight delay:
             await Future.delayed(Duration(seconds: 1));
@@ -541,7 +536,7 @@ void main() async {
 
           test('The Dart DevTools IFRAME has the correct query parameters',
               () async {
-            final chromeDevToolsPage = await _getChromeDevToolsPage(browser);
+            final chromeDevToolsPage = await getChromeDevToolsPage(browser);
             // There are no hooks for when a panel is added to Chrome DevTools,
             // therefore we rely on a slight delay:
             await Future.delayed(Duration(seconds: 1));
@@ -618,9 +613,7 @@ void main() async {
       });
 
       tearDown(() async {
-        await workerEvalDelay();
-        await worker.evaluate(_clearStorageJs());
-        await workerEvalDelay();
+        await tearDownHelper(worker: worker);
       });
 
       tearDownAll(() async {
@@ -670,13 +663,6 @@ Future<bool> _clickLaunchButton(
   } catch (_) {
     return false;
   }
-}
-
-Future<Page> _getChromeDevToolsPage(Browser browser) async {
-  final chromeDevToolsTarget = browser.targets
-      .firstWhere((target) => target.url.startsWith('devtools://devtools'));
-  chromeDevToolsTarget.type = 'page';
-  return await chromeDevToolsTarget.page;
 }
 
 Future<Page> _getPanelPage(
@@ -783,16 +769,6 @@ String _fetchStorageObjJs(
           }
         });
       });
-    }
-''';
-}
-
-String _clearStorageJs() {
-  return '''
-    async () => {
-      await chrome.storage.local.clear();
-      await chrome.storage.session.clear();
-      return true;
     }
 ''';
 }


### PR DESCRIPTION
Uses `printOnFailure` to log the most recent messages logged to the service worker or chrome devtools console for debugging purposes.

Also fixes some test failures.