### PR TITLE
Don't run proper_release_test with the rest of the test common tests

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.5.7
+# Created with package:mono_repo v6.5.3
 name: Dart CI
 on:
   push:
@@ -37,7 +37,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.5.7
+        run: dart pub global activate mono_repo 6.5.3
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
@@ -382,7 +382,7 @@ jobs:
       - job_003
       - job_004
   job_010:
-    name: "unit_test; linux; Dart dev; PKG: test_common; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test`"
+    name: "unit_test; linux; Dart dev; PKG: test_common; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test --exclude-tags=release`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -411,8 +411,8 @@ jobs:
         run: "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &"
         if: "always() && steps.test_common_pub_upgrade.conclusion == 'success'"
         working-directory: test_common
-      - name: test_common; dart test
-        run: dart test
+      - name: "test_common; dart test --exclude-tags=release"
+        run: "dart test --exclude-tags=release"
         if: "always() && steps.test_common_pub_upgrade.conclusion == 'success'"
         working-directory: test_common
     needs:
@@ -639,7 +639,7 @@ jobs:
       - job_003
       - job_004
   job_017:
-    name: "unit_test; linux; Dart main; PKG: test_common; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test`"
+    name: "unit_test; linux; Dart main; PKG: test_common; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test --exclude-tags=release`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -668,8 +668,8 @@ jobs:
         run: "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &"
         if: "always() && steps.test_common_pub_upgrade.conclusion == 'success'"
         working-directory: test_common
-      - name: test_common; dart test
-        run: dart test
+      - name: "test_common; dart test --exclude-tags=release"
+        run: "dart test --exclude-tags=release"
         if: "always() && steps.test_common_pub_upgrade.conclusion == 'success'"
         working-directory: test_common
     needs:
@@ -867,7 +867,7 @@ jobs:
       - job_003
       - job_004
   job_025:
-    name: "unit_test; windows; Dart dev; PKG: test_common; `dart test`"
+    name: "unit_test; windows; Dart dev; PKG: test_common; `dart test --exclude-tags=release`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
@@ -882,8 +882,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: test_common
-      - name: test_common; dart test
-        run: dart test
+      - name: "test_common; dart test --exclude-tags=release"
+        run: "dart test --exclude-tags=release"
         if: "always() && steps.test_common_pub_upgrade.conclusion == 'success'"
         working-directory: test_common
     needs:
@@ -1042,7 +1042,7 @@ jobs:
       - job_003
       - job_004
   job_032:
-    name: "unit_test; windows; Dart main; PKG: test_common; `dart test`"
+    name: "unit_test; windows; Dart main; PKG: test_common; `dart test --exclude-tags=release`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
@@ -1057,8 +1057,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: test_common
-      - name: test_common; dart test
-        run: dart test
+      - name: "test_common; dart test --exclude-tags=release"
+        run: "dart test --exclude-tags=release"
         if: "always() && steps.test_common_pub_upgrade.conclusion == 'success'"
         working-directory: test_common
     needs:

--- a/.github/workflows/release_reminder.yml
+++ b/.github/workflows/release_reminder.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-reminder:
-    if: ${{ !contains(github.event.*.labels.*.name, 'release-prep') }}
+    if: ${{ !contains(github.event.*.labels.*.name, 'prepare-release') }}
     name: Maybe prevent submission
     runs-on: ubuntu-latest
     steps:
@@ -20,5 +20,5 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Run proper release test
-        run:  dart test test/proper_release_test.dart
+        run: dart test test/proper_release_test.dart
         working-directory: test_common

--- a/dwds/debug_extension/tool/update_dev_files.dart
+++ b/dwds/debug_extension/tool/update_dev_files.dart
@@ -38,7 +38,7 @@ Future<void> _updateManifestJson() async {
           oldLine: line,
           newKey: 'default_icon',
           newValue: 'dart_dev.png',
-        )
+        ),
       ];
     }
     if (_matchesValue(line: line, value: 'background.js')) {
@@ -47,7 +47,7 @@ Future<void> _updateManifestJson() async {
           oldLine: line,
           newKey: null,
           newValue: 'background.dart.js',
-        )
+        ),
       ];
     } else {
       return [line];

--- a/dwds/debug_extension_mv3/tool/update_dev_files.dart
+++ b/dwds/debug_extension_mv3/tool/update_dev_files.dart
@@ -36,7 +36,7 @@ Future<void> _updateManifestJson() async {
           oldLine: line,
           newKey: 'default_icon',
           newValue: 'static_assets/dart_dev.png',
-        )
+        ),
       ];
     } else {
       return [line];

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -20,7 +20,7 @@ class ClassHelper extends Domain {
     final staticClasses = [
       classRefForClosure,
       classRefForString,
-      classRefForUnknown
+      classRefForUnknown,
     ];
     for (var classRef in staticClasses) {
       final classId = classRef.id;

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -583,7 +583,7 @@ class Debugger extends Domain {
               'skipList': _skipLists.compute(
                 scriptId,
                 await _locations.locationsForUrl(url),
-              )
+              ),
             },
           );
           return;

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -536,7 +536,7 @@ class AppInspector implements AppInspectorInterface {
     // breakpoints. This is because the token positions are derived from the
     // DDC source maps which Chrome also uses.
     final tokenPositions = <int>[
-      for (var location in mappedLocations) location.tokenPos
+      for (var location in mappedLocations) location.tokenPos,
     ];
     tokenPositions.sort();
 
@@ -721,7 +721,7 @@ class AppInspector implements AppInspectorInterface {
         final parts = scripts[uri];
         final scriptRefs = [
           ScriptRef(uri: uri, id: createId()),
-          for (var part in parts ?? []) ScriptRef(uri: part, id: createId())
+          for (var part in parts ?? []) ScriptRef(uri: part, id: createId()),
         ];
         final libraryRef = await _libraryHelper.libraryRefFor(uri);
         final libraryId = libraryRef?.id;

--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -479,7 +479,7 @@ class InstanceHelper extends Domain {
       for (var i = positionalOffset + 1;
           i <= positionalOffset + positionalRangeCount;
           i++)
-        i
+        i,
     ];
 
     // Collect named fields in the requested range.

--- a/dwds/lib/src/debugging/location.dart
+++ b/dwds/lib/src/debugging/location.dart
@@ -276,8 +276,8 @@ class Locations {
         lineNumber,
         for (var location in locations) ...[
           location.tokenPos,
-          location.dartLocation.column
-        ]
+          location.dartLocation.column,
+        ],
       ]);
     }
     _sourceToTokenPosTable[serverPath] = tokenPosTable;

--- a/dwds/lib/src/debugging/metadata/function.dart
+++ b/dwds/lib/src/debugging/metadata/function.dart
@@ -29,7 +29,7 @@ class FunctionMetaData {
       }
     ''';
     final arguments = [
-      {'objectId': remoteObject.objectId}
+      {'objectId': remoteObject.objectId},
     ];
     final response = await remoteDebugger.sendCommand(
       'Runtime.callFunctionOn',

--- a/dwds/lib/src/debugging/metadata/module_metadata.dart
+++ b/dwds/lib/src/debugging/metadata/module_metadata.dart
@@ -83,7 +83,7 @@ class LibraryMetadata {
     return {
       'name': name,
       'importUri': importUri,
-      'partUris': [...partUris]
+      'partUris': [...partUris],
     };
   }
 }
@@ -174,7 +174,7 @@ class ModuleMetadata {
       'sourceMapUri': sourceMapUri,
       'moduleUri': moduleUri,
       'libraries': [for (var lib in libraries.values) lib.toJson()],
-      'soundNullSafety': soundNullSafety
+      'soundNullSafety': soundNullSafety,
     };
   }
 }

--- a/dwds/lib/src/debugging/skip_list.dart
+++ b/dwds/lib/src/debugging/skip_list.dart
@@ -65,6 +65,6 @@ class SkipLists {
       {
         'scriptId': scriptId,
         'start': {'lineNumber': startLine, 'columnNumber': startColumn},
-        'end': {'lineNumber': endLine, 'columnNumber': endColumn}
+        'end': {'lineNumber': endLine, 'columnNumber': endColumn},
       };
 }

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -87,9 +87,9 @@ class DwdsVmClient {
               <String, Object>{
                 'id': isolate.id,
                 'isolate': isolate.toJson(),
-              }
+              },
           ],
-        }
+        },
       };
     });
     await client.registerService('_flutter.listViews', 'DWDS');
@@ -231,7 +231,7 @@ Future<Map<String, dynamic>> _hotRestart(
       'error': {
         'code': RPCErrorKind.kInternalError.code,
         'message': e.message,
-      }
+      },
     };
   }
   // Start listening for isolate create events before issuing a hot
@@ -255,7 +255,7 @@ Future<Map<String, dynamic>> _hotRestart(
           'code': code,
           'message': message,
           'data': exception,
-        }
+        },
       };
     }
   } on ChromeDebugException catch (exception) {
@@ -264,7 +264,7 @@ Future<Map<String, dynamic>> _hotRestart(
       'error': {
         'code': RPCErrorKind.kInternalError.code,
         'message': '$exception',
-      }
+      },
     };
   }
   _logger.info('Waiting for Isolate Start event.');

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -71,7 +71,7 @@ class DwdsInjector {
             return Response.ok(
               result,
               headers: {
-                HttpHeaders.contentTypeHeader: 'application/javascript'
+                HttpHeaders.contentTypeHeader: 'application/javascript',
               },
             );
           } else if (request.url.path.endsWith(bootstrapJsExtension)) {

--- a/dwds/lib/src/servers/extension_backend.dart
+++ b/dwds/lib/src/servers/extension_backend.dart
@@ -51,7 +51,7 @@ class ExtensionBackend {
           headers: {
             if (request.headers.containsKey('origin'))
               'Access-Control-Allow-Origin': request.headers['origin']!,
-            'Access-Control-Allow-Credentials': 'true'
+            'Access-Control-Allow-Credentials': 'true',
           },
         );
       }

--- a/dwds/lib/src/servers/extension_debugger.dart
+++ b/dwds/lib/src/servers/extension_debugger.dart
@@ -76,7 +76,7 @@ class ExtensionDebugger implements RemoteDebugger {
         if (message is ExtensionResponse) {
           final encodedResult = {
             'result': json.decode(message.result),
-            'id': message.id
+            'id': message.id,
           };
           final completer = _completers[message.id];
           if (completer == null) {
@@ -88,7 +88,7 @@ class ExtensionDebugger implements RemoteDebugger {
         } else if (message is ExtensionEvent) {
           final map = {
             'method': json.decode(message.method),
-            'params': json.decode(message.params)
+            'params': json.decode(message.params),
           };
           // Note: package:sse will try to keep the connection alive, even after
           // the client has been closed. Therefore the extension sends an event to
@@ -104,7 +104,7 @@ class ExtensionDebugger implements RemoteDebugger {
           for (var event in message.events) {
             final map = {
               'method': json.decode(event.method),
-              'params': json.decode(event.params)
+              'params': json.decode(event.params),
             };
             _notificationController.sink.add(WipEvent(map));
           }

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -1487,7 +1487,7 @@ ${globalLoadStrategy.loadModuleSnippet}("dart_sdk").developer.invokeExtension(
           protocolName: 'VM Service',
           major: version.major,
           minor: version.minor,
-        )
+        ),
       ],
     );
   }

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -134,9 +134,9 @@ class _Compiler {
           {
             'path': modules[moduleName]!.fullDillPath,
             'summaryPath': modules[moduleName]!.summaryPath,
-            'moduleName': moduleName
+            'moduleName': moduleName,
           },
-      ]
+      ],
     });
     final result = (response['succeeded'] as bool?) ?? false;
     if (result) {

--- a/dwds/lib/src/services/javascript_builder.dart
+++ b/dwds/lib/src/services/javascript_builder.dart
@@ -242,7 +242,7 @@ class JsBuilder {
     final args = params.where((e) => e != original);
     final substitutedParams = [
       ...params.where((e) => e != original),
-      substitute
+      substitute,
     ];
 
     writeFunctionDefinition(

--- a/dwds/test/build_daemon_callstack_test.dart
+++ b/dwds/test/build_daemon_callstack_test.dart
@@ -131,7 +131,7 @@ void main() {
                     breakpoints[i].script,
                     breakpoints[i].function,
                     lines[i],
-                  )
+                  ),
               ];
               expect(stack.frames, containsAll(expected));
 

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -190,7 +190,7 @@ void main() async {
             'callFrames': [
               {'callFrameId': '', 'functionName': ''},
             ],
-          }
+          },
         }),
       );
       expect(

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -126,7 +126,7 @@ void main() {
           emitsThrough(
             matchesEvent(DwdsEventKind.compilerUpdateDependencies, {
               'entrypoint': 'hello_world/main.dart.bootstrap.js',
-              'elapsedMilliseconds': isNotNull
+              'elapsedMilliseconds': isNotNull,
             }),
           ),
         );

--- a/dwds/test/expression_evaluator_test.dart
+++ b/dwds/test/expression_evaluator_test.dart
@@ -121,7 +121,7 @@ void main() async {
             'params': {
               'reason': 'other',
               'callFrames': [],
-            }
+            },
           }),
         );
 

--- a/dwds/test/extension_debugger_test.dart
+++ b/dwds/test/extension_debugger_test.dart
@@ -35,7 +35,7 @@ void main() async {
       final extensionResponse = ExtensionResponse(
         (b) => b
           ..result = jsonEncode({
-            'result': {'value': 3.14}
+            'result': {'value': 3.14},
           })
           ..id = 0
           ..success = true,
@@ -119,7 +119,7 @@ void main() async {
 
     test('a request with some params', () async {
       final params = {
-        'location': {'scriptId': '555', 'lineNumber': 28}
+        'location': {'scriptId': '555', 'lineNumber': 28},
       };
       final extensionRequest = ExtensionRequest(
         (b) => b
@@ -170,7 +170,7 @@ void main() async {
       callToSendCommand() => extensionDebugger.sendCommand(
             'Debugger.setBreakpoint',
             params: {
-              'location': {'scriptId': '555', 'lineNumber': 28}
+              'location': {'scriptId': '555', 'lineNumber': 28},
             },
           );
       // Should not throw any errors:

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -355,9 +355,9 @@ class TestContext {
                 'remote-debugging-port=$debugPort',
                 if (enableDebugExtension)
                   '--load-extension=debug_extension/prod_build',
-                if (headless) '--headless'
-              ]
-            }
+                if (headless) '--headless',
+              ],
+            },
           });
         _webDriver = await createDriver(
           spec: WebDriverSpec.JsonWire,

--- a/dwds/test/fixtures/debugger_data.dart
+++ b/dwds/test/fixtures/debugger_data.dart
@@ -20,7 +20,7 @@ List<Map<String, dynamic>> frames1Json = [
     "functionLocation": {
       "scriptId": "69",
       "lineNumber": 88,
-      "columnNumber": 72
+      "columnNumber": 72,
     },
     "location": {"scriptId": "69", "lineNumber": 37, "columnNumber": 0},
     "url": "http://127.0.0.1:8081/foo.ddc.js",
@@ -31,14 +31,14 @@ List<Map<String, dynamic>> frames1Json = [
           "type": "object",
           "className": "Object",
           "description": "Object",
-          "objectId": "{\"injectedScriptId\":2,\"id\":3}"
+          "objectId": "{\"injectedScriptId\":2,\"id\":3}",
         },
         "startLocation": {
           "scriptId": "69",
           "lineNumber": 88,
-          "columnNumber": 72
+          "columnNumber": 72,
         },
-        "endLocation": {"scriptId": "69", "lineNumber": 93, "columnNumber": 7}
+        "endLocation": {"scriptId": "69", "lineNumber": 93, "columnNumber": 7},
       },
       {
         "type": "closure",
@@ -46,15 +46,15 @@ List<Map<String, dynamic>> frames1Json = [
           "type": "object",
           "className": "Object",
           "description": "Object",
-          "objectId": "{\"injectedScriptId\":2,\"id\":4}"
+          "objectId": "{\"injectedScriptId\":2,\"id\":4}",
         },
         "name": "main",
         "startLocation": {
           "scriptId": "69",
           "lineNumber": 74,
-          "columnNumber": 48
+          "columnNumber": 48,
         },
-        "endLocation": {"scriptId": "69", "lineNumber": 100, "columnNumber": 5}
+        "endLocation": {"scriptId": "69", "lineNumber": 100, "columnNumber": 5},
       },
       {
         "type": "closure",
@@ -63,14 +63,14 @@ List<Map<String, dynamic>> frames1Json = [
           "type": "object",
           "className": "Object",
           "description": "Object",
-          "objectId": "{\"injectedScriptId\":2,\"id\":5}"
+          "objectId": "{\"injectedScriptId\":2,\"id\":5}",
         },
         "startLocation": {
           "scriptId": "69",
           "lineNumber": 0,
-          "columnNumber": 29
+          "columnNumber": 29,
         },
-        "endLocation": {"scriptId": "69", "lineNumber": 126, "columnNumber": 1}
+        "endLocation": {"scriptId": "69", "lineNumber": 126, "columnNumber": 1},
       },
       {
         "type": "global",
@@ -78,8 +78,8 @@ List<Map<String, dynamic>> frames1Json = [
           "type": "object",
           "className": "Window",
           "description": "Window",
-          "objectId": "{\"injectedScriptId\":2,\"id\":6}"
-        }
+          "objectId": "{\"injectedScriptId\":2,\"id\":6}",
+        },
       }
     ],
     "this": {"type": "undefined"},
@@ -93,7 +93,7 @@ List<Map<String, dynamic>> frames1Json = [
 var variables1 = [
   WipResponse({
     'id': 1,
-    'result': {'result': []}
+    'result': {'result': []},
   }),
   WipResponse({
     'id': 2,
@@ -101,18 +101,18 @@ var variables1 = [
       'result': [
         {
           'name': 'a',
-          'value': {'type': 'string', 'value': 'foo'}
+          'value': {'type': 'string', 'value': 'foo'},
         },
         {
           'name': 'b',
-          'value': {'type': 'string', 'value': 'bar'}
+          'value': {'type': 'string', 'value': 'bar'},
         }
-      ]
-    }
+      ],
+    },
   }),
   WipResponse({
     'id': 3,
-    'result': {'result': []}
+    'result': {'result': []},
   }),
   // Fake that the SDK is loaded.
   WipResponse({
@@ -120,17 +120,17 @@ var variables1 = [
     'result': {
       'result': [
         {'name': 'dart', 'value': null},
-        {'name': 'core', 'value': null}
-      ]
-    }
+        {'name': 'core', 'value': null},
+      ],
+    },
   }),
   WipResponse({
     'id': 5,
-    'result': {'result': []}
+    'result': {'result': []},
   }),
   WipResponse({
     'id': 6,
-    'result': {'result': []}
+    'result': {'result': []},
   }),
 ];
 
@@ -141,7 +141,7 @@ var scriptParsedParams = {
   "executionContextAuxData": {
     "frameId": "75DC0B9DAB420DD67036D4560E614998",
     "isDefault": true,
-    "type": "default"
+    "type": "default",
   },
   "executionContextId": 7,
   "hasSourceURL": false,
@@ -153,5 +153,5 @@ var scriptParsedParams = {
   "sourceMapURL": "main.ddc.js.map",
   "startColumn": 0,
   "startLine": 0,
-  "url": "http://localhost:8080/main.ddc.js"
+  "url": "http://localhost:8080/main.ddc.js",
 };

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -444,5 +444,5 @@ class FakeExpressionCompiler implements ExpressionCompiler {
 
 final fakeWipResponse = WipResponse({
   'id': 1,
-  'result': {'fake': ''}
+  'result': {'fake': ''},
 });

--- a/dwds/test/frontend_server_callstack_test.dart
+++ b/dwds/test/frontend_server_callstack_test.dart
@@ -128,7 +128,7 @@ void main() {
                   breakpoints[i].script,
                   breakpoints[i].function,
                   lines[i],
-                )
+                ),
             ];
             expect(stack.frames, containsAll(expected));
 

--- a/dwds/test/handlers/injector_test.dart
+++ b/dwds/test/handlers/injector_test.dart
@@ -133,7 +133,7 @@ void main() {
         injector.devHandlerPaths,
         emitsInOrder([
           'http://localhost:${server.port}/foo/\$dwdsSseHandler',
-          'http://localhost:${server.port}/blah/\$dwdsSseHandler'
+          'http://localhost:${server.port}/blah/\$dwdsSseHandler',
         ]),
       );
     });
@@ -367,7 +367,7 @@ void main() {
         injector.devHandlerPaths,
         emitsInOrder([
           'ws://localhost:${server.port}/foo/\$dwdsSseHandler',
-          'ws://localhost:${server.port}/blah/\$dwdsSseHandler'
+          'ws://localhost:${server.port}/blah/\$dwdsSseHandler',
         ]),
       );
     });

--- a/dwds/test/instances/instance_inspection_common.dart
+++ b/dwds/test/instances/instance_inspection_common.dart
@@ -146,7 +146,7 @@ class TestInspector {
   ) async {
     final refs = <String, InstanceRef>{
       for (var variable in frame.vars!)
-        variable.name!: variable.value as InstanceRef
+        variable.name!: variable.value as InstanceRef,
     };
     final instances = <String, Instance>{};
     for (final p in refs.entries) {

--- a/dwds/test/instances/record_inspection_test.dart
+++ b/dwds/test/instances/record_inspection_test.dart
@@ -264,24 +264,24 @@ Future<void> _runTests({
         expect(await getFields(instanceRef), {
           1: true,
           2: 3,
-          3: {'a': 1, 'b': 5}
+          3: {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 0), {
           1: true,
           2: 3,
-          3: {'a': 1, 'b': 5}
+          3: {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 1), {
           2: 3,
-          3: {'a': 1, 'b': 5}
+          3: {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 1, count: 1), {2: 3});
         expect(await getFields(instanceRef, offset: 1, count: 2), {
           2: 3,
-          3: {'a': 1, 'b': 5}
+          3: {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 2), {
-          3: {'a': 1, 'b': 5}
+          3: {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 3), {});
         expect(await getFields(instanceRef, offset: 0, count: 0), {});
@@ -293,7 +293,7 @@ Future<void> _runTests({
         expect(await getFields(instanceRef, offset: 0, count: 5), {
           1: true,
           2: 3,
-          3: {'a': 1, 'b': 5}
+          3: {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 3, count: 5), {});
       });
@@ -352,24 +352,24 @@ Future<void> _runTests({
         expect(await getFields(instanceRef), {
           1: true,
           2: 3,
-          'array': {'a': 1, 'b': 5}
+          'array': {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 0), {
           1: true,
           2: 3,
-          'array': {'a': 1, 'b': 5}
+          'array': {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 1), {
           2: 3,
-          'array': {'a': 1, 'b': 5}
+          'array': {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 1, count: 1), {2: 3});
         expect(await getFields(instanceRef, offset: 1, count: 2), {
           2: 3,
-          'array': {'a': 1, 'b': 5}
+          'array': {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 2), {
-          'array': {'a': 1, 'b': 5}
+          'array': {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 3), {});
         expect(await getFields(instanceRef, offset: 0, count: 0), {});
@@ -381,7 +381,7 @@ Future<void> _runTests({
         expect(await getFields(instanceRef, offset: 0, count: 5), {
           1: true,
           2: 3,
-          'array': {'a': 1, 'b': 5}
+          'array': {'a': 1, 'b': 5},
         });
         expect(await getFields(instanceRef, offset: 3, count: 5), {});
       });
@@ -439,25 +439,25 @@ Future<void> _runTests({
 
         expect(await getFields(instanceRef), {
           1: true,
-          2: {1: false, 2: 5}
+          2: {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 0), {
           1: true,
-          2: {1: false, 2: 5}
+          2: {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 1), {
-          2: {1: false, 2: 5}
+          2: {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 2), {});
         expect(await getFields(instanceRef, offset: 0, count: 0), {});
         expect(await getFields(instanceRef, offset: 0, count: 1), {1: true});
         expect(await getFields(instanceRef, offset: 0, count: 2), {
           1: true,
-          2: {1: false, 2: 5}
+          2: {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 0, count: 5), {
           1: true,
-          2: {1: false, 2: 5}
+          2: {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 2, count: 5), {});
       });
@@ -510,31 +510,31 @@ Future<void> _runTests({
 
         expect(await getFields(instanceRef), {
           1: true,
-          'inner': {1: false, 2: 5}
+          'inner': {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 0), {
           1: true,
-          'inner': {1: false, 2: 5}
+          'inner': {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 1), {
-          'inner': {1: false, 2: 5}
+          'inner': {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 1, count: 1), {
-          'inner': {1: false, 2: 5}
+          'inner': {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 1, count: 2), {
-          'inner': {1: false, 2: 5}
+          'inner': {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 2), {});
         expect(await getFields(instanceRef, offset: 0, count: 0), {});
         expect(await getFields(instanceRef, offset: 0, count: 1), {1: true});
         expect(await getFields(instanceRef, offset: 0, count: 2), {
           1: true,
-          'inner': {1: false, 2: 5}
+          'inner': {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 0, count: 5), {
           1: true,
-          'inner': {1: false, 2: 5}
+          'inner': {1: false, 2: 5},
         });
         expect(await getFields(instanceRef, offset: 2, count: 5), {});
       });

--- a/dwds/test/listviews_test.dart
+++ b/dwds/test/listviews_test.dart
@@ -38,7 +38,7 @@ void main() {
             <String, Object?>{
               'id': isolate.id,
               'isolate': isolate.toJson(),
-            }
+            },
         ],
       };
 

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -86,9 +86,9 @@ void main() {
         {
           'name': 'main',
           'importUri': 'org-dartlang-app:///web/main.dart',
-          'partUris': ['org-dartlang-app:///web/main.dart']
+          'partUris': ['org-dartlang-app:///web/main.dart'],
         }
-      ]
+      ],
     };
 
     final metadata = ModuleMetadata.fromJson(json);

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -190,7 +190,7 @@ void main() {
           'localThatsNull',
           'nestedFunction',
           'parameter',
-          'testClass'
+          'testClass',
         ]),
       );
     });

--- a/dwds/tool/copy_builder.dart
+++ b/dwds/tool/copy_builder.dart
@@ -11,7 +11,7 @@ Builder copyBuilder(_) => _CopyBuilder();
 class _CopyBuilder extends Builder {
   @override
   Map<String, List<String>> get buildExtensions => {
-        _clientJsId.path: [_clientJsCopyId.path]
+        _clientJsId.path: [_clientJsCopyId.path],
       };
 
   @override

--- a/dwds/web/reloader/legacy_restarter.dart
+++ b/dwds/web/reloader/legacy_restarter.dart
@@ -16,7 +16,7 @@ class LegacyRestarter implements Restarter {
       dartLibrary.callMethod('reload');
     } else {
       dartLibrary.callMethod('reload', [
-        JsObject.jsify({'runId': runId})
+        JsObject.jsify({'runId': runId}),
       ]);
     }
     final reloadCompleter = Completer<bool>();

--- a/test_common/dart_test.yaml
+++ b/test_common/dart_test.yaml
@@ -1,3 +1,7 @@
 concurrency: 1
 retry: 3
 
+tags:
+  # The release tests are only run from the release_reminder.yml workflow.
+  # This allows them to be skipped with the `prepare-release` label.
+  release:

--- a/test_common/mono_pkg.yaml
+++ b/test_common/mono_pkg.yaml
@@ -1,27 +1,27 @@
 # See https://pub.dev/packages/mono_repo for details
 stages:
   - analyzer_and_format:
-    - group:
-      - format
-      - analyze: --fatal-infos .
-      sdk: dev
+      - group:
+          - format
+          - analyze: --fatal-infos .
+        sdk: dev
   - unit_test:
-    # Linux tests:
-    # Note: `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &` must be
-    # run first for Linux.
-    - group:
-      - command: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-      - test:
-      sdk:
-        - dev
-        - main
-      os:
-        - linux
-     # Windows tests:
-    - group:
-      - test:
-      sdk:
-        - dev
-        - main
-      os:
-        - windows
+      # Linux tests:
+      # Note: `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &` must be
+      # run first for Linux.
+      - group:
+          - command: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          - test: --exclude-tags=release
+        sdk:
+          - dev
+          - main
+        os:
+          - linux
+        # Windows tests:
+      - group:
+          - test: --exclude-tags=release
+        sdk:
+          - dev
+          - main
+        os:
+          - windows

--- a/test_common/test/proper_release_test.dart
+++ b/test_common/test/proper_release_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Tags(['release'])
 import 'dart:io';
 
 import 'package:path/path.dart' as p;

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.5.7
+# Created with package:mono_repo v6.5.3
 
 # Support built in commands on windows out of the box.
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
@@ -108,8 +108,8 @@ for PKG in ${PKGS}; do
         dart test -j 1 || EXIT_CODE=$?
         ;;
       test_6)
-        echo 'dart test'
-        dart test || EXIT_CODE=$?
+        echo 'dart test --exclude-tags=release'
+        dart test --exclude-tags=release || EXIT_CODE=$?
         ;;
       test_7)
         echo 'dart test test/build/ensure_build_test.dart'


### PR DESCRIPTION
The proper release test is run to verify that the proper release procedures are being followed for DWDS and Webdev: https://github.com/dart-lang/webdev/blob/master/test_common/test/proper_release_test.dart

It checks that:
- the current version has been released 
- the current version gets reset to be a `-wip` version

This test fails for PRs that prepare DWDS for the next release. In those cases, we use the `prepare-release` github label to tell github CI to now run the test. Therefore, we should only be running the test from the [release_reminder](https://github.com/dart-lang/webdev/blob/master/.github/workflows/release_reminder.yml) workflow, and not as part of the `test_common` unit tests.



 
