### PR TITLE
Re-enable `events_test` with fix

### DIFF
--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -684,6 +684,7 @@ class DevHandler {
       scheme: 'http',
       host: devTools.hostname,
       port: devTools.port,
+      path: 'debugger',
       queryParameters: {
         'uri': debugServiceUri,
         if (ideQueryParam.isNotEmpty) 'ide': ideQueryParam,

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -160,7 +160,6 @@ void main() {
             () => keyboard.sendChord([Keyboard.alt, 'd']),
           );
         },
-        skip: 'https://github.com/dart-lang/webdev/issues/2181',
       );
 
       test('emits DEVTOOLS_LAUNCH event', () async {


### PR DESCRIPTION
The `events_test` was disabled in https://github.com/dart-lang/webdev/pull/2182

Now that the Chromedriver regression has been resolved (https://bugs.chromium.org/p/chromium/issues/detail?id=1466427), I was able to figure out what was going wrong.

The latest DevTools release has added a new "home" screen (see screenshot below). For web apps, we want to auto-open the debugger panel instead, which is where the `DEBUGGER_READY` and `DEVTOOLS_LOAD` events get emitted. 

![Screenshot 2023-08-09 at 3 47 45 PM](https://github.com/dart-lang/webdev/assets/21270878/85349da1-6cb8-4894-bba9-493871385f9f)
