### PR TITLE
Disable tests using webdriver

### DIFF
--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -57,4 +57,4 @@ dev_dependencies:
   test: ^1.21.1
   test_common:
     path: ../test_common
-  webdriver: ^3.0.2
+  webdriver: ^3.0.0

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -57,4 +57,4 @@ dev_dependencies:
   test: ^1.21.1
   test_common:
     path: ../test_common
-  webdriver: ^3.0.0
+  webdriver: ^3.0.2

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -8,6 +8,7 @@
 @Timeout(Duration(minutes: 2))
 @OnPlatform({
   'windows': Skip('https://github.com/dart-lang/webdev/issues/711'),
+  'linux': Skip('https://github.com/dart-lang/webdev/issues/2114'),
 })
 
 import 'package:dwds/src/connections/debug_connection.dart';

--- a/dwds/test/devtools_test.dart
+++ b/dwds/test/devtools_test.dart
@@ -184,7 +184,7 @@ void main() {
       // extension tests on Windows.
     },
     tags: ['extension'],
-    skip: Platform.isWindows,
+    skip: 'https://github.com/dart-lang/webdev/issues/2114',
   );
 }
 


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/2114

The extension tests are testing the old extension anyways, I need to update to using the puppeteer tests anyways (see https://github.com/dart-lang/webdev/pull/2100). 