### PR TITLE
Switch `EvaluationErrorKind` from class to enum 

### DIFF
--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -491,7 +491,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
       // and reference errors from JavaScript evaluation in chrome.
       final evaluationError = EvaluationErrorKind.fromString(result.type);
       if (evaluationError != null) {
-        if (_hasReportableEvaluationError(evaluationError)) {
+        if (evaluationError.isReportable()) {
           _logger.warning('Failed to evaluate expression \'$expression\': '
               '${result.type}: ${result.value}.');
 
@@ -518,16 +518,6 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
       _logger.info('$e:$s');
       return ErrorRef(kind: 'error', message: '<unknown>', id: createId());
     }
-  }
-
-  // Decides if the error is serious enough to be shown to the user
-  // to encourage bug reporting.
-  bool _hasReportableEvaluationError(EvaluationErrorKind error) {
-    final ignorableErrors = [
-      EvaluationErrorKind.compilation,
-      EvaluationErrorKind.asyncFrame,
-    ];
-    return !ignorableErrors.contains(error);
   }
 
   @override

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -489,7 +489,6 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
       // Handle compilation errors, internal errors,
       // and reference errors from JavaScript evaluation in chrome.
-
       if (_hasReportableEvaluationError(result.type)) {
         _logger.warning('Failed to evaluate expression \'$expression\': '
             '${result.type}: ${result.value}.');

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -497,12 +497,13 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
         _logger.info('Please follow instructions at '
             'https://github.com/dart-lang/webdev/issues/956 '
             'to file a bug.');
+
+        return ErrorRef(
+          kind: 'error',
+          message: '${result.type}: ${result.value}',
+          id: createId(),
+        );
       }
-      return ErrorRef(
-        kind: 'error',
-        message: '${result.type}: ${result.value}',
-        id: createId(),
-      );
       return (await _instanceRef(result));
     } on RPCError catch (_) {
       rethrow;

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -489,14 +489,16 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
       // Handle compilation errors, internal errors,
       // and reference errors from JavaScript evaluation in chrome.
-      if (_hasReportableEvaluationError(result.type)) {
-        _logger.warning('Failed to evaluate expression \'$expression\': '
-            '${result.type}: ${result.value}.');
+      final evaluationError = EvaluationErrorKind.fromString(result.type);
+      if (evaluationError != null) {
+        if (_hasReportableEvaluationError(evaluationError)) {
+          _logger.warning('Failed to evaluate expression \'$expression\': '
+              '${result.type}: ${result.value}.');
 
-        _logger.info('Please follow instructions at '
-            'https://github.com/dart-lang/webdev/issues/956 '
-            'to file a bug.');
-
+          _logger.info('Please follow instructions at '
+              'https://github.cm/dart-lang/webdev/issues/956 '
+              'to file a bug.');
+        }
         return ErrorRef(
           kind: 'error',
           message: '${result.type}: ${result.value}',
@@ -520,15 +522,12 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
   // Decides if the error is serious enough to be shown to the user
   // to encourage bug reporting.
-  bool _hasReportableEvaluationError(String type) {
-    final evaluationError = EvaluationErrorKind.fromString(type);
-    if (evaluationError == null) return false;
-
-    if (evaluationError == EvaluationErrorKind.compilation ||
-        evaluationError == EvaluationErrorKind.asyncFrame) {
-      return false;
-    }
-    return true;
+  bool _hasReportableEvaluationError(EvaluationErrorKind error) {
+    final ignorableErrors = [
+      EvaluationErrorKind.compilation,
+      EvaluationErrorKind.asyncFrame,
+    ];
+    return !ignorableErrors.contains(error);
   }
 
   @override

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -496,7 +496,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
               '${result.type}: ${result.value}.');
 
           _logger.info('Please follow instructions at '
-              'https://github.cm/dart-lang/webdev/issues/956 '
+              'https://github.com/dart-lang/webdev/issues/956 '
               'to file a bug.');
         }
         return ErrorRef(

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -489,21 +489,20 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
 
       // Handle compilation errors, internal errors,
       // and reference errors from JavaScript evaluation in chrome.
-      if (_hasEvaluationError(result.type)) {
-        if (_hasReportableEvaluationError(result.type)) {
-          _logger.warning('Failed to evaluate expression \'$expression\': '
-              '${result.type}: ${result.value}.');
 
-          _logger.info('Please follow instructions at '
-              'https://github.com/dart-lang/webdev/issues/956 '
-              'to file a bug.');
-        }
-        return ErrorRef(
-          kind: 'error',
-          message: '${result.type}: ${result.value}',
-          id: createId(),
-        );
+      if (_hasReportableEvaluationError(result.type)) {
+        _logger.warning('Failed to evaluate expression \'$expression\': '
+            '${result.type}: ${result.value}.');
+
+        _logger.info('Please follow instructions at '
+            'https://github.com/dart-lang/webdev/issues/956 '
+            'to file a bug.');
       }
+      return ErrorRef(
+        kind: 'error',
+        message: '${result.type}: ${result.value}',
+        id: createId(),
+      );
       return (await _instanceRef(result));
     } on RPCError catch (_) {
       rethrow;
@@ -519,15 +518,14 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
     }
   }
 
-  bool _hasEvaluationError(String type) => type.contains('Error');
-
   // Decides if the error is serious enough to be shown to the user
   // to encourage bug reporting.
   bool _hasReportableEvaluationError(String type) {
-    if (!_hasEvaluationError(type)) return false;
+    final evaluationError = EvaluationErrorKind.fromString(type);
+    if (evaluationError == null) return false;
 
-    if (type == EvaluationErrorKind.compilation ||
-        type == EvaluationErrorKind.asyncFrame) {
+    if (evaluationError == EvaluationErrorKind.compilation ||
+        evaluationError == EvaluationErrorKind.asyncFrame) {
       return false;
     }
     return true;

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -24,6 +24,12 @@ enum EvaluationErrorKind {
 
   static final _nameMap = EvaluationErrorKind.values.asNameMap();
 
+  /// The following errors are not serious enough to be shown to the user:
+  static final _ignorableErrors = {
+    EvaluationErrorKind.asyncFrame,
+    EvaluationErrorKind.compilation,
+  };
+
   static EvaluationErrorKind? fromString(String value) {
     final kind = value.split('.').last;
     return _nameMap[kind];
@@ -31,6 +37,10 @@ enum EvaluationErrorKind {
 
   @override
   String toString() => 'EvaluationError.$name';
+
+  // Determines whether the error is serious enough to be shown to the user to
+  // encourage bug reporting.
+  bool isReportable() => !_ignorableErrors.contains(this);
 }
 
 /// ExpressionEvaluator provides functionality to evaluate dart expressions

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -13,16 +13,24 @@ import 'package:dwds/src/utilities/objects.dart' as chrome;
 import 'package:logging/logging.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-class EvaluationErrorKind {
-  EvaluationErrorKind._();
+enum EvaluationErrorKind {
+  compilation,
+  type,
+  reference,
+  internal,
+  asyncFrame,
+  invalidInput,
+  loadModule;
 
-  static const compilation = 'CompilationError';
-  static const type = 'TypeError';
-  static const reference = 'ReferenceError';
-  static const internal = 'InternalError';
-  static const asyncFrame = 'AsyncFrameError';
-  static const invalidInput = 'InvalidInputError';
-  static const loadModule = 'LoadModuleError';
+  static final _nameMap = EvaluationErrorKind.values.asNameMap();
+
+  static EvaluationErrorKind? fromString(String value) {
+    final kind = value.split('.').last;
+    return _nameMap[kind];
+  }
+
+  @override
+  String toString() => 'EvaluationError.$name';
 }
 
 /// ExpressionEvaluator provides functionality to evaluate dart expressions
@@ -59,12 +67,10 @@ class ExpressionEvaluator {
     this._compiler,
   );
 
-  /// Create and error with [severity] and [message]
-  ///
-  /// [severity] is one of kinds in [EvaluationErrorKind]
-  RemoteObject createError(String severity, String message) {
+  /// Create an error with [kind] and [message]
+  RemoteObject createError(EvaluationErrorKind kind, String message) {
     return RemoteObject(
-      <String, String>{'type': severity, 'value': message},
+      <String, String>{'type': '$kind', 'value': message},
     );
   }
 

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -6,7 +6,6 @@
 @Timeout(Duration(minutes: 2))
 import 'dart:async';
 
-import 'package:dwds/src/services/expression_evaluator.dart';
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -705,7 +705,7 @@ void testAll({
               isA<ErrorRef>().having(
                 (instance) => instance.message,
                 'message',
-                contains(EvaluationErrorKind.compilation),
+                contains(EvaluationErrorKind.compilation.toString()),
               ),
             );
           });
@@ -762,7 +762,7 @@ void testAll({
             isA<ErrorRef>().having(
               (instance) => instance.message,
               'message',
-              contains(EvaluationErrorKind.asyncFrame),
+              contains(EvaluationErrorKind.asyncFrame.toString()),
             ),
           );
 
@@ -793,7 +793,7 @@ void testAll({
                 isA<ErrorRef>().having(
                   (instance) => instance.message,
                   'message',
-                  contains(EvaluationErrorKind.loadModule),
+                  contains(EvaluationErrorKind.loadModule.toString()),
                 ),
               );
             });

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -705,7 +705,7 @@ void testAll({
               isA<ErrorRef>().having(
                 (instance) => instance.message,
                 'message',
-                contains(EvaluationErrorKind.compilation.toString()),
+                contains('EvaluationError.compilation'),
               ),
             );
           });
@@ -762,7 +762,7 @@ void testAll({
             isA<ErrorRef>().having(
               (instance) => instance.message,
               'message',
-              contains(EvaluationErrorKind.asyncFrame.toString()),
+              contains('EvaluationError.asyncFrame'),
             ),
           );
 
@@ -793,7 +793,7 @@ void testAll({
                 isA<ErrorRef>().having(
                   (instance) => instance.message,
                   'message',
-                  contains(EvaluationErrorKind.loadModule.toString()),
+                  contains('EvaluationError.loadModule'),
                 ),
               );
             });

--- a/dwds/test/expression_evaluator_test.dart
+++ b/dwds/test/expression_evaluator_test.dart
@@ -133,7 +133,8 @@ void main() async {
         expect(
           result,
           isA<RemoteObject>()
-              .having((o) => o.json['type'], 'type', 'AsyncFrameError')
+              .having(
+                  (o) => o.json['type'], 'type', 'EvaluationError.asyncFrame',)
               .having(
                 (o) => o.json['value'],
                 'value',
@@ -162,7 +163,7 @@ void main() async {
         expect(
           result,
           const TypeMatcher<RemoteObject>()
-              .having((o) => o.type, 'type', 'InternalError')
+              .having((o) => o.type, 'type', 'EvaluationError.internal')
               .having(
                 (o) => o.value,
                 'value',
@@ -180,7 +181,7 @@ void main() async {
         expect(
           result,
           const TypeMatcher<RemoteObject>()
-              .having((o) => o.type, 'type', 'InternalError')
+              .having((o) => o.type, 'type', 'EvaluationError.internal')
               .having((o) => o.value, 'value', contains('evaluator closed')),
         );
       });
@@ -210,7 +211,7 @@ void main() async {
         expect(
           result,
           const TypeMatcher<RemoteObject>()
-              .having((o) => o.type, 'type', 'InternalError')
+              .having((o) => o.type, 'type', 'EvaluationError.internal')
               .having((o) => o.value, 'value', contains('evaluator closed')),
         );
       });

--- a/dwds/test/expression_evaluator_test.dart
+++ b/dwds/test/expression_evaluator_test.dart
@@ -134,7 +134,10 @@ void main() async {
           result,
           isA<RemoteObject>()
               .having(
-                  (o) => o.json['type'], 'type', 'EvaluationError.asyncFrame',)
+                (o) => o.json['type'],
+                'type',
+                'EvaluationError.asyncFrame',
+              )
               .having(
                 (o) => o.json['value'],
                 'value',


### PR DESCRIPTION
This means logging will now show "EvaluationError.compilation: some error message" instead of "CompilationError: some error message". Happy to change it a bit more if we want the string in format "CompilationError" specifically.