### PR TITLE
Dart Debug Extension builder fix

### DIFF
--- a/dwds/debug_extension_mv3/build.yaml
+++ b/dwds/debug_extension_mv3/build.yaml
@@ -13,7 +13,7 @@ targets:
       
 builders:
   client_js_copy_builder:
-    required_inputs: [".js",".png", ".html", ".css", ".json"]
+    required_inputs: [".js", ".png", ".html", ".css", ".json"]
     import: "tool/copy_builder.dart"
     builder_factories:
         - copyBuilder

--- a/dwds/debug_extension_mv3/build.yaml
+++ b/dwds/debug_extension_mv3/build.yaml
@@ -13,6 +13,7 @@ targets:
       
 builders:
   client_js_copy_builder:
+    required_inputs: [".js",".png", ".html", ".css", ".json"]
     import: "tool/copy_builder.dart"
     builder_factories:
         - copyBuilder


### PR DESCRIPTION
Actual fix for the broken Dart Debug Extension builder based on the comment in https://github.com/dart-lang/webdev/pull/2116#issuecomment-1546435028

