### PR TITLE
[MV3 Debug Extension] Small fixes for building the extension

### DIFF
--- a/dwds/debug_extension_mv3/tool/build_extension.dart
+++ b/dwds/debug_extension_mv3/tool/build_extension.dart
@@ -60,6 +60,9 @@ Future<int> run({required bool isProd, required bool isMV3}) async {
     // Return non-zero exit code to indicate failure:
     return 1;
   }
+  // If we're compiling for prod, skip updating the manifest.json:
+  if (isProd) return 0;
+  // Update manifest.json for dev:
   _logInfo('Updating manifest.json in /compiled directory.');
   final updateStep = await Process.start(
     'dart',

--- a/dwds/debug_extension_mv3/tool/update_dev_files.dart
+++ b/dwds/debug_extension_mv3/tool/update_dev_files.dart
@@ -30,6 +30,14 @@ Future<void> _updateManifestJson() async {
             newValue: extensionKey,
           ),
       ];
+    } else if (_matchesKey(line: line, key: 'default_icon')) {
+      return [
+        _newKeyValue(
+          oldLine: line,
+          newKey: 'default_icon',
+          newValue: 'static_assets/dart_dev.png',
+        )
+      ];
     } else {
       return [line];
     }

--- a/dwds/debug_extension_mv3/web/manifest_mv2.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv2.json
@@ -4,7 +4,7 @@
   "manifest_version": 2,
   "devtools_page": "static_assets/devtools.html",
   "browser_action": {
-    "default_icon": "static_assets/dart_dev.png"
+    "default_icon": "static_assets/dart_grey.png"
   },
   "externally_connectable": {
     "ids": ["nbkbficgbembimioedhceniahniffgpl"]
@@ -16,7 +16,6 @@
     "tabs",
     "webNavigation"
   ],
-  "host_permissions": ["<all_urls>"],
   "background": {
     "scripts": ["background.dart.js"]
   },


### PR DESCRIPTION
- Skip updating the dev files if we are compiling the prod extension
- Have the grey icon as the default, and switch to the `dart_dev` icon if we are compiling for dev
- Remove `"host_permissions": ["<all_urls>"]` from the manifest.json for MV2 (only MV3 supports it)