### PR TITLE
[webdev] Hide `--null-safety` option

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.8-wip
 
-- Hide and deprecate now unsupported `--null-safety` flag.
+- Hide and deprecate now unsupported `--null-safety` option.
 
 ## 3.0.7
 

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.0.8-wip
 
+- Hide and deprecate now unsupported `--null-safety` flag.
+
 ## 3.0.7
 
 - Update `build_web_compilers` constraint to `^4.0.4`.

--- a/webdev/README.md
+++ b/webdev/README.md
@@ -103,16 +103,6 @@ Common:
                                            "--output" value should be passed to
                                            `build_runner`.
                                            (defaults to "NONE")
--n, --null-safety                          If "sound",
-                                           `package:build_web_compilers` will be
-                                           run with sound null safety support.
-                                           If "unsound",
-                                           `package:build_web_compilers` will be
-                                           run without sound null safety
-                                           support. If "auto", the default
-                                           `package:build_web_compilers`
-                                           behavior is used.
-                                           [sound, unsound, auto (default)]
 -r, --[no-]release                         Build with release mode defaults for
                                            builders.
     --[no-]build-web-compilers             If a dependency on
@@ -145,16 +135,6 @@ Usage: webdev build [arguments]
                                            "--output" value should be passed to
                                            `build_runner`.
                                            (defaults to "web:build")
--n, --null-safety                          If "sound",
-                                           `package:build_web_compilers` will be
-                                           run with sound null safety support.
-                                           If "unsound",
-                                           `package:build_web_compilers` will be
-                                           run without sound null safety
-                                           support. If "auto", the default
-                                           `package:build_web_compilers`
-                                           behavior is used.
-                                           [sound, unsound, auto (default)]
 -r, --[no-]release                         Build with release mode defaults for
                                            builders.
                                            (defaults to on)

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -33,12 +33,13 @@ void addSharedArgs(ArgParser argParser,
         defaultsTo: nullSafetyAuto,
         allowed: [nullSafetySound, nullSafetyUnsound, nullSafetyAuto],
         help:
-            'If "sound", `package:build_web_compilers` will be run with sound '
-            'null safety support. '
+            'DEPRECATED: If "sound", `package:build_web_compilers` will be run '
+            'with sound null safety support. '
             'If "unsound", `package:build_web_compilers` will be run without '
             'sound null safety support. '
             'If "auto", the default `package:build_web_compilers` '
-            'behavior is used.')
+            'behavior is used.',
+        hide: true)
     ..addFlag(releaseFlag,
         abbr: 'r',
         defaultsTo: releaseDefault,


### PR DESCRIPTION
This flag is confusing now that `webdev` requires a Dart 3 SDK which doesn't support unsound null safety. To reduce this confusion, this PR hides the `--null-safety` flag from the output help messages.

I was going to remove use of the flag entirely, but I wasn't sure if the flag is still used internally somehow. Let me know if it doesn't need to be wired up and I'd be happy to remove it :) 