### PR TITLE
Rename `plainUri` to `debugUri` and send it to the extension

### DIFF
--- a/dwds/debug_extension_mv3/web/debug_session.dart
+++ b/dwds/debug_extension_mv3/web/debug_session.dart
@@ -414,7 +414,7 @@ void _routeDwdsEvent(String eventData, SocketClient client, int tabId) {
         _openDevTools(message.params, dartAppTabId: tabId);
       }
     }
-    if (message.method == 'dwds.plainUri') {
+    if (message.method == 'dwds.debugUri') {
       sendMessageToCider(
         messageType: CiderMessageType.startDebugResponse,
         messageBody: message.params,

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -598,6 +598,7 @@ class DevHandler {
       appServices = await _createAppDebugServices(
         debugService,
       );
+      extensionDebugger.sendEvent('dwds.debugUri', debugService.uri);
       final encodedUri = await debugService.encodedUri;
       extensionDebugger.sendEvent('dwds.encodedUri', encodedUri);
       safeUnawaited(


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/2198

When it receives a request to start debugging, DWDS sends the debug URI to the Dart Debug Extension, which then sends it to Cider.
