### PR TITLE
Fix for listening to custom streams in DWDS.

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -707,7 +707,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
         default:
           throw RPCError(
             'streamListen',
-            RPCError.kMethodNotFound,
+            RPCError.kInvalidParams,
             'The stream `$streamId` is not supported on web devices',
           );
       }

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -2021,9 +2021,9 @@ void main() {
         await service.setVMName('test');
       });
 
-      test('custom stream', () async {
+      test('custom stream', () {
         expect(
-            () => service.streamListen('VM'),
+            () => service.streamListen('aCustomStreamId'),
             throwsA(predicate(
                 (e) => (e is RPCError) && e.code == RPCError.kInvalidParams)));
       });

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -2020,6 +2020,13 @@ void main() {
                 e.kind == EventKind.kVMUpdate && e.vm!.name == 'test')));
         await service.setVMName('test');
       });
+
+      test('custom stream', () async {
+        expect(
+            () => service.streamListen('VM'),
+            throwsA(predicate(
+                (e) => (e is RPCError) && e.code == RPCError.kInvalidParams)));
+      });
     });
 
     test('Logging', () async {


### PR DESCRIPTION
![](https://media.giphy.com/media/3o6Zt5Mb5U9AAYyrg4/giphy.gif)

Fixes https://github.com/Dart-Code/Dart-Code/issues/4414#issuecomment-1450374486

When listening to a stream, DDS does a streamListen on the VMService. If the VMService, doesn't recognize the stream it will respond with `kInvalidParams`. This lets DDS know that the stream is nonstandard, [so it can handle the events for that stream on it's own.](https://dart-review.googlesource.com/c/sdk/+/275121/4/pkg/dds/lib/src/stream_manager.dart#226)

This PR changes DWDS to behave like the VMService in this regard. Fixing this will allow us to streamListen on custom streams using DWDS.
