### PR TITLE
Pass the package config directly to the load strategy instead of depending on an app entrypoint

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Breaking changes**
 
-- Allow clients to specify where to find the package config. - [#2199](https://github.com/dart-lang/webdev/pull/2199).
+- Allow clients to specify where to find the package config. - [#2203](https://github.com/dart-lang/webdev/pull/2203).
 - Allow clients to specify a way to convert absolute paths to g3-relative paths. - [#2200](https://github.com/dart-lang/webdev/pull/2200)
 
 ## 20.0.1

--- a/dwds/lib/src/loaders/legacy.dart
+++ b/dwds/lib/src/loaders/legacy.dart
@@ -66,16 +66,6 @@ class LegacyStrategy extends LoadStrategy {
   /// an app URI.
   final String? Function(String appUri) _serverPathForAppUri;
 
-  /// Returns the absolute path to the app's package config, determined by the
-  /// app's [entrypoint] path.
-  ///
-  /// Example:
-  ///
-  ///  main_module.bootstrap.js
-  ///   -> /Users/john_doe/my_dart_app/.dart_tool/package_config.json
-  ///
-  final String? Function(String entrypoint) _packageConfigLocator;
-
   /// Returns the relative path in google3, determined by the [absolutePath].
   ///
   /// Returns `null` if not a google3 app.
@@ -92,9 +82,9 @@ class LegacyStrategy extends LoadStrategy {
     this._moduleInfoForProvider,
     AssetReader assetReader,
     this._appEntrypoint,
-    this._packageConfigLocator,
     this._g3RelativePath,
-  ) : super(assetReader);
+    String? packageConfigPath,
+  ) : super(assetReader, packageConfigPath: packageConfigPath);
 
   @override
   Handler get handler => (request) => Response.notFound(request.url.toString());
@@ -139,10 +129,6 @@ class LegacyStrategy extends LoadStrategy {
 
   @override
   Uri? get appEntrypoint => _appEntrypoint;
-
-  @override
-  String? packageConfigLocator(String entrypoint) =>
-      _packageConfigLocator(entrypoint);
 
   @override
   String? g3RelativePath(String absolutePath) => _g3RelativePath(absolutePath);

--- a/dwds/lib/src/loaders/require.dart
+++ b/dwds/lib/src/loaders/require.dart
@@ -285,8 +285,5 @@ if(!window.\$requireLoader) {
       _moduleInfoForProvider(metadataProviderFor(entrypoint));
 
   @override
-  String? packageConfigLocator(String entrypoint) => null;
-
-  @override
   String? g3RelativePath(String absolutePath) => null;
 }

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -11,10 +11,13 @@ import 'package:shelf/shelf.dart';
 
 abstract class LoadStrategy {
   final AssetReader _assetReader;
+  final String? _packageConfigPath;
   final _providers = <String, MetadataProvider>{};
-  String? _packageConfigPath;
 
-  LoadStrategy(this._assetReader);
+  LoadStrategy(
+    this._assetReader, {
+    String? packageConfigPath,
+  }) : _packageConfigPath = packageConfigPath;
 
   /// The ID for this strategy.
   ///
@@ -100,28 +103,17 @@ abstract class LoadStrategy {
   /// an app URI.
   String? serverPathForAppUri(String appUri);
 
-  /// Returns the absolute path to the app's package config, determined by the
-  /// app's [entrypoint] path.
-  ///
-  /// Example:
-  ///
-  ///  main_module.bootstrap.js
-  ///   -> /Users/john_doe/my_dart_app/.dart_tool/package_config.json
-  ///
-  String? packageConfigLocator(String entrypoint);
-
   /// Returns the relative path in google3, determined by the [absolutePath].
   ///
   /// Returns `null` if not a google3 app.
   String? g3RelativePath(String absolutePath);
 
-  /// The absolute path to the app's package config, or null if not provided by
-  /// [packageConfigLocator].
+  /// The absolute path to the app's package configuration.
   String get packageConfigPath {
     return _packageConfigPath ?? _defaultPackageConfigPath;
   }
 
-  /// The default package config path, if none is provided by the load strategy.
+  /// The default package config path if none is provided.
   String get _defaultPackageConfigPath => p.join(
         DartUri.currentDirectory,
         '.dart_tool',
@@ -142,7 +134,6 @@ abstract class LoadStrategy {
   /// provided [entrypoint].
   void trackEntrypoint(String entrypoint) {
     final metadataProvider = MetadataProvider(entrypoint, _assetReader);
-    _packageConfigPath = packageConfigLocator(entrypoint);
     _providers[metadataProvider.entrypoint] = metadataProvider;
   }
 }

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -314,8 +314,9 @@ class FakeExecutionContext extends ExecutionContext {
 
 class FakeStrategy extends LoadStrategy {
   FakeStrategy(
-    AssetReader assetReader,
-  ) : super(assetReader);
+    AssetReader assetReader, {
+    String? packageConfigPath,
+  }) : super(assetReader, packageConfigPath: packageConfigPath);
 
   @override
   Future<String> bootstrapFor(String entrypoint) async => 'dummy_bootstrap';
@@ -340,9 +341,6 @@ class FakeStrategy extends LoadStrategy {
 
   @override
   Uri? get appEntrypoint => Uri.parse('package:myapp/main.dart');
-
-  @override
-  String? packageConfigLocator(String entrypoint) => null;
 
   @override
   String? g3RelativePath(String absolutePath) => null;

--- a/dwds/test/load_strategy_test.dart
+++ b/dwds/test/load_strategy_test.dart
@@ -5,7 +5,6 @@
 @TestOn('vm')
 @Timeout(Duration(minutes: 1))
 
-import 'package:dwds/asset_reader.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_common/test_sdk_configuration.dart';
@@ -13,16 +12,6 @@ import 'package:test_common/test_sdk_configuration.dart';
 import 'fixtures/context.dart';
 import 'fixtures/fakes.dart';
 import 'fixtures/project.dart';
-
-class LoadStrategyCustomPackageConfig extends FakeStrategy {
-  LoadStrategyCustomPackageConfig(
-    AssetReader assetReader,
-  ) : super(assetReader);
-
-  @override
-  String? packageConfigLocator(String entrypoint) =>
-      '$entrypoint/custom/package_config/path';
-}
 
 void main() {
   final provider = TestSdkConfigurationProvider();
@@ -45,7 +34,6 @@ void main() {
       final strategy = FakeStrategy(FakeAssetReader());
 
       test('defaults to "./dart_tool/packageconfig.json"', () {
-        strategy.trackEntrypoint('my_app/entrypoint');
         expect(
           p.split(strategy.packageConfigPath).join('/'),
           endsWith('_testSound/.dart_tool/package_config.json'),
@@ -54,13 +42,15 @@ void main() {
     });
 
     group('When the packageConfigLocator specifies a package config path', () {
-      final strategy = LoadStrategyCustomPackageConfig(FakeAssetReader());
+      final strategy = FakeStrategy(
+        FakeAssetReader(),
+        packageConfigPath: 'custom/package_config/path',
+      );
 
       test('uses the specified package config path', () {
-        strategy.trackEntrypoint('my_app/entrypoint');
         expect(
           strategy.packageConfigPath,
-          equals('my_app/entrypoint/custom/package_config/path'),
+          equals('custom/package_config/path'),
         );
       });
     });

--- a/dwds/test/load_strategy_test.dart
+++ b/dwds/test/load_strategy_test.dart
@@ -41,7 +41,7 @@ void main() {
       });
     });
 
-    group('When the packageConfigLocator specifies a package config path', () {
+    group('When a custom package config path is specified', () {
       final strategy = FakeStrategy(
         FakeAssetReader(),
         packageConfigPath: 'custom/package_config/path',


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/2198

Simplifies the logic added in https://github.com/dart-lang/webdev/pull/2203 to no longer require an app entrypoint to determine the package config path