### PR TITLE
Prepare `3.0.7+1` hotfix release for Webdev

### DIFF
--- a/fixtures/_webdevSmoke/pubspec.yaml
+++ b/fixtures/_webdevSmoke/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: none
 # and build_web_compilers constraint should match those defined
 # in pubspec.dart.
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ">=3.0.0-188.0.dev <4.0.0"
 
 dev_dependencies:
   build_runner: '>=1.6.2 <3.0.0'

--- a/fixtures/_webdevSoundSmoke/pubspec.yaml
+++ b/fixtures/_webdevSoundSmoke/pubspec.yaml
@@ -4,7 +4,7 @@ description: A test fixture for webdev testing with sound support.
 publish_to: none
 
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ">=3.0.0-188.0.dev <4.0.0"
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.7+1
+
+- Downgrade `dwds` constraint to `19.0.2+1` to fix a versioning conflict with the Dart SDK. - [#53459](https://github.com/dart-lang/sdk/issues/53459).
+
 ## 3.0.7
 
 - Update `build_web_compilers` constraint to `^4.0.4`.

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -139,7 +139,6 @@ class WebDevServer {
           verbose: options.configuration.verbose,
           experiments: options.configuration.experiments,
           sdkConfigurationProvider: const DefaultSdkConfigurationProvider(),
-          canaryFeatures: options.configuration.canaryFeatures,
         );
       }
       var shouldServeDevTools =

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.0.7';
+const packageVersion = '3.0.7+1';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -8,7 +8,7 @@ description: >-
   features for users and tools to build and deploy web applications with Dart.
 repository: https://github.com/dart-lang/webdev/tree/master/webdev
 environment:
-  sdk: ">=3.1.0-340.0.dev <4.0.0"
+  sdk: ">=3.0.0-188.0.dev <4.0.0"
 
 dependencies:
   args: ^2.3.1

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `dart run build_runner build`.
-version: 3.0.7
+version: 3.0.7+1
 # We should not depend on a dev SDK before publishing.
 # publish_to: none
 description: >-
@@ -19,7 +19,7 @@ dependencies:
   crypto: ^3.0.2
   dds: ^2.2.0
   # Pin DWDS to avoid dependency conflicts with vm_service:
-  dwds: 20.0.1
+  dwds: 19.0.2+1
   http: ^0.13.4
   http_multi_server: ^3.2.0
   io: ^1.0.3


### PR DESCRIPTION
Prepares a Webdev hotfix to resolve the Dart SDK versioning issue found in https://github.com/dart-lang/sdk/issues/53459