### PR TITLE
Temporarily skip tests failing due a bug in dev SDK

### DIFF
--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -5,8 +5,10 @@
 @TestOn('vm')
 @Timeout(Duration(minutes: 2))
 import 'dart:async';
+import 'dart:io';
 
 import 'package:dwds/src/services/expression_evaluator.dart';
+import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
@@ -736,26 +738,38 @@ void testAll({
           expect(result, matchInstanceRef(expected));
         });
 
-        test('instance of a generic class', () async {
-          final libraryId = getRootLibraryId();
-          final result =
-              await getInstanceRef(libraryId, '<String>[].toString()');
+        test(
+          'instance of a generic class',
+          () async {
+            final libraryId = getRootLibraryId();
+            final result =
+                await getInstanceRef(libraryId, '<String>[].toString()');
 
-          expect(result, matchInstanceRef('[]'));
-        });
+            expect(result, matchInstanceRef('[]'));
+          }, // TODO:(annagrin): remove when dev version updates to 3.2.0-126.0.dev or later.
+          skip: semver.Version.parse(Platform.version.split(' ')[0])
+                  .compareTo(semver.Version.parse('3.2.0-126.0.dev')) <
+              0,
+        );
 
-        test('in parallel (in a batch)', () async {
-          final libraryId = getRootLibraryId();
+        test(
+          'in parallel (in a batch)',
+          () async {
+            final libraryId = getRootLibraryId();
 
-          final evaluation1 =
-              getInstanceRef(libraryId, 'MainClass(1,0).toString()');
-          final evaluation2 =
-              getInstanceRef(libraryId, 'MainClass(1,1).toString()');
+            final evaluation1 =
+                getInstanceRef(libraryId, 'MainClass(1,0).toString()');
+            final evaluation2 =
+                getInstanceRef(libraryId, 'MainClass(1,1).toString()');
 
-          final results = await Future.wait([evaluation1, evaluation2]);
-          expect(results[0], matchInstanceRef('1, 0'));
-          expect(results[1], matchInstanceRef('1, 1'));
-        });
+            final results = await Future.wait([evaluation1, evaluation2]);
+            expect(results[0], matchInstanceRef('1, 0'));
+            expect(results[1], matchInstanceRef('1, 1'));
+          }, // TODO:(annagrin): remove when dev version updates to 3.2.0-126.0.dev or later.
+          skip: semver.Version.parse(Platform.version.split(' ')[0])
+                  .compareTo(semver.Version.parse('3.2.0-126.0.dev')) <
+              0,
+        );
 
         test('in parallel (in a batch) handles errors', () async {
           final libraryId = getRootLibraryId();

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -736,6 +736,14 @@ void testAll({
           expect(result, matchInstanceRef(expected));
         });
 
+        test('instance of a generic class', () async {
+          final libraryId = getRootLibraryId();
+          final result =
+              await getInstanceRef(libraryId, '<String>[].toString()');
+
+          expect(result, matchInstanceRef('[]'));
+        });
+
         test('in parallel (in a batch)', () async {
           final libraryId = getRootLibraryId();
 


### PR DESCRIPTION
Skip evaluation tests that fail due to a bug in SDK, to unblock our CI.

Note: The issue is fixed in https://github.com/dart-lang/sdk/commit/8d52ee6547b8412a0400cdf9a26037afd6938e57 ([3.2.0-126.0.dev](https://github.com/dart-lang/sdk/releases/tag/3.2.0-126.0.dev)), so the tests will only be failing until dev channel updates to that version  in a few days, and no users currently depend on that version.
