### PR TITLE
Prepare DWDS for release to version 20.0.1

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 20.0.1
+
+- Update file dependency to `>=6.0.0 < 8.0.0` - [#123260](https://github.com/flutter/flutter/pull/123260#issuecomment-1674001623).
+
 ## 20.0.0
 
 - Require clients to specify the `basePath` on `AssetReader`. - [#2160](https://github.com/dart-lang/webdev/pull/2160)

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '20.0.0';
+const packageVersion = '20.0.1';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 20.0.0
+version: 20.0.1
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM
   service protocol.
@@ -15,7 +15,7 @@ dependencies:
   collection: ^1.15.0
   crypto: ^3.0.2
   dds: ^2.7.1
-  file: ^7.0.0
+  file: ">=6.0.0 <8.0.0"
   http: ^0.13.4
   http_multi_server: ^3.2.0
   logging: ^1.0.2


### PR DESCRIPTION
Resolve version compatibility issues with `package:file` so that DWDS can be updated in `flutter_tools`. 

See https://github.com/flutter/flutter/pull/123260#issuecomment-1674001623