### PR TITLE
Update README.md to use `dart pub` instead of `pub`

### DIFF
--- a/webdev/README.md
+++ b/webdev/README.md
@@ -21,7 +21,7 @@ dev_dependencies:
 ["activated"][activating].
 
 ```console
-$ pub global activate webdev
+$ dart pub global activate webdev
 ```
 
 Learn more about activating and using packages [here][pub global].


### PR DESCRIPTION
The `pub` command no longer exist and users are therefore required to use `dart pub` instead for installation.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
