### PR TITLE
Update the release script to take into account `pubspec_overrides.yaml`

### DIFF
--- a/tool/release.dart
+++ b/tool/release.dart
@@ -192,12 +192,13 @@ void _updateOverrides(
   String package, {
   required bool includeOverrides,
 }) {
-  final pubspecOverrides = File('../$package/pubspec_overrides.yaml');
-  final newLines = <String>[];
-  for (final line in pubspecOverrides.readAsLinesSync()) {
-    newLines.add(includeOverrides ? _uncomment(line) : _commentOut(line));
+  final overridesFilePath = '../$package/pubspec_overrides.yaml';
+  final noOverridesFilePath = '../$package/ignore_pubspec_overrides.yaml';
+  if (includeOverrides) {
+    File(noOverridesFilePath).rename(overridesFilePath);
+  } else {
+    File(overridesFilePath).rename(noOverridesFilePath);
   }
-  return pubspecOverrides.writeAsStringSync(newLines.joinWithNewLine());
 }
 
 void _updateVersionStrings(
@@ -217,36 +218,6 @@ void _updateVersionStrings(
       _replaceInFile(file, query: currentVersion, replaceWith: nextVersion);
     }
   }
-}
-
-String _uncomment(String line) {
-  if (_isEmptyLine(line)) return line;
-
-  if (!_isCommentedOut(line)) {
-    _logWarning('$line is not commented out.');
-    return line;
-  }
-
-  return line.substring(2);
-}
-
-String _commentOut(String line) {
-  if (_isEmptyLine(line)) return line;
-
-  if (_isCommentedOut(line)) {
-    _logWarning('$line is already commented out.');
-    return line;
-  }
-
-  return '# $line';
-}
-
-bool _isCommentedOut(String line) {
-  return line.startsWith('# ');
-}
-
-bool _isEmptyLine(String line) {
-  return line.trim().isEmpty;
 }
 
 void _addNewLine(

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -129,7 +129,7 @@ Future<int> runRelease({
     _logInfo('Updating pinned version of DWDS.');
     await _updateDwdsPin('webdev');
     await _updateDwdsPin('test_common');
-  // Remove the dependency overrides of DWDS for webdev releases:
+    // Remove the dependency overrides of DWDS for webdev releases:
     _logInfo('Removing dependency overrides of DWDS.');
     _updateOverrides('webdev', includeOverrides: false);
     _updateOverrides('test_common', includeOverrides: false);


### PR DESCRIPTION
A script to automate most of the manual steps of releasing `webdev` / `dwds` was recently added:
* https://github.com/dart-lang/webdev/pull/2049

As were `pubspec_override.yaml` files (this was so we wouldn't have to comment-out our dependency overrides when publishing):
* https://github.com/dart-lang/webdev/pull/2048

Reading through comments on https://github.com/dart-lang/pub/pull/3782, it seems `pubspec_overrides` **are** used during publishing. 

Therefore, this PR updates our release script to comment out the overrides when publishing, and un-comment them when resetting the packages after publishing.
 


