### PR TITLE
Use `github.event.pull_request.head.sha` as PR reference in DCM workflow

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -30,7 +30,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
-          ref: "${{ github.event.pull_request.sha }}"
+          ref: "${{ github.event.pull_request.head.sha }}"
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade


### PR DESCRIPTION
Follow up to https://github.com/dart-lang/webdev/pull/2135

Currently the DCM workflow is running against the last commit on the master branch, not on the PR branch

From reading https://github.com/orgs/community/discussions/25191#discussioncomment-3246770, I believe github.event.pull_request.head.sha is what we want.
