### PR TITLE
contribute issue templates and pull request labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/dwds.md
+++ b/.github/ISSUE_TEMPLATE/dwds.md
@@ -1,0 +1,5 @@
+---
+name: "package:dwds"
+about: "Create a bug or file a feature request against package:dwds."
+labels: "package:dwds"
+---

--- a/.github/ISSUE_TEMPLATE/frontend_server_client.md
+++ b/.github/ISSUE_TEMPLATE/frontend_server_client.md
@@ -1,0 +1,5 @@
+---
+name: "package:frontend_server_client"
+about: "Create a bug or file a feature request against package:frontend_server_client."
+labels: "package:frontend_server_client"
+---

--- a/.github/ISSUE_TEMPLATE/webdev.md
+++ b/.github/ISSUE_TEMPLATE/webdev.md
@@ -1,0 +1,5 @@
+---
+name: "package:webdev"
+about: "Create a bug or file a feature request against package:webdev."
+labels: "package:webdev"
+---

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,13 @@
+# This configures the .github/workflows/pull_request_label.yml workflow. 
+
+'infra':
+  - '.github/**'
+
+'package:dwds':
+  - dwds/**/*
+
+'package:frontend_server_client':
+  - frontend_server_client/**/*
+
+'package:webdev':
+  - webdev/**/*

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -1,0 +1,22 @@
+# This workflow applies labels to pull requests based on the paths that are
+# modified in the pull request.
+#
+# Edit `.github/labeler.yml` to configure labels. For more information, see
+# https://github.com/actions/labeler.
+
+name: Pull Request Labeler
+permissions: read-all
+
+on:
+  pull_request_target
+
+jobs:
+  label:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@5c7539237e04b714afd8ad9b4aed733815b9fab4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
- contribute issue templates
- contribute a pull request labeling workflow

@annagrin @elliette 

This will add `package:` labels to PRs that effect those package's files, and will show allow people to specify which package an issue is for in the 'new issue' page.
