### PR TITLE
Try to fix dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "dart.yaml"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     schedule:
       interval: monthly
     ignore:
-      - dependency-name: "dart.yaml"
+      - dependency-name: "workflows/dart.yaml"


### PR DESCRIPTION
The dependabot PRs update the `dart.yaml` file, which is generated by `mono_repo generate`.  That means for every dependabot PR, the `mono_repo validate` step fails (`dart.yaml` no longer matches what it would be if it were generated).

See https://github.com/dart-lang/webdev/pull/2104 for example

Therefore the dependabot PRs should not update the `dart.yaml` file. 
