### PR TITLE
Check for new events more often in batched stream.

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Refactor code for presenting record instances. - [#2074](https://github.com/dart-lang/webdev/pull/2074)
 - Display record types concisely. - [#2070](https://github.com/dart-lang/webdev/pull/2070)
 - Display type objects concisely. - [#2103](https://github.com/dart-lang/webdev/pull/2103)
+- Check for new events more often in batched stream. - [#2123](https://github.com/dart-lang/webdev/pull/2123)
 
 ## 19.0.0
 

--- a/dwds/lib/shared/batched_stream.dart
+++ b/dwds/lib/shared/batched_stream.dart
@@ -3,14 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math';
 import 'package:async/async.dart';
 import 'package:dwds/src/utilities/shared.dart';
 
 /// Stream controller allowing to batch events.
 class BatchedStreamController<T> {
   static const _defaultBatchDelayMilliseconds = 1000;
-  static const _checkDelayMilliseconds = 100;
 
+  final int _checkDelayMilliseconds;
   final int _batchDelayMilliseconds;
 
   final StreamController<T> _inputController;
@@ -26,6 +27,7 @@ class BatchedStreamController<T> {
   BatchedStreamController({
     int delay = _defaultBatchDelayMilliseconds,
   })  : _batchDelayMilliseconds = delay,
+        _checkDelayMilliseconds = max(delay ~/ 10, 1),
         _inputController = StreamController<T>(),
         _outputController = StreamController<List<T>>() {
     _inputQueue = StreamQueue<T>(_inputController.stream);
@@ -46,7 +48,7 @@ class BatchedStreamController<T> {
 
   /// Send events to the output in a batch every [_batchDelayMilliseconds].
   Future<void> _batchAndSendEvents() async {
-    const duration = Duration(milliseconds: _checkDelayMilliseconds);
+    final duration = Duration(milliseconds: _checkDelayMilliseconds);
     final buffer = <T>[];
 
     // Batch events every `_batchDelayMilliseconds`.


### PR DESCRIPTION
I noticed in my expression evaluation experiments that changing the delay in batched stream to 100ms from 200ms does not always change how often the batches are emitted, due to waiting time for the next event being  greater than the delay.

Fix that by making the duration we use for waiting for a new event a fraction of the batch delay.

Not adding tests since the behavior is not supposed to change, only the timing.