### PR TITLE
Manually update dependencies 

### DIFF
--- a/.github/workflows/changelog_reminder.yml
+++ b/.github/workflows/changelog_reminder.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repositiory
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Check changed files
         run: |
           git fetch origin master

--- a/.github/workflows/daily_testing.yml
+++ b/.github/workflows/daily_testing.yml
@@ -17,7 +17,7 @@ jobs:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade

--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -28,7 +28,7 @@ jobs:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade

--- a/.github/workflows/release_reminder.yml
+++ b/.github/workflows/release_reminder.yml
@@ -18,7 +18,7 @@ jobs:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Run proper release test
         run:  dart test test/proper_release_test.dart
         working-directory: test_common


### PR DESCRIPTION
Copies the changes over from https://github.com/dart-lang/webdev/pull/2104, but excludes `dart.yaml` updates. 

See https://github.com/dart-lang/webdev/pull/2112 for the reasoning