### PR TITLE
Fix issue with the embedded inspector panel

### DIFF
--- a/dwds/debug_extension_mv3/web/utils.dart
+++ b/dwds/debug_extension_mv3/web/utils.dart
@@ -143,6 +143,7 @@ String addQueryParameters(
 }) {
   final originalUri = Uri.parse(uri);
   final newUri = originalUri.replace(
+    path: '', // Replace the /debugger path so that the inspector url works.
     queryParameters: {
       ...originalUri.queryParameters,
       ...queryParameters,

--- a/dwds/test/puppeteer/extension_common.dart
+++ b/dwds/test/puppeteer/extension_common.dart
@@ -692,7 +692,8 @@ void testAll({
           // origin, and being able to connect to the embedded Dart app.
           // See https://github.com/dart-lang/webdev/issues/1779
 
-          test('The Dart DevTools IFRAME has the correct query parameters',
+          test(
+              'The Dart DevTools IFRAME has the correct query parameters and path',
               () async {
             final chromeDevToolsPage = await getChromeDevToolsPage(browser);
             // There are no hooks for when a panel is added to Chrome DevTools,
@@ -734,6 +735,7 @@ void testAll({
               queryParameters,
               containsPair('backgroundColor', isNotEmpty),
             );
+            expect(uri.path, equals('/'));
           });
 
           test('Trying to debug a page with multiple Dart apps shows warning',


### PR DESCRIPTION
We were including `/debugger` in the path, which meant that we were loading the debugger panel instead of the inspector panel.
