### PR TITLE
update publishing automation integration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 # This configures the .github/workflows/pull_request_label.yml workflow. 
 
-'infra':
+'type-infra':
   - '.github/**'
 
 'package:dwds':

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,16 +1,17 @@
 # A CI configuration to auto-publish pub packages.
 
-# name: Publish
+name: Publish
 
-# on:
-#   pull_request:
-#     branches: [ master ]
-#   push:
-#     tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
+on:
+  pull_request:
+    branches: [ master ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  push:
+    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 
-# jobs:
-#   publish:
-#     if: ${{ github.repository_owner == 'dart-lang' }}
-#     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
-#     with:
-#       sdk: dev
+jobs:
+  publish:
+    if: ${{ github.repository_owner == 'dart-lang' }}
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    with:
+      sdk: dev


### PR DESCRIPTION
- re-enable publishing automation, and update the config to listen for PR label changes (this will let us support the new `publish-ignore-warnings` label to suppress publish dry-run warnings)
- address https://github.com/dart-lang/webdev/issues/1995
- tweak the PR labeling workflow slightly (use `type-infra` instead of `infra`)
