### PR TITLE
Fix conflicting webdev smoke package names.

### DIFF
--- a/fixtures/_webdevSoundSmoke/pubspec.yaml
+++ b/fixtures/_webdevSoundSmoke/pubspec.yaml
@@ -1,4 +1,4 @@
-name: _webdev_smoke
+name: _webdev_sound_smoke
 description: A test fixture for webdev testing with sound support.
 
 publish_to: none


### PR DESCRIPTION
Packages rolled into the Dart SDK via DEPS need to have non-colliding package names.

Bug: b/297182119