### PR TITLE
Cider expects messages from a Chrome extension to be a JS object, not a string

### DIFF
--- a/dwds/debug_extension_mv3/pubspec.yaml
+++ b/dwds/debug_extension_mv3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mv3_extension
 publish_to: none
-version: 1.36.0
+version: 1.37.0
 homepage: https://github.com/dart-lang/webdev
 description: >-
   A Chrome extension for Dart debugging.

--- a/dwds/debug_extension_mv3/web/cider_connection.dart
+++ b/dwds/debug_extension_mv3/web/cider_connection.dart
@@ -6,6 +6,7 @@
 library cider_connection;
 
 import 'dart:convert';
+import 'dart:js_util';
 
 import 'package:dwds/data/debug_info.dart';
 import 'package:js/js.dart';
@@ -14,6 +15,11 @@ import 'chrome_api.dart';
 import 'debug_session.dart';
 import 'logger.dart';
 import 'storage.dart';
+
+/// Used to identify messages passed to/fron Cider.
+///
+/// This must match the key defined in the Cider extension.
+const _ciderDartMessageKey = 'CIDER_DART';
 
 /// Defines the message types that can be passed to/from Cider.
 ///
@@ -67,7 +73,7 @@ void sendMessageToCider({
     'messageType': messageType.name,
     'messageBody': messageBody,
   });
-  _ciderPort!.postMessage(message);
+  _sendMessageToCider(message);
 }
 
 /// Sends an error message to the Cider-connected port.
@@ -82,19 +88,29 @@ void sendErrorMessageToCider({
     'errorType': errorType.name,
     'messageBody': errorDetails,
   });
+  _sendMessageToCider(message);
+}
+
+void _sendMessageToCider(String json) {
+  final message = {
+    'key': _ciderDartMessageKey,
+    'json': json,
+  };
   _ciderPort!.postMessage(message);
 }
 
 Future<void> _handleMessageFromCider(dynamic message, Port _) async {
-  if (message is! String) {
+  final key = getProperty(message, 'key');
+  final json = getProperty(message, 'json');
+  if (key != _ciderDartMessageKey || json is! String) {
     sendErrorMessageToCider(
       errorType: CiderErrorType.invalidRequest,
-      errorDetails: 'Expected request to be a string: $message',
+      errorDetails: 'Invalid message format: $message',
     );
     return;
   }
 
-  final decoded = jsonDecode(message) as Map<String, dynamic>;
+  final decoded = jsonDecode(json) as Map<String, dynamic>;
   final messageType = decoded['messageType'] as String?;
   final messageBody = decoded['messageBody'] as String?;
 

--- a/dwds/debug_extension_mv3/web/cider_connection.dart
+++ b/dwds/debug_extension_mv3/web/cider_connection.dart
@@ -16,7 +16,7 @@ import 'debug_session.dart';
 import 'logger.dart';
 import 'storage.dart';
 
-/// Used to identify messages passed to/fron Cider.
+/// Used to identify messages passed to/from Cider.
 ///
 /// This must match the key defined in the Cider extension.
 const _ciderDartMessageKey = 'CIDER_DART';

--- a/dwds/debug_extension_mv3/web/cider_connection.dart
+++ b/dwds/debug_extension_mv3/web/cider_connection.dart
@@ -96,7 +96,7 @@ void _sendMessageToCider(String json) {
     'key': _ciderDartMessageKey,
     'json': json,
   };
-  _ciderPort!.postMessage(message);
+  _ciderPort!.postMessage(jsify(message));
 }
 
 Future<void> _handleMessageFromCider(dynamic message, Port _) async {
@@ -188,7 +188,7 @@ Future<int?> _findDartTabIdForWorkspace(String workspaceName) async {
   }
   if (dartTabIds.length > 1) {
     sendErrorMessageToCider(
-      errorType: CiderErrorType.noDartTab,
+      errorType: CiderErrorType.multipleDartTabs,
       errorDetails: 'Too many debuggable Dart tabs found.',
     );
     return null;

--- a/dwds/debug_extension_mv3/web/manifest_mv2.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv2.json
@@ -1,6 +1,6 @@
 {
   "name": "Dart Debug Extension",
-  "version": "1.36",
+  "version": "1.37",
   "manifest_version": 2,
   "devtools_page": "static_assets/devtools.html",
   "browser_action": {

--- a/dwds/debug_extension_mv3/web/manifest_mv3.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv3.json
@@ -1,6 +1,6 @@
 {
   "name": "Dart Debug Extension",
-  "version": "1.36",
+  "version": "1.37",
   "manifest_version": 3,
   "devtools_page": "static_assets/devtools.html",
   "action": {


### PR DESCRIPTION
Previously we were sending a JSON string to Cider. Cider actually expects the message to be a JS object, so now we are passing a JS object that looks like:

```
{
key: 'CIDER_DART',
json: [[the original json string]]
}
```

Work towards https://github.com/dart-lang/webdev/issues/2198