### PR TITLE
Fix the Puppeteer tests for the Debug Extension

### DIFF
--- a/dwds/.gitignore
+++ b/dwds/.gitignore
@@ -1,1 +1,2 @@
 .local-chromium
+.local-chrome

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -52,7 +52,7 @@ dev_dependencies:
   js: ^0.6.4
   lints: ^2.0.0
   pubspec_parse: ^1.2.0
-  puppeteer: ^2.19.0
+  puppeteer: ^3.0.0
   stream_channel: ^2.1.0
   test: ^1.21.1
   test_common:

--- a/dwds/test/puppeteer/extension_test.dart
+++ b/dwds/test/puppeteer/extension_test.dart
@@ -184,7 +184,7 @@ void main() async {
             // Navigate to the Dart app:
             final appTab =
                 await navigateToPage(browser, url: appUrl, isNew: true);
-            var appWindowId = await _getCurrentWindowId(
+            final appWindowId = await _getCurrentWindowId(
               worker: worker,
               backgroundPage: backgroundPage,
             );


### PR DESCRIPTION
We recently removed the `tabs` permission for the debug extension: https://github.com/dart-lang/webdev/pull/2136

This is because we weren't using the permission in the extension itself, however we were using it in the tests. 

This PR:
- refactors the tests so that we don't require the `tabs` permission
- updates to the newest version of puppeteer

Work towards https://github.com/dart-lang/webdev/issues/1787