### PR TITLE
Don't show non-instantiated variables

### DIFF
--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -67,6 +67,8 @@ Future<List<Property>> visibleProperties({
     if (value == null) return true;
 
     final type = value.type;
+    if (type == 'undefined') return true;
+
     final description = value.description ?? '';
     final name = property.name ?? '';
 

--- a/dwds/test/instances/patterns_inspection_test.dart
+++ b/dwds/test/instances/patterns_inspection_test.dart
@@ -156,6 +156,30 @@ Future<void> _runTests({
             previousLocation = location;
           }
         });
+
+        test('before instantiation of pattern-matching variables', () async {
+          await onBreakPoint('testPattern2Case1', (event) async {
+            final frame = event.topFrame!;
+
+            expect(await getFrameVariables(frame), {
+              'dog': matchPrimitiveInstance(kind: 'String', value: 'Prismo')
+            });
+          });
+        });
+
+        test('after instantiation of pattern-matching variables', () async {
+          await onBreakPoint('testPattern2Case2', (event) async {
+            final frame = event.topFrame!;
+
+            expect(await getFrameVariables(frame), {
+              'dog': matchPrimitiveInstance(kind: 'String', value: 'Prismo'),
+              'cats': matchListInstance(type: 'List<String>'),
+              'firstCat':
+                  matchPrimitiveInstance(kind: 'String', value: 'Garfield'),
+              'secondCat': matchPrimitiveInstance(kind: 'String', value: 'Tom'),
+            });
+          });
+        });
       });
     }, // TODO(annagrin): Remove when dart 3.0 is stable.
     skip: semver.Version.parse(Platform.version.split(' ')[0]) <

--- a/dwds/test/instances/patterns_inspection_test.dart
+++ b/dwds/test/instances/patterns_inspection_test.dart
@@ -162,8 +162,10 @@ Future<void> _runTests({
         await onBreakPoint('testPattern2Case1', (event) async {
           final frame = event.topFrame!;
 
-          expect(await getFrameVariables(frame),
-              {'dog': matchPrimitiveInstance(kind: 'String', value: 'Prismo')});
+          expect(
+            await getFrameVariables(frame),
+            {'dog': matchPrimitiveInstance(kind: 'String', value: 'Prismo')},
+          );
         });
       });
 

--- a/dwds/test/instances/patterns_inspection_test.dart
+++ b/dwds/test/instances/patterns_inspection_test.dart
@@ -156,28 +156,27 @@ Future<void> _runTests({
             previousLocation = location;
           }
         });
+      });
 
-        test('before instantiation of pattern-matching variables', () async {
-          await onBreakPoint('testPattern2Case1', (event) async {
-            final frame = event.topFrame!;
+      test('before instantiation of pattern-matching variables', () async {
+        await onBreakPoint('testPattern2Case1', (event) async {
+          final frame = event.topFrame!;
 
-            expect(await getFrameVariables(frame), {
-              'dog': matchPrimitiveInstance(kind: 'String', value: 'Prismo')
-            });
-          });
+          expect(await getFrameVariables(frame),
+              {'dog': matchPrimitiveInstance(kind: 'String', value: 'Prismo')});
         });
+      });
 
-        test('after instantiation of pattern-matching variables', () async {
-          await onBreakPoint('testPattern2Case2', (event) async {
-            final frame = event.topFrame!;
+      test('after instantiation of pattern-matching variables', () async {
+        await onBreakPoint('testPattern2Case2', (event) async {
+          final frame = event.topFrame!;
 
-            expect(await getFrameVariables(frame), {
-              'dog': matchPrimitiveInstance(kind: 'String', value: 'Prismo'),
-              'cats': matchListInstance(type: 'List<String>'),
-              'firstCat':
-                  matchPrimitiveInstance(kind: 'String', value: 'Garfield'),
-              'secondCat': matchPrimitiveInstance(kind: 'String', value: 'Tom'),
-            });
+          expect(await getFrameVariables(frame), {
+            'dog': matchPrimitiveInstance(kind: 'String', value: 'Prismo'),
+            'cats': matchListInstance(type: 'List<String>'),
+            'firstCat':
+                matchPrimitiveInstance(kind: 'String', value: 'Garfield'),
+            'secondCat': matchPrimitiveInstance(kind: 'String', value: 'Tom'),
           });
         });
       });

--- a/fixtures/_experimentSound/web/main.dart
+++ b/fixtures/_experimentSound/web/main.dart
@@ -19,6 +19,7 @@ void main() {
     testPattern(['a', 1]);
     testPattern([3.14, 'b']);
     testPattern([0, 1]);
+    testPattern2();
   });
 
   document.body!.appendText('Program is running!');
@@ -63,4 +64,12 @@ String testPattern(Object obj) {
     default:
       return 'default'; // Breakpoint: testPatternDefault
   }
+}
+
+String testPattern2() {
+  final dog = 'Prismo'; 
+  final cats = ['Garfield', 'Tom']; // Breakpoint: testPattern2Case1
+  final [firstCat, secondCat] = cats;
+  print(firstCat); // Breakpoint: testPattern2Case2
+  return '$dog, $firstCat, $secondCat';
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/2060
Work towards https://github.com/dart-lang/webdev/issues/2056

See screenshots below:

### When paused at:

![Screenshot 2023-03-30 at 12 50 34 PM](https://user-images.githubusercontent.com/21270878/228948740-56e945ff-f8e1-4d6b-a006-15280ce69d68.png)

### With this change:

![Screenshot 2023-03-30 at 12 50 42 PM](https://user-images.githubusercontent.com/21270878/228948759-a592acb7-2682-4810-aacd-c088fda7410b.png)

-  `name` is not shown (this matches the behavior of `vm_service`)
- `count` is `null` (as expected)
- `first` and `second` are not shown (as expected)

### Without this change:

![Screenshot 2023-03-30 at 12 55 03 PM](https://user-images.githubusercontent.com/21270878/228949655-21a83b7e-2cf9-4517-ba0e-f40e90809728.png)
 
-  `name` is shown and is `null` (does not match `vm_service` implementation!)
- `first` and `second` are shown as `null` (not expected!)

