### PR TITLE
Remove tabs permission for the Dart Debug Extension

### DIFF
--- a/dwds/debug_extension_mv3/web/manifest_mv2.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv2.json
@@ -13,7 +13,6 @@
     "debugger",
     "notifications",
     "storage",
-    "tabs",
     "webNavigation"
   ],
   "background": {

--- a/dwds/debug_extension_mv3/web/manifest_mv3.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv3.json
@@ -14,7 +14,6 @@
     "notifications",
     "scripting",
     "storage",
-    "tabs",
     "webNavigation"
   ],
   "host_permissions": ["<all_urls>"],


### PR DESCRIPTION
From Chrome extension documentation (https://developer.chrome.com/docs/extensions/reference/tabs/#perms):

>The "tabs" permission
> This permission does not give access to the chrome.tabs namespace. Instead, it grants an extension the ability to call [tabs.query()](https://developer.chrome.com/docs/extensions/reference/tabs/#method-query) against four sensitive properties on [tabs.Tab](https://developer.chrome.com/docs/extensions/reference/tabs/#type-Tab) instances: url, pendingUrl, title, and favIconUrl.

Therefore we don't need the permission since we are not calling `tabs.query` against any of those properties.
