### PR TITLE
Update SDK constraints for Dart 3.0 and 3.1 stable releases

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.4.3
+# Created with package:mono_repo v6.5.7
 name: Dart CI
 on:
   push:
@@ -37,7 +37,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.4.3
+        run: dart pub global activate mono_repo 6.5.7
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 21.0.0-wip
 
-- Update Dart SDK constraint to `>=3.2.0-36.0.dev <4.0.0`.
+- Update Dart SDK constraint to `>=3.2.0-36.0.dev <4.0.0`. - [#2207](https://github.com/dart-lang/webdev/pull/2207)
 
 **Breaking changes**
 

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 21.0.0-wip
 
+- Update Dart SDK constraint to `>=3.2.0-36.0.dev <4.0.0`.
+
 **Breaking changes**
 
 - Allow clients to specify where to find the package config. - [#2203](https://github.com/dart-lang/webdev/pull/2203).

--- a/dwds/debug_extension/pubspec.yaml
+++ b/dwds/debug_extension/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   A chrome extension for Dart debugging.
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   async: ^2.3.0

--- a/dwds/debug_extension_mv3/pubspec.yaml
+++ b/dwds/debug_extension_mv3/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   A Chrome extension for Dart debugging.
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   built_value: ^8.3.0

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -420,15 +420,13 @@ class DevHandler {
       debuggerStart: debuggerStart,
       devToolsStart: DateTime.now(),
     );
-    if (_devTools != null) {
-      await _launchDevTools(
-        appServices.chromeProxyService.remoteDebugger,
-        _constructDevToolsUri(
-          appServices.debugService.uri,
-          ideQueryParam: 'Dwds',
-        ),
-      );
-    }
+    await _launchDevTools(
+      appServices.chromeProxyService.remoteDebugger,
+      _constructDevToolsUri(
+        appServices.debugService.uri,
+        ideQueryParam: 'Dwds',
+      ),
+    );
   }
 
   Future<AppConnection> _handleConnectRequest(

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -203,7 +203,7 @@ class DebugService {
   Future<String> get encodedUri async {
     if (_encodedUri != null) return _encodedUri!;
     var encoded = uri;
-    if (_urlEncoder != null) encoded = await _urlEncoder!(encoded);
+    if (_urlEncoder != null) encoded = await _urlEncoder(encoded);
     return _encodedUri = encoded;
   }
 

--- a/dwds/lib/src/utilities/objects.dart
+++ b/dwds/lib/src/utilities/objects.dart
@@ -21,7 +21,7 @@ class Property {
   ///
   /// Useful for getting access to properties of particular types of
   /// RemoteObject.
-  Object? get rawValue => _map == null ? null : _map!['value'];
+  Object? get rawValue => _map == null ? null : _map['value'];
 
   /// Remote object value in case of primitive values or JSON values (if it was
   /// requested). (optional)
@@ -29,7 +29,7 @@ class Property {
     if (_remoteObjectValue != null) return _remoteObjectValue!;
     if (_map == null) return null;
     if (rawValue == null) return null;
-    final val = _map!['value'];
+    final val = _map['value'];
     if (val is RemoteObject) {
       _remoteObjectValue = val;
     } else {
@@ -59,7 +59,7 @@ class Property {
   /// Will be of the form 'Symbol(_actualName)' for private fields.
   String? get rawName {
     if (_map == null) return null;
-    return _map!['name'] as String;
+    return _map['name'] as String;
   }
 
   @override

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   service protocol.
 repository: https://github.com/dart-lang/webdev/tree/master/dwds
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   async: ^2.9.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: A web app example for webdev CLI.
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/fixtures/_experimentSound/pubspec.yaml
+++ b/fixtures/_experimentSound/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-254.0.dev<4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   intl: ^0.17.0

--- a/fixtures/_test/pubspec.yaml
+++ b/fixtures/_test/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   intl: ^0.17.0

--- a/fixtures/_testCircular1/pubspec.yaml
+++ b/fixtures/_testCircular1/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   intl: ^0.17.0

--- a/fixtures/_testCircular1Sound/pubspec.yaml
+++ b/fixtures/_testCircular1Sound/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   intl: ^0.17.0

--- a/fixtures/_testCircular2/pubspec.yaml
+++ b/fixtures/_testCircular2/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   _test_circular1:

--- a/fixtures/_testCircular2Sound/pubspec.yaml
+++ b/fixtures/_testCircular2Sound/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   _test_circular1_sound:

--- a/fixtures/_testPackage/pubspec.yaml
+++ b/fixtures/_testPackage/pubspec.yaml
@@ -9,7 +9,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-254.0.dev<4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   _test:

--- a/fixtures/_testPackageSound/pubspec.yaml
+++ b/fixtures/_testPackageSound/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   _test_sound:

--- a/fixtures/_testSound/pubspec.yaml
+++ b/fixtures/_testSound/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   intl: ^0.17.0

--- a/fixtures/_webdevSmoke/pubspec.yaml
+++ b/fixtures/_webdevSmoke/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: none
 # and build_web_compilers constraint should match those defined
 # in pubspec.dart.
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dev_dependencies:
   build_runner: '>=1.6.2 <3.0.0'

--- a/fixtures/_webdevSoundSmoke/pubspec.yaml
+++ b/fixtures/_webdevSoundSmoke/pubspec.yaml
@@ -4,7 +4,7 @@ description: A test fixture for webdev testing with sound support.
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/frontend_server_client/CHANGELOG.md
+++ b/frontend_server_client/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.3.0-dev
+## 3.3.0-wip
 
-- Update SDK constraint to `>=3.0.0-134.0.dev <4.0.0`.
+- Update Dart SDK constraint to `>=3.0.0 <4.0.0`.
 - Support changes in the SDK layout for Dart 3.0.
 
 ## 3.2.0

--- a/frontend_server_client/pubspec.yaml
+++ b/frontend_server_client/pubspec.yaml
@@ -1,12 +1,12 @@
 name: frontend_server_client
-version: 3.3.0-dev
+version: 3.3.0-wip
 description: >-
   Client code to start and interact with the frontend_server compiler from the
   Dart SDK.
 repository: https://github.com/dart-lang/webdev/tree/master/frontend_server_client
 
 environment:
-  sdk: ">=3.0.0-134.0.dev <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   async: ^2.5.0

--- a/frontend_server_client/test/frontend_sever_client_test.dart
+++ b/frontend_server_client/test/frontend_sever_client_test.dart
@@ -28,7 +28,7 @@ dependencies:
   path: ^1.0.0
 
 environment:
-  sdk: ">3.0.0-134.0.dev <4.0.0"
+  sdk: ^3.0.0
       '''),
       d.dir('bin', [
         d.file('main.dart', '''

--- a/frontend_server_common/pubspec.yaml
+++ b/frontend_server_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: >-
   Frontend server integration code to use for dwds tests. Mimics flutter code.
 environment:
-  sdk: ">=3.0.0-134.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   dwds: any

--- a/test_common/pubspec.yaml
+++ b/test_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: >-
   Common test functionality.
 environment:
-  sdk: ">=3.0.0-134.0.dev <4.0.0"
+  sdk: ^3.1.0
 
 dependencies:
   dwds: any

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.4.3
+# Created with package:mono_repo v6.5.7
 
 # Support built in commands on windows out of the box.
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: >-
   Common tools for the mono-repo.
 environment:
-  sdk: ">=3.0.0-134.0.dev <4.0.0"
+  sdk: ^3.1.0
 
 dev_dependencies:
   args: ^2.4.0

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.8-wip
 
-- Update Dart SDK constraint to `>=3.2.0-36.0.dev <4.0.0`.
+- Update Dart SDK constraint to `>=3.2.0-36.0.dev <4.0.0`. - [#2207](https://github.com/dart-lang/webdev/pull/2207)
 
 ## 3.0.7
 

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.0.8-wip
 
+- Update Dart SDK constraint to `>=3.2.0-36.0.dev <4.0.0`.
+
 ## 3.0.7
 
 - Update `build_web_compilers` constraint to `^4.0.4`.

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -91,7 +91,7 @@ class PubspecLock {
         PackageExceptionDetails.missingDep(pkgName, constraint);
 
     var pkgDataMap =
-        (_packages == null) ? null : _packages![pkgName] as YamlMap?;
+        (_packages == null) ? null : _packages[pkgName] as YamlMap?;
     if (pkgDataMap == null) {
       issues.add(missingDetails);
     } else {

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -8,7 +8,7 @@ description: >-
   features for users and tools to build and deploy web applications with Dart.
 repository: https://github.com/dart-lang/webdev/tree/master/webdev
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ^3.2.0-36.0.dev
 
 dependencies:
   args: ^2.3.1


### PR DESCRIPTION
Update SDK constraints for most packages to the first `dev` release of 3.2.0 since the stable 3.1.0 release doesn't actually include the DDC debugger runtime API changes, but will allow for package resolution with the `3.1.0-...-dev` constraint and a 3.1.0 SDK. This will prevent that.

Others are updated to stable releases.

Issue reference: https://github.com/dart-lang/sdk/issues/53459

