### PR TITLE
Update build_daemon constraint and log errors

### DIFF
--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
 dev_dependencies:
   args: ^2.3.1
   build: ^2.3.0
-  build_daemon: ^3.1.0
+  build_daemon: ^4.0.0
   build_runner: ^2.4.0
   build_version: ^2.1.1
   build_web_compilers: ^4.0.0

--- a/dwds/test/fixtures/server.dart
+++ b/dwds/test/fixtures/server.dart
@@ -97,6 +97,8 @@ class TestServer {
           return BuildResult((b) => b.status = BuildStatus.failed);
         case daemon.BuildStatus.succeeded:
           return BuildResult((b) => b.status = BuildStatus.succeeded);
+        default:
+          break;
       }
       throw StateError('Unexpected Daemon build result: $result');
     });

--- a/dwds/test/instances/record_inspection_test.dart
+++ b/dwds/test/instances/record_inspection_test.dart
@@ -394,5 +394,5 @@ Future<void> _runTests({
         expect(await getFields(instanceRef, offset: 0), {1: false, 2: 5});
       });
     });
-  });
+  }, skip: 'https://github.com/dart-lang/webdev/pull/2032');
 }

--- a/dwds/test/instances/record_inspection_test.dart
+++ b/dwds/test/instances/record_inspection_test.dart
@@ -394,5 +394,5 @@ Future<void> _runTests({
         expect(await getFields(instanceRef, offset: 0), {1: false, 2: 5});
       });
     });
-  }, skip: 'https://github.com/dart-lang/webdev/pull/2032');
+  }, skip: 'https://github.com/dart-lang/webdev/issues/2033');
 }

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.0.2-dev
 
+-  Update `build_daemon` constraint to `^4.0.0`.
+
 ## 3.0.1
 
 - Update SDK constraint to `>=3.0.0-188.0.dev <4.0.0`.

--- a/webdev/lib/src/command/daemon_command.dart
+++ b/webdev/lib/src/command/daemon_command.dart
@@ -15,6 +15,7 @@ import '../daemon/app_domain.dart';
 import '../daemon/daemon.dart';
 import '../daemon/daemon_domain.dart';
 import '../logging.dart';
+import '../pubspec.dart';
 import '../serve/dev_workflow.dart';
 import '../serve/utils.dart';
 import 'configuration.dart';
@@ -65,7 +66,13 @@ class DaemonCommand extends Command<int> {
             launchInChrome: true, debug: true, autoRun: false, release: false));
     configureLogWriter(configuration.verbose);
     // Validate the pubspec first to ensure we are in a Dart project.
-    var pubspecLock = await readPubspecLock(configuration);
+    PubspecLock? pubspecLock;
+    try {
+      pubspecLock = await readPubspecLock(configuration);
+    } on PackageException catch (e) {
+      logWriter(Level.SEVERE, 'Pubspec errors: ', error: '${e.details}');
+      rethrow;
+    }
 
     Daemon? daemon;
     DevWorkflow? workflow;

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -6,8 +6,10 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:logging/logging.dart';
 
 import '../logging.dart';
+import '../pubspec.dart';
 import '../serve/dev_workflow.dart';
 import 'configuration.dart';
 import 'shared.dart';
@@ -93,7 +95,13 @@ refresh: Performs a full page refresh.
     Configuration configuration;
     configuration = Configuration.fromArgs(argResults);
     configureLogWriter(configuration.verbose);
-    var pubspecLock = await readPubspecLock(configuration);
+    PubspecLock? pubspecLock;
+    try {
+      pubspecLock = await readPubspecLock(configuration);
+    } on PackageException catch (e) {
+      logWriter(Level.SEVERE, 'Pubspec errors: ', error: '${e.details}');
+      rethrow;
+    }
     // Forward remaining arguments as Build Options to the Daemon.
     // This isn't documented. Should it be advertised?
     var buildOptions = buildRunnerArgs(pubspecLock, configuration)

--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -48,6 +48,8 @@ class AppDomain extends Domain {
           'finished': true,
         });
         break;
+      default:
+        break;
     }
   }
 

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -126,7 +126,7 @@ class PubspecLock {
 
 Future<List<PackageExceptionDetails>> _validateBuildDaemonVersion(
     PubspecLock pubspecLock) async {
-  var buildDaemonConstraint = '>=2.0.0 <4.0.0';
+  var buildDaemonConstraint = '^4.0.0';
 
   var issues = <PackageExceptionDetails>[];
 

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -101,6 +101,8 @@ class WebDevServer {
           return BuildResult((b) => b.status = BuildStatus.failed);
         case daemon.BuildStatus.succeeded:
           return BuildResult((b) => b.status = BuildStatus.succeeded);
+        default:
+          break;
       }
       throw StateError('Unexpected Daemon build result: $result');
     });

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   args: ^2.3.1
   async: ^2.9.0
-  build_daemon: ^3.1.0
+  build_daemon: ^4.0.0
   browser_launcher: ^1.1.0
   collection: ^1.15.0
   crypto: ^3.0.2

--- a/webdev/test/chrome_test.dart
+++ b/webdev/test/chrome_test.dart
@@ -27,7 +27,8 @@ void main() {
       chrome!.chromeConnection.getUrl(_closeTabUrl(tab.id));
 
   Future<WipConnection> connectToTab(String url) async {
-    var tab = await chrome!.chromeConnection.getTab((t) => t.url.contains(url));
+    var tab = await chrome!.chromeConnection.getTab((t) => t.url.contains(url),
+        retryFor: const Duration(milliseconds: 60));
     expect(tab, isNotNull);
     return tab!.connect();
   }
@@ -78,7 +79,7 @@ void main() {
       } else {
         expect(result, contains('chrome_user_data'));
       }
-    });
+    }, skip: 'https://github.com/dart-lang/webdev/issues/2030');
   });
 
   group('chrome with user data dir', () {
@@ -152,7 +153,7 @@ void main() {
       } else {
         expect(result, contains('chrome_user_data_copy'));
       }
-    });
+    }, skip: 'https://github.com/dart-lang/webdev/issues/2030');
 
     test('can auto detect default chrome directory', () async {
       var userDataDir = autoDetectChromeUserDataDirectory();
@@ -170,7 +171,7 @@ void main() {
       expect(result, contains('chrome_user_data_copy'));
     }, onPlatform: {
       'windows': const Skip('https://github.com/dart-lang/webdev/issues/1545')
-    });
+    }, skip: 'https://github.com/dart-lang/webdev/issues/2030');
 
     test('cannot auto detect default chrome directory on windows', () async {
       var userDataDir = autoDetectChromeUserDataDirectory();

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -72,7 +72,7 @@ name: sample
   var invalidRanges = <String, List<String>>{
     'build_runner': ['0.8.9', '3.0.0'],
     'build_web_compilers': ['0.3.5', '5.0.0'],
-    'build_daemon': ['0.3.0', '4.0.0'],
+    'build_daemon': ['0.3.0', '5.0.0'],
   };
 
   for (var command in ['build', 'serve', 'daemon']) {
@@ -174,7 +174,7 @@ name: sample
                   break;
                 case 'build_daemon':
                   buildDaemonVersion = version;
-                  supportedRange = '>=$_supportedBuildDaemonVersion <4.0.0';
+                  supportedRange = '^$_supportedBuildDaemonVersion';
               }
 
               await d.file('pubspec.yaml', '''
@@ -278,7 +278,7 @@ dependencies:
 
 const _supportedBuildRunnerVersion = '2.4.0';
 const _supportedWebCompilersVersion = '4.0.0';
-const _supportedBuildDaemonVersion = '2.0.0';
+const _supportedBuildDaemonVersion = '4.0.0';
 
 String _pubspecLock(
     {String? runnerVersion = _supportedBuildRunnerVersion,


### PR DESCRIPTION
Update build_daemon constraint check to `^4.0.0` to match the latest build_runner constraint requirements.

Closes: https://github.com/dart-lang/webdev/issues/2028
Closes: https://github.com/dart-lang/webdev/issues/1939
Related: https://github.com/dart-lang/webdev/pull/2031 (disables broken chrome tests)
Related: https://github.com/dart-lang/webdev/issues/2033 (disables broken record tests)

**Details**

This is one is a part of 3 unrelated CI breaks:

- build runner constraint broken by build_daemon update (current)
  https://github.com/dart-lang/webdev/issues/2028  
  https://github.com/dart-lang/webdev/pull/2029 (current)

- record type matching broken by SDK update: 
  https://github.com/dart-lang/webdev/issues/2033
  https://github.com/dart-lang/webdev/pull/2032 

-  chrome tests broken by chromedriver update: 
  https://github.com/dart-lang/webdev/issues/2030
