### PR TITLE
Run `chrome_proxy_service_test.dart` everyday at 8 AM PST

### DIFF
--- a/.github/workflows/daily_testing.yml
+++ b/.github/workflows/daily_testing.yml
@@ -1,0 +1,35 @@
+# A CI workflow to run tests on a daily cron job.
+
+name: Daily Testing
+
+on:
+  pull_request
+
+jobs:
+  daily_testing:
+    name: Daily Testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+      - id: dwds_pub_upgrade
+        name: dwds; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: dwds
+      - id: dwds_daily_tests
+        name: "dwds; dart test --tags=daily"
+        run: "dart test --tags=daily"
+        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
+        working-directory: dwds
+      - name: "Notify failure"
+        if: "always() && steps.dwds_daily_tests.conclusion == 'failure'"
+        run: |
+          curl -H "Content-Type: application/json" -X POST -d \
+            "{'text':'Testing chat webhook, disregard! @elliottbrooks ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
+            "${{ secrets.BUILD_AND_TEST_TEAM_CHAT_WEBHOOK_URL }}"

--- a/.github/workflows/daily_testing.yml
+++ b/.github/workflows/daily_testing.yml
@@ -33,4 +33,4 @@ jobs:
         run: |
           curl -H "Content-Type: application/json" -X POST -d \
             "{'text':'Daily Webdev tests failed! ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
-            "${{ secrets.BUILD_AND_TEST_TEAM_CHAT_WEBHOOK_URL }}"
+            "${{ secrets.WEBDEV_NOTIFICATION_CHAT_WEBHOOK }}"

--- a/.github/workflows/daily_testing.yml
+++ b/.github/workflows/daily_testing.yml
@@ -3,7 +3,8 @@
 name: Daily Testing
 
 on:
-  pull_request
+  schedule:
+    - cron: '00 14 * * *' # Everyday at 3:00 PM UTC (8:00 AM PST)
 
 jobs:
   daily_testing:
@@ -31,5 +32,5 @@ jobs:
         if: "always() && steps.dwds_daily_tests.conclusion == 'failure'"
         run: |
           curl -H "Content-Type: application/json" -X POST -d \
-            "{'text':'Testing chat webhook, disregard! @${{ secrets.REPO_OWNER}} ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
+            "{'text':'Daily Webdev tests failed! ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
             "${{ secrets.BUILD_AND_TEST_TEAM_CHAT_WEBHOOK_URL }}"

--- a/.github/workflows/daily_testing.yml
+++ b/.github/workflows/daily_testing.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
-          sdk: dev
+          sdk: main
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3

--- a/.github/workflows/daily_testing.yml
+++ b/.github/workflows/daily_testing.yml
@@ -31,5 +31,5 @@ jobs:
         if: "always() && steps.dwds_daily_tests.conclusion == 'failure'"
         run: |
           curl -H "Content-Type: application/json" -X POST -d \
-            "{'text':'Testing chat webhook, disregard! @elliottbrooks ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
+            "{'text':'Testing chat webhook, disregard! @${{ secrets.REPO_OWNER}} ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
             "${{ secrets.BUILD_AND_TEST_TEAM_CHAT_WEBHOOK_URL }}"

--- a/dwds/dart_test.yaml
+++ b/dwds/dart_test.yaml
@@ -3,3 +3,4 @@ retry: 3
 
 tags:
   extension:  # Extension tests require configuration, so we may exclude.
+  daily: # Daily tests also run on a scheduled daily cron job.

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Tags(['daily'])
 @Timeout(Duration(minutes: 2))
 import 'dart:async';
 import 'dart:convert';
@@ -82,7 +83,7 @@ void main() {
         expect(firstBp.id, equals(secondBp.id));
 
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id!, firstBp.id!);
+        await service.removeBreakpoint(isolate.id!, 'notAnId');
       });
 
       test('addBreakpoint succeeds when sending the same breakpoint twice',

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -83,7 +83,7 @@ void main() {
         expect(firstBp.id, equals(secondBp.id));
 
         // Remove breakpoint so it doesn't impact other tests.
-        await service.removeBreakpoint(isolate.id!, 'notAnId');
+        await service.removeBreakpoint(isolate.id!, firstBp.id!);
       });
 
       test('addBreakpoint succeeds when sending the same breakpoint twice',


### PR DESCRIPTION
Final step in https://github.com/dart-lang/webdev/issues/2093 (besides updating documentation)

- Adds a Github workflow to run any DWDS tests tagged `daily` everyday at 8 AM PST
- Currently the only test is `chrome_proxy_service_test`, which will catch any breakages to DWDS from the VM Service