### PR TITLE
[MV3 Debug Extension] Ignore page reloads for detecting navigation away from app

### DIFF
--- a/dwds/debug_extension_mv3/web/background.dart
+++ b/dwds/debug_extension_mv3/web/background.dart
@@ -163,6 +163,7 @@ bool _isInternalNavigation(NavigationInfo navigationInfo) {
     'form_submit',
     'link',
     'manual_subframe',
+    'reload',
   ].contains(navigationInfo.transitionType);
 }
 

--- a/dwds/debug_extension_mv3/web/background.dart
+++ b/dwds/debug_extension_mv3/web/background.dart
@@ -140,7 +140,7 @@ Future<void> _handleRuntimeMessages(
 Future<void> _detectNavigationAwayFromDartApp(
     NavigationInfo navigationInfo) async {
   // Ignore any navigation events within the page itself (e.g., opening a link,
-  // reloading an IFRAME, etc):
+  // reloading the page, reloading an IFRAME, etc):
   if (_isInternalNavigation(navigationInfo)) return;
   final tabId = navigationInfo.tabId;
   final debugInfo = await _fetchDebugInfo(navigationInfo.tabId);


### PR DESCRIPTION
Follow up to https://github.com/dart-lang/webdev/pull/1991

Include page reloads as a navigation event that should be ignored when determining whether a user has navigated away from the Dart app