### PR TITLE
Prepare the Dart Debug Extension for release to version 1.36

### DIFF
--- a/dwds/debug_extension_mv3/pubspec.yaml
+++ b/dwds/debug_extension_mv3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mv3_extension
 publish_to: none
-version: 1.35.0
+version: 1.36.0
 homepage: https://github.com/dart-lang/webdev
 description: >-
   A Chrome extension for Dart debugging.

--- a/dwds/debug_extension_mv3/web/manifest_mv2.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv2.json
@@ -1,6 +1,6 @@
 {
   "name": "Dart Debug Extension",
-  "version": "1.35",
+  "version": "1.36",
   "manifest_version": 2,
   "devtools_page": "static_assets/devtools.html",
   "browser_action": {

--- a/dwds/debug_extension_mv3/web/manifest_mv3.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv3.json
@@ -1,6 +1,6 @@
 {
   "name": "Dart Debug Extension",
-  "version": "1.35",
+  "version": "1.36",
   "manifest_version": 3,
   "devtools_page": "static_assets/devtools.html",
   "action": {


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/2198

This is the version that supports debugging from Cider 
