### PR TITLE
Add a new workspaceName parameter to DWDS on start up

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## 22.0.0-wip
 
+- Update the interface for ChromeProxyService.getSourceReport to match the VM service. - [#2235](https://github.com/dart-lang/webdev/pull/2235)
+
 **Breaking changes**
 
 - Refactor the parameters to `Dwds.start`. - [#2231](https://github.com/dart-lang/webdev/pull/2231).
-
-- Update the interface for ChromeProxyService.getSourceReport to match the VM service. - [#2235](https://github.com/dart-lang/webdev/pull/2235)
+- Add a new parameter `workspaceName` to the `ToolConfiguration` passed to `Dwds.start`. - [#2237](https://github.com/dart-lang/webdev/pull/2237)
 
 ## 21.0.0
 

--- a/dwds/lib/src/config/tool_configuration.dart
+++ b/dwds/lib/src/config/tool_configuration.dart
@@ -36,11 +36,13 @@ ToolConfiguration get globalToolConfiguration => _globalToolConfiguration;
 class AppMetadata {
   final String hostname;
   final bool isInternalBuild;
+  final String? workspaceName;
   Future<bool> Function() isFlutterApp;
 
   AppMetadata({
     this.hostname = 'localhost',
     this.isInternalBuild = false,
+    this.workspaceName,
     Future<bool> Function()? isFlutterApp,
   }) : isFlutterApp = isFlutterApp ?? (() => Future.value(true));
 }

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -200,5 +200,9 @@ Future<String> _injectedClientSnippet(
   if (extensionUri != null) {
     injectedBody += 'window.\$dartExtensionUri = "$extensionUri";\n';
   }
+  final workspaceName = globalToolConfiguration.appMetadata.workspaceName;
+  if (workspaceName != null) {
+    injectedBody += 'window.\$dartWorkspaceName = "$workspaceName";\n';
+  }
   return injectedBody;
 }

--- a/dwds/lib/src/injected/client.js
+++ b/dwds/lib/src/injected/client.js
@@ -25792,6 +25792,8 @@
       t1.toString;
       t1 = A._asBoolQ(A.JsObject_JsObject$fromBrowserObject(t1).$index(0, "$isFlutterApp"));
       b.get$_$this()._isFlutterApp = t1;
+      t1 = A._asStringQ(self.$dartWorkspaceName);
+      b.get$_$this()._workspaceName = t1;
       return b;
     },
     $signature: 76

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -154,6 +154,7 @@ class TestContext {
     bool isInternalBuild = false,
     List<String> experiments = const <String>[],
     bool canaryFeatures = false,
+    String? workspaceName,
   }) async {
     final sdkLayout = sdkConfigurationProvider.sdkLayout;
     final toolConfiguration = createToolConfiguration(
@@ -171,6 +172,7 @@ class TestContext {
         hostname: hostname,
         isInternalBuild: isInternalBuild,
         isFlutterApp: () => Future.value(isFlutterApp),
+        workspaceName: workspaceName,
       ),
     );
     setGlobalsForTesting(toolConfiguration: toolConfiguration);
@@ -427,6 +429,7 @@ class TestContext {
         ddcService,
         isFlutterApp,
         isInternalBuild,
+        workspaceName,
         sdkLayout,
       );
 

--- a/dwds/test/fixtures/server.dart
+++ b/dwds/test/fixtures/server.dart
@@ -82,6 +82,7 @@ class TestServer {
     ExpressionCompilerService? ddcService,
     bool isFlutterApp,
     bool isInternalBuild,
+    String? workspaceName,
     TestSdkLayout sdkLayout,
   ) async {
     var pipeline = const Pipeline();
@@ -132,6 +133,7 @@ class TestServer {
       hostname: hostname,
       isInternalBuild: isInternalBuild,
       isFlutterApp: () => Future.value(isFlutterApp),
+      workspaceName: workspaceName,
     );
 
     final toolConfiguration = ToolConfiguration(

--- a/dwds/test/puppeteer/extension_common.dart
+++ b/dwds/test/puppeteer/extension_common.dart
@@ -59,6 +59,7 @@ void testAll({
             extensionPath: extensionPath,
             serveDevTools: true,
             useSse: useSse,
+            workspaceName: 'test-workspace',
           );
 
           if (isMV3) {
@@ -111,6 +112,7 @@ void testAll({
           expect(debugInfo.appUrl, isNotNull);
           expect(debugInfo.isInternalBuild, isNotNull);
           expect(debugInfo.isFlutterApp, isNotNull);
+          expect(debugInfo.workspaceName, isNotNull);
           await appTab.close();
         });
 

--- a/dwds/test/puppeteer/test_utils.dart
+++ b/dwds/test/puppeteer/test_utils.dart
@@ -42,6 +42,7 @@ Future<Browser> setUpExtensionTest(
   bool isInternalBuild = false,
   bool isFlutterApp = false,
   bool openChromeDevTools = false,
+  String? workspaceName,
 }) async {
   // TODO(elliette): Only start a TestServer, that way we can get rid of the
   // launchChrome parameter: https://github.com/dart-lang/webdev/issues/1779
@@ -52,6 +53,7 @@ Future<Browser> setUpExtensionTest(
     enableDebugExtension: true,
     isInternalBuild: isInternalBuild,
     isFlutterApp: isFlutterApp,
+    workspaceName: workspaceName,
   );
   return await puppeteer.launch(
     devTools: openChromeDevTools,

--- a/dwds/web/client.dart
+++ b/dwds/web/client.dart
@@ -271,7 +271,8 @@ void _launchCommunicationWithDebugExtension() {
           ..authUrl = _authUrl
           ..extensionUrl = _extensionUrl
           ..isInternalBuild = _isInternalBuild
-          ..isFlutterApp = _isFlutterApp,
+          ..isFlutterApp = _isFlutterApp
+          ..workspaceName = dartWorkspaceName,
       ),
     ),
   );
@@ -357,6 +358,9 @@ external bool get isInternalBuild;
 
 @JS(r'$isFlutterApp')
 external bool get isFlutterApp;
+
+@JS(r'$dartWorkspaceName')
+external String? get dartWorkspaceName;
 
 bool get _isChromium => window.navigator.vendor.contains('Google');
 


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/2198

Add a `workspaceName` parameter to DWDS on start up, which will be used to determine which dart tab to connect to from Cider.