### PR TITLE
Avoid passing a nullable value to Future<nn-type>.value or Completer<nn-type>.completer.

### DIFF
--- a/dwds/lib/src/services/batched_expression_evaluator.dart
+++ b/dwds/lib/src/services/batched_expression_evaluator.dart
@@ -156,7 +156,7 @@ class BatchedExpressionEvaluator extends ExpressionEvaluator {
             length: requests.length,
           )
               .then((v) {
-            final result = v.first.value;
+            final result = v.first.value!;
             _logger.fine(
               'Got result out of a batch for ${request.expression}: $result',
             );


### PR DESCRIPTION
This is cleanup work required to start enforcing this with static analysis, as per https://github.com/dart-lang/sdk/issues/53253.

Real quick this issue is that this code is unsafe:

```dart
void f(Completer<int> c, int? i) {
  Future<int>.value(i); // Ouch!
  c.complete(i);        // Ouch!
}
```

This change should be a no-op. Adding this explicit null-assert ensures that any exception is thrown right at the null-assert.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
