### PR TITLE
Dart Debug Extension: don't forward events to Chrome that will cause a crash

### DIFF
--- a/dwds/debug_extension_mv3/pubspec.yaml
+++ b/dwds/debug_extension_mv3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mv3_extension
 publish_to: none
-version: 1.34.0
+version: 1.35.0
 homepage: https://github.com/dart-lang/webdev
 description: >-
   A Chrome extension for Dart debugging.

--- a/dwds/debug_extension_mv3/web/chrome_api.dart
+++ b/dwds/debug_extension_mv3/web/chrome_api.dart
@@ -134,6 +134,16 @@ class Notifications {
     NotificationOptions options,
     Function? callback,
   );
+
+  external OnClickedHandler get onClicked;
+}
+
+@JS()
+@anonymous
+class OnClickedHandler {
+  external void addListener(
+    void Function(String) callback,
+  );
 }
 
 @JS()

--- a/dwds/debug_extension_mv3/web/debug_session.dart
+++ b/dwds/debug_extension_mv3/web/debug_session.dart
@@ -485,11 +485,8 @@ bool _shouldSkipEventForChrome115Bug(String command) {
   if (unsupportedOnChrome115) {
     final chromeVersionMatch =
         RegExp('Chrome/([0-9.]+)').firstMatch(window.navigator.userAgent);
-    final chromeVersion =
-        chromeVersionMatch == null ? '' : chromeVersionMatch[0];
-    if (chromeVersion?.startsWith('Chrome/115') ?? false) {
-      return true;
-    }
+    final chromeVersion = chromeVersionMatch?[0];
+    return chromeVersion?.startsWith('Chrome/115') ?? false;
   }
   return false;
 }

--- a/dwds/debug_extension_mv3/web/debug_session.dart
+++ b/dwds/debug_extension_mv3/web/debug_session.dart
@@ -7,6 +7,7 @@ library debug_session;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:html';
 
 import 'package:built_collection/built_collection.dart';
 import 'package:collection/collection.dart' show IterableExtension;
@@ -42,6 +43,9 @@ const _devToolsAlreadyOpenedAlert =
 
 final _debugSessions = <_DebugSession>[];
 final _tabIdToTrigger = <int, Trigger>{};
+
+// TODO(elliette): Remove once regression is fixed in Chrome.
+const _chrome115Error = 'chrome115Error';
 
 enum DetachReason {
   canceledByUser,
@@ -114,6 +118,8 @@ Future<void> attachDebugger(
 
   _tabIdToTrigger[dartAppTabId] = trigger;
   _registerDebugEventListeners();
+  // TODO(elliette): Remove once regression is fixed in Chrome.
+  _registerChrome115NotificationListeners();
   chrome.debugger.attach(
     Debuggee(tabId: dartAppTabId),
     '1.3',
@@ -424,6 +430,13 @@ void _forwardDwdsEventToChromeDebugger(
     final params = messageParams == null
         ? <String, Object>{}
         : BuiltMap<String, Object>(json.decode(messageParams)).toMap();
+
+    // TODO(elliette): Remove once regression is fixed in Chrome.
+    if (_shouldSkipEventForChrome115Bug(message.command)) {
+      _showChrome115ErrorNotification(message.command, tabId);
+      return;
+    }
+
     chrome.debugger.sendCommand(
       Debuggee(tabId: tabId),
       message.command,
@@ -464,6 +477,55 @@ void _forwardDwdsEventToChromeDebugger(
       'Error forwarding ${message.command} with ${message.commandParams} to chrome.debugger: $error',
     );
   }
+}
+
+bool _shouldSkipEventForChrome115Bug(String command) {
+  final unsupportedOnChrome115 = command.contains('Debugger.setBreakpoint') ||
+      command.contains('Debugger.pause');
+  if (unsupportedOnChrome115) {
+    final chromeVersionMatch =
+        RegExp('Chrome/([0-9.]+)').firstMatch(window.navigator.userAgent);
+    final chromeVersion =
+        chromeVersionMatch == null ? '' : chromeVersionMatch[0];
+    if (chromeVersion?.startsWith('Chrome/115') ?? false) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void _showChrome115ErrorNotification(String command, int tabId) {
+  chrome.notifications.create(
+    // notificationId
+    '$_chrome115Error-$tabId',
+    NotificationOptions(
+      title: '[Error] Dart Debug Extension',
+      message:
+          'Regression in Chrome 115 prevents $command. Click here for more details.',
+      iconUrl: 'static_assets/dart.png',
+      type: 'basic',
+    ),
+    // callback
+    null,
+  );
+}
+
+void _registerChrome115NotificationListeners() {
+  chrome.notifications.onClicked.addListener(
+    allowInterop((notificationId) async {
+      if (notificationId.startsWith(_chrome115Error)) {
+        final tabId = notificationId.split('-')[1];
+        final debugInfo = await fetchStorageObject<DebugInfo>(
+          type: StorageObject.debugInfo,
+          tabId: int.parse(tabId),
+        );
+        final bugLink = debugInfo?.isInternalBuild ?? false
+            ? 'https://bugs.chromium.org/p/chromium/issues/detail?id=1469092'
+            : 'https://github.com/Dart-Code/Dart-Code/issues/4664';
+        await createTab(bugLink);
+      }
+    }),
+  );
 }
 
 void _forwardChromeDebuggerEventToDwds(

--- a/dwds/debug_extension_mv3/web/manifest_mv2.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv2.json
@@ -1,6 +1,6 @@
 {
   "name": "Dart Debug Extension",
-  "version": "1.34",
+  "version": "1.35",
   "manifest_version": 2,
   "devtools_page": "static_assets/devtools.html",
   "browser_action": {
@@ -9,12 +9,7 @@
   "externally_connectable": {
     "ids": ["nbkbficgbembimioedhceniahniffgpl"]
   },
-  "permissions": [
-    "debugger",
-    "notifications",
-    "storage",
-    "webNavigation"
-  ],
+  "permissions": ["debugger", "notifications", "storage", "webNavigation"],
   "background": {
     "scripts": ["background.dart.js"]
   },

--- a/dwds/debug_extension_mv3/web/manifest_mv3.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv3.json
@@ -1,6 +1,6 @@
 {
   "name": "Dart Debug Extension",
-  "version": "1.34",
+  "version": "1.35",
   "manifest_version": 3,
   "devtools_page": "static_assets/devtools.html",
   "action": {


### PR DESCRIPTION
See details in https://bugs.chromium.org/p/chromium/issues/detail?id=1469092

This PR skips forwarding events that will cause a crash to Chrome, and instead displays a warning to the user:

<img width="381" alt="Screenshot 2023-08-02 at 3 18 05 PM" src="https://github.com/dart-lang/webdev/assets/21270878/991b18a8-bd3e-46e3-90b7-b29256916882">

FYI @DanTup 
