### PR TITLE
Fix expression evaluation failures on empty scopes

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Remove test-only code from `sdk_configuration.dart`.
 - Move shared test-only code to a new `test_common` package.
 - Convert unnecessary async code to sync.
+- Allow empty scopes in expression evaluation in a frame.
 
 **Breaking changes**
 

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -143,7 +143,7 @@ class ExpressionEvaluator {
   /// [expression] dart expression to evaluate.
   Future<RemoteObject> evaluateExpressionInFrame(String isolateId,
       int frameIndex, String expression, Map<String, String>? scope) async {
-    if (scope != null) {
+    if (scope != null && scope.isNotEmpty) {
       // TODO(annagrin): Implement scope support.
       // Issue: https://github.com/dart-lang/webdev/issues/1344
       return createError(

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -49,6 +49,11 @@ const isSentinelException = TypeMatcher<SentinelException>();
 final Matcher throwsRPCError = throwsA(isRPCError);
 final Matcher throwsSentinelException = throwsA(isSentinelException);
 
+Matcher isRPCErrorWithMessage(String message) =>
+    isA<RPCError>().having((e) => e.message, 'message', contains(message));
+Matcher throwsRPCErrorWithMessage(String message) =>
+    throwsA(isRPCErrorWithMessage(message));
+
 enum CompilationMode { buildDaemon, frontendServer }
 
 class TestContext {


### PR DESCRIPTION
Allow expression evaluation on a frame with an empty scope.

Closes: https://github.com/dart-lang/webdev/issues/1997