### PR TITLE
[MV3 Debug Extension] Use the new Dart Debug Extension bug template

### DIFF
--- a/dwds/debug_extension_mv3/web/panel.dart
+++ b/dwds/debug_extension_mv3/web/panel.dart
@@ -175,7 +175,7 @@ Future<void> _maybeUpdateFileABugLink() async {
     final bugLink = document.getElementById(_bugLinkId);
     if (bugLink == null) return;
     bugLink.setAttribute(
-        'href', 'http://b/issues/new?component=775375&template=1369639');
+        'href', 'http://b/issues/new?component=775375&template=1791321');
   }
 }
 


### PR DESCRIPTION
Created a new template just for debug extension issues, and switched the "file a bug link" to that template.