### PR TITLE
Run the Webdev tests daily with the Dart stable SDK

### DIFF
--- a/.github/workflows/daily_stable_testing.yml
+++ b/.github/workflows/daily_stable_testing.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Setup stable Dart SDK
         uses: dart-lang/setup-dart@8a4b97ea2017cc079571daec46542f76189836b1
         with:
-          sdk: stable
+          sdk: dev
+          # sdk: stable
       - name: Activate Webdev 
         run: dart pub global activate webdev
       - name: Get Webdev version
@@ -29,8 +30,8 @@ jobs:
       - name: Checkout Webdev repository     
         id: checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-        with:
-          ref: webdev-v${{ steps.version.outputs.VERSION_TAG }}
+        # with:
+        #   ref: webdev-v${{ steps.version.outputs.VERSION_TAG }}
       # - name: Switch to release branch
       #   run: |
       #     git checkout webdev-v${{ steps.version.outputs.VERSION_TAG }}

--- a/.github/workflows/daily_stable_testing.yml
+++ b/.github/workflows/daily_stable_testing.yml
@@ -1,0 +1,50 @@
+# A CI workflow to run stable tests on a daily cron job.
+
+name: Daily Stable Testing
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  schedule:
+    - cron: "00 14 * * *" # Everyday at 3:00 PM UTC (8:00 AM PST)
+
+jobs:
+  testing_stable:
+    name: Testing Dart Stable SDK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup stable Dart SDK
+        uses: dart-lang/setup-dart@8a4b97ea2017cc079571daec46542f76189836b1
+        with:
+          sdk: stable
+      - name: Activate Webdev 
+        run: dart pub global activate webdev
+      - name: Get Webdev version
+        id: version
+        run: |
+          echo "VERSION_TAG=$(webdev --version)"
+      - name: Checkout Webdev repository     
+        id: checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - name: Switch to release branch
+        run: |
+          git checkout ${{ steps.version.outputs.VERSION_TAG }}
+      - name: Upgrade deps
+        id: webdev_pub_upgrade
+        run: dart pub upgrade
+        working-directory: webdev
+      - name: Run stable tests
+        id: webdev_stable_tests
+        # TODO(elliette): Switch to using a stable tag once it hits the stable release.
+        run: "dart test test/e2e_test.dart"
+        if: "always() && steps.webdev_pub_upgrade.conclusion == 'success'"
+        working-directory: webdev
+      - name: "Notify failure"
+        if: "always() && steps.webdev_stable_tests.conclusion == 'failure'"
+        run: |
+          curl -H "Content-Type: application/json" -X POST -d \
+            "{'text':'Webdev tests failed (stable)! ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
+            "${{ secrets.WEBDEV_NOTIFICATION_CHAT_WEBHOOK }}"

--- a/.github/workflows/daily_stable_testing.yml
+++ b/.github/workflows/daily_stable_testing.yml
@@ -29,9 +29,14 @@ jobs:
       - name: Checkout Webdev repository     
         id: checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-      - name: Switch to release branch
-        run: |
-          git checkout webdev-v${{ steps.version.outputs.VERSION_TAG }}
+        with:
+          ref: webdev-v${{ steps.version.outputs.VERSION_TAG }}
+      # - name: Switch to release branch
+      #   run: |
+      #     git checkout webdev-v${{ steps.version.outputs.VERSION_TAG }}
+      # - name: Switch to release branch
+      #   run: |
+      #     git checkout webdev-v${{ steps.version.outputs.VERSION_TAG }}
       - name: Upgrade deps
         id: webdev_pub_upgrade
         run: dart pub upgrade

--- a/.github/workflows/daily_stable_testing.yml
+++ b/.github/workflows/daily_stable_testing.yml
@@ -23,35 +23,28 @@ jobs:
       - name: Setup stable Dart SDK
         uses: dart-lang/setup-dart@8a4b97ea2017cc079571daec46542f76189836b1
         with:
-          sdk: dev
-          # sdk: stable
+          sdk: stable
       - name: Activate Webdev 
         run: dart pub global activate webdev
-      - name: Get Webdev version
+      - name: Get Webdev version tag
         id: version
         run: |
           echo "VERSION_TAG=$(webdev --version)" >> $GITHUB_OUTPUT
-      - name: Checkout Webdev repository     
+      - name: Checkout Webdev at version tag 
         id: checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-        # with:
-        #   ref: webdev-v${{ steps.version.outputs.VERSION_TAG }}
-      # - name: Switch to release branch
-      #   run: |
-      #     git checkout webdev-v${{ steps.version.outputs.VERSION_TAG }}
-      # - name: Switch to release branch
-      #   run: |
-      #     git checkout webdev-v${{ steps.version.outputs.VERSION_TAG }}
+        with:
+          ref: webdev-v${{ steps.version.outputs.VERSION_TAG }}
       - name: Upgrade deps
         id: webdev_pub_upgrade
         run: dart pub upgrade
         working-directory: webdev
-      - name: "Xvfb :99"
+      # Required for Chrome headless tests on Linux:
+      - name: Set up X virtual frame buffer
         run: "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &"
         working-directory: webdev
       - name: Run stable tests
         id: webdev_stable_tests
-        # TODO(elliette): Switch to using a stable tag once it hits the stable release.
         run: "dart test test/e2e_test.dart"
         if: "always() && steps.webdev_pub_upgrade.conclusion == 'success'"
         working-directory: webdev
@@ -59,5 +52,5 @@ jobs:
         if: "always() && steps.webdev_stable_tests.conclusion == 'failure'"
         run: |
           curl -H "Content-Type: application/json" -X POST -d \
-            "{'text':'Daily Webdev stable tests failed! ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
+            "{'text':'Daily stable tests failed! ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
             "${{ secrets.WEBDEV_NOTIFICATION_CHAT_WEBHOOK }}"

--- a/.github/workflows/daily_stable_testing.yml
+++ b/.github/workflows/daily_stable_testing.yml
@@ -41,6 +41,9 @@ jobs:
         id: webdev_pub_upgrade
         run: dart pub upgrade
         working-directory: webdev
+      - name: "Xvfb :99"
+        run: "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &"
+        working-directory: webdev
       - name: Run stable tests
         id: webdev_stable_tests
         # TODO(elliette): Switch to using a stable tag once it hits the stable release.
@@ -51,5 +54,5 @@ jobs:
         if: "always() && steps.webdev_stable_tests.conclusion == 'failure'"
         run: |
           curl -H "Content-Type: application/json" -X POST -d \
-            "{'text':'Webdev tests failed (stable)! ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
+            "{'text':'Daily Webdev stable tests failed! ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \
             "${{ secrets.WEBDEV_NOTIFICATION_CHAT_WEBHOOK }}"

--- a/.github/workflows/daily_stable_testing.yml
+++ b/.github/workflows/daily_stable_testing.yml
@@ -3,11 +3,6 @@
 name: Daily Stable Testing
 
 on:
-  push:
-    branches:
-      - main
-      - master
-  pull_request:
   schedule:
     - cron: "00 14 * * *" # Everyday at 3:00 PM UTC (8:00 AM PST)
 
@@ -41,7 +36,7 @@ jobs:
         id: webdev_pub_upgrade
         run: dart pub upgrade
         working-directory: webdev
-      # Required for Chrome headless tests on Linux:
+      # Note: xvfb is required to run Chrome headless tests on Linux.
       - name: Set up X virtual frame buffer
         run: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
         working-directory: webdev
@@ -51,7 +46,8 @@ jobs:
         if: "always() && steps.webdev_pub_upgrade.conclusion == 'success'"
         working-directory: webdev
       - name: "Notify failure"
-        if: "always() && steps.webdev_stable_tests.conclusion == 'failure'"
+        # TODO(elliette): Uncomment after determining that notifications are working.
+        # if: "always() && steps.webdev_stable_tests.conclusion == 'failure'"
         run: |
           curl -H "Content-Type: application/json" -X POST -d \
             "{'text':'Daily stable tests failed! ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}'}" \

--- a/.github/workflows/daily_stable_testing.yml
+++ b/.github/workflows/daily_stable_testing.yml
@@ -15,22 +15,24 @@ env:
   PUB_ENVIRONMENT: bot.github
   DISPLAY: ":99"
 
+# TODO(elliette): Consider parsing the Webdev pubspec to find the pinned DWDS
+# version, and running tests against DWDS as well.
 jobs:
   testing_stable:
     name: Testing Dart Stable SDK
     runs-on: ubuntu-latest
     steps:
-      - name: Setup stable Dart SDK
+      - name: Set up stable Dart SDK
         uses: dart-lang/setup-dart@8a4b97ea2017cc079571daec46542f76189836b1
         with:
           sdk: stable
-      - name: Activate Webdev 
+      - name: Activate Webdev
         run: dart pub global activate webdev
       - name: Get Webdev version tag
         id: version
         run: |
           echo "VERSION_TAG=$(webdev --version)" >> $GITHUB_OUTPUT
-      - name: Checkout Webdev at version tag 
+      - name: Checkout Webdev at version tag
         id: checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
         with:
@@ -41,11 +43,11 @@ jobs:
         working-directory: webdev
       # Required for Chrome headless tests on Linux:
       - name: Set up X virtual frame buffer
-        run: "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &"
+        run: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
         working-directory: webdev
       - name: Run stable tests
         id: webdev_stable_tests
-        run: "dart test test/e2e_test.dart"
+        run: dart test -j 1
         if: "always() && steps.webdev_pub_upgrade.conclusion == 'success'"
         working-directory: webdev
       - name: "Notify failure"

--- a/.github/workflows/daily_stable_testing.yml
+++ b/.github/workflows/daily_stable_testing.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: "00 14 * * *" # Everyday at 3:00 PM UTC (8:00 AM PST)
 
+env:
+  PUB_ENVIRONMENT: bot.github
+  DISPLAY: ":99"
+
 jobs:
   testing_stable:
     name: Testing Dart Stable SDK

--- a/.github/workflows/daily_stable_testing.yml
+++ b/.github/workflows/daily_stable_testing.yml
@@ -25,13 +25,13 @@ jobs:
       - name: Get Webdev version
         id: version
         run: |
-          echo "VERSION_TAG=$(webdev --version)"
+          echo "VERSION_TAG=$(webdev --version)" >> $GITHUB_OUTPUT
       - name: Checkout Webdev repository     
         id: checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Switch to release branch
         run: |
-          git checkout ${{ steps.version.outputs.VERSION_TAG }}
+          git checkout webdev-v${{ steps.version.outputs.VERSION_TAG }}
       - name: Upgrade deps
         id: webdev_pub_upgrade
         run: dart pub upgrade


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/2226

This PR adds a Github workflow to run the Webdev tests with the Dart stable SDK on a daily cron job. 

The workflow:
- Sets up the Dart stable SDK
- Runs `dart pub global activate webdev` to get the latest Webdev compatible with the stable SDK
- Gets the activated Webdev version
- Checks out the Webdev repo at the commit for that version tag
- Runs all the Webdev tests at that commit

This means that any tests added after the Webdev release was cut will not be included (so the test case added in https://github.com/dart-lang/webdev/pull/2250 won't be run as part of the stable testing until the current dev version of Webdev is the version activated for the Dart stable SDK).

Example workflow run: https://github.com/dart-lang/webdev/actions/runs/6513830745/job/17694130291

