### PR TITLE
Add dependency on `package:vm_service_interface`

### DIFF
--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -12,7 +12,8 @@ import 'package:dwds/src/services/debug_service.dart';
 import 'package:dwds/src/utilities/synchronized.dart';
 import 'package:logging/logging.dart';
 import 'package:uuid/uuid.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServerConnection;
+import 'package:vm_service_interface/vm_service_interface.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 final _logger = Logger('DwdsVmClient');

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -27,7 +27,9 @@ import 'package:dwds/src/utilities/dart_uri.dart';
 import 'package:dwds/src/utilities/shared.dart';
 import 'package:logging/logging.dart' hide LogRecord;
 import 'package:pub_semver/pub_semver.dart' as semver;
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart'
+    hide VmServiceInterface, vmServiceVersion;
+import 'package:vm_service_interface/vm_service_interface.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 /// A proxy from the chrome debug protocol to the dart vm service protocol.

--- a/dwds/lib/src/services/debug_service.dart
+++ b/dwds/lib/src/services/debug_service.dart
@@ -24,7 +24,7 @@ import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf.dart' hide Response;
 import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:sse/server/sse_handler.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service_interface/vm_service_interface.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 bool _acceptNewConnections = true;

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   built_value: ^8.3.0
   collection: ^1.15.0
   crypto: ^3.0.2
-  dds: ^2.7.1
+  dds: ^3.0.0
   file: ">=6.0.0 <8.0.0"
   http: ^0.13.4
   http_multi_server: ^3.2.0

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   sse: ^4.1.2
   uuid: ^3.0.6
   vm_service: ^12.0.0
+  vm_service_interface: 1.0.0
   web_socket_channel: ^2.2.0
   webkit_inspection_protocol: ^1.0.1
 

--- a/dwds/pubspec_overrides.yaml
+++ b/dwds/pubspec_overrides.yaml
@@ -3,3 +3,7 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/vm_service
+  vm_service_interface:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/vm_service_interface

--- a/dwds/test/build_daemon_breakpoint_test.dart
+++ b/dwds/test/build_daemon_breakpoint_test.dart
@@ -7,7 +7,8 @@
 
 import 'package:test/test.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServiceInterface;
+import 'package:vm_service_interface/vm_service_interface.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/project.dart';

--- a/dwds/test/build_daemon_callstack_test.dart
+++ b/dwds/test/build_daemon_callstack_test.dart
@@ -8,7 +8,8 @@
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServiceInterface;
+import 'package:vm_service_interface/vm_service_interface.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/project.dart';

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -18,7 +18,8 @@ import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServiceInterface;
+import 'package:vm_service_interface/vm_service_interface.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import 'fixtures/context.dart';

--- a/dwds/test/evaluate_circular_common.dart
+++ b/dwds/test/evaluate_circular_common.dart
@@ -8,7 +8,8 @@
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServiceInterface;
+import 'package:vm_service_interface/vm_service_interface.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/project.dart';

--- a/dwds/test/events_test.dart
+++ b/dwds/test/events_test.dart
@@ -11,7 +11,8 @@ import 'package:dwds/src/utilities/server.dart';
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServiceInterface;
+import 'package:vm_service_interface/vm_service_interface.dart';
 import 'package:webdriver/async_core.dart';
 
 import 'fixtures/context.dart';

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -118,7 +118,7 @@ class TestContext {
   ChromeProxyService get service => fetchChromeProxyService(debugConnection);
 
   /// External VM service.
-  VmServiceInterface get vmService => debugConnection.vmService;
+  VmService get vmService => debugConnection.vmService;
 
   TestContext(this.project, this.sdkConfigurationProvider)
       : nullSafety = project.nullSafety {

--- a/dwds/test/frontend_server_breakpoint_test.dart
+++ b/dwds/test/frontend_server_breakpoint_test.dart
@@ -8,7 +8,8 @@
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServiceInterface;
+import 'package:vm_service_interface/vm_service_interface.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/project.dart';

--- a/dwds/test/frontend_server_callstack_test.dart
+++ b/dwds/test/frontend_server_callstack_test.dart
@@ -8,7 +8,8 @@
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServiceInterface;
+import 'package:vm_service_interface/vm_service_interface.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/project.dart';

--- a/dwds/test/instances/common/instance_inspection_common.dart
+++ b/dwds/test/instances/common/instance_inspection_common.dart
@@ -23,7 +23,7 @@ void runTests({
       : TestProject.testPackageWithWeakNullSafety();
   final context = TestContext(project, provider);
 
-  late VmServiceInterface service;
+  late VmService service;
   late Stream<Event> stream;
   late String isolateId;
   late ScriptRef mainScript;

--- a/dwds/test/instances/common/patterns_inspection_common.dart
+++ b/dwds/test/instances/common/patterns_inspection_common.dart
@@ -21,7 +21,7 @@ void runTests({
       TestContext(TestProject.testExperimentWithSoundNullSafety, provider);
   final testInspector = TestInspector(context);
 
-  late VmServiceInterface service;
+  late VmService service;
   late Stream<Event> stream;
   late String isolateId;
   late ScriptRef mainScript;

--- a/dwds/test/instances/common/record_inspection_common.dart
+++ b/dwds/test/instances/common/record_inspection_common.dart
@@ -21,7 +21,7 @@ void runTests({
       TestContext(TestProject.testExperimentWithSoundNullSafety, provider);
   final testInspector = TestInspector(context);
 
-  late VmServiceInterface service;
+  late VmService service;
   late Stream<Event> stream;
   late String isolateId;
   late ScriptRef mainScript;

--- a/dwds/test/instances/common/record_type_inspection_common.dart
+++ b/dwds/test/instances/common/record_type_inspection_common.dart
@@ -21,7 +21,7 @@ void runTests({
       TestContext(TestProject.testExperimentWithSoundNullSafety, provider);
   final testInspector = TestInspector(context);
 
-  late VmServiceInterface service;
+  late VmService service;
   late Stream<Event> stream;
   late String isolateId;
   late ScriptRef mainScript;

--- a/dwds/test/instances/common/test_inspector.dart
+++ b/dwds/test/instances/common/test_inspector.dart
@@ -11,7 +11,7 @@ class TestInspector {
   TestInspector(this.context);
   TestContext context;
 
-  VmServiceInterface get service => context.debugConnection.vmService;
+  VmService get service => context.debugConnection.vmService;
 
   Future<void> onBreakPoint(
     Stream<Event> stream,

--- a/dwds/test/instances/common/type_inspection_common.dart
+++ b/dwds/test/instances/common/type_inspection_common.dart
@@ -21,7 +21,7 @@ void runTests({
   final context = TestContext(project, provider);
   final testInspector = TestInspector(context);
 
-  late VmServiceInterface service;
+  late VmService service;
   late Stream<Event> stream;
   late String isolateId;
   late ScriptRef mainScript;

--- a/dwds/test/refresh_test.dart
+++ b/dwds/test/refresh_test.dart
@@ -12,7 +12,8 @@ import 'dart:async';
 
 import 'package:test/test.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServiceInterface;
+import 'package:vm_service_interface/vm_service_interface.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/project.dart';

--- a/dwds/test/restore_breakpoints_test.dart
+++ b/dwds/test/restore_breakpoints_test.dart
@@ -9,7 +9,8 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServiceInterface;
+import 'package:vm_service_interface/vm_service_interface.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/project.dart';

--- a/dwds/test/run_request_test.dart
+++ b/dwds/test/run_request_test.dart
@@ -8,7 +8,8 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide VmServiceInterface;
+import 'package:vm_service_interface/vm_service_interface.dart';
 
 import 'fixtures/context.dart';
 import 'fixtures/project.dart';

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 3.2.0-wip
 
-- Add dependency on `package:vm_service_interface`.
+- Add dependency on `package:vm_service_interface`. - [#2262](https://github.com/dart-lang/webdev/pull/2262)
 
 ## 3.1.0
 
-- Update the parameters passed to `Dwds.start`. - [#2231](https://github.com/dart-lang/webdev/pull/2231).
+- Update the parameters passed to `Dwds.start`. - [#2231](https://github.com/dart-lang/webdev/pull/2231)
 - Update `package:vm_service` constraint to `>=10.1.0 <13.0.0`. - [#2248](https://github.com/dart-lang/webdev/pull/2248)
 - Update `dwds` constraint to `21.0.0`.
 

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.2.0-wip
 
+- Add dependency on `package:vm_service_interface`.
+
 ## 3.1.0
 
 - Update the parameters passed to `Dwds.start`. - [#2231](https://github.com/dart-lang/webdev/pull/2231).

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   browser_launcher: ^1.1.0
   collection: ^1.15.0
   crypto: ^3.0.2
-  dds: ^2.2.0
+  dds: ^3.0.0
   # Pin DWDS to avoid dependency conflicts with vm_service:
   dwds: 22.0.0
   http: ^0.13.4


### PR DESCRIPTION
Since `package:vm_service` is still `^12.0.0`, imports of `vm_service` have been modified to hide duplicate symbols that are now surfaced via `package:vm_service_interface`.