### PR TITLE
[MV3 Debug Extension] Fix authentication issue for the Dart Debug Extension

### DIFF
--- a/dwds/debug_extension_mv3/web/debug_session.dart
+++ b/dwds/debug_extension_mv3/web/debug_session.dart
@@ -563,7 +563,7 @@ Future<bool> _authenticateUser(int tabId) async {
     type: StorageObject.debugInfo,
     tabId: tabId,
   );
-  final authUrl = debugInfo?.authUrl;
+  final authUrl = debugInfo?.authUrl ?? _authUrl(debugInfo?.extensionUrl);
   if (authUrl == null) {
     await _showWarningNotification('Cannot authenticate user.');
     return false;
@@ -739,6 +739,19 @@ class _DebugSession {
     } catch (error) {
       debugError('Error closing batch controller: $error');
     }
+  }
+}
+
+String? _authUrl(String? extensionUrl) {
+  if (extensionUrl == null) return null;
+  final authUrl = Uri.parse(extensionUrl).replace(path: authenticationPath);
+  switch (authUrl.scheme) {
+    case 'ws':
+      return authUrl.replace(scheme: 'http').toString();
+    case 'wss':
+      return authUrl.replace(scheme: 'https').toString();
+    default:
+      return authUrl.toString();
   }
 }
 

--- a/dwds/test/puppeteer/fake_app/main.js
+++ b/dwds/test/puppeteer/fake_app/main.js
@@ -2,7 +2,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
     window['$dartEntrypointPath'] = 'DART_ENTRYPOINT_PATH';
     window['$dartAppId'] = 'DART_APP_ID';
     window['$dartAppInstanceId'] = 'DART_APP_INSTANCE_ID';
-    window['$dartExtensionUri'] = 'DART_EXTENSION_URI';
+    window['$dartExtensionUri'] = 'http://localhost:8080/extensionPath';
     window['$isInternalBuild'] = true;
     window['$isFlutterApp'] = false;
     setTimeout(() => {


### PR DESCRIPTION
Follow-up to https://github.com/dart-lang/webdev/issues/2025, fixes the underlying issue. 

Allows users on older versions of DWDS (`>18.0.0`) to still authenticate with the Dart Debug Extension. 