### PR TITLE
Include `requested-by = DWDS` header in ProxyServerAssetReader

### DIFF
--- a/dwds/lib/src/readers/proxy_server_asset_reader.dart
+++ b/dwds/lib/src/readers/proxy_server_asset_reader.dart
@@ -49,8 +49,9 @@ class ProxyServerAssetReader implements AssetReader {
   Future<String?> _readResource(String path) async {
     // Handlers expect a fully formed HTML URI. The actual hostname and port
     // does not matter.
-    final response =
-        await _handler(Request('GET', Uri.parse('http://foo:0000/$path')));
+    final request = Request('GET', Uri.parse('http://foo:0000/$path'))
+        .change(headers: {'requested-by': 'DWDS'});
+    final response = await _handler(request);
 
     if (response.statusCode != HttpStatus.ok) {
       _logger.warning('''


### PR DESCRIPTION
Fixes b/284033857 when combined with cl/537127416 

Notifies the code runner that a request has come from DWDS instead of from Chrome.