### PR TITLE
Expose a keyboard shortcut to copy the Dart app ID

### DIFF
--- a/dwds/debug_extension_mv3/web/background.dart
+++ b/dwds/debug_extension_mv3/web/background.dart
@@ -5,8 +5,6 @@
 @JS()
 library background;
 
-import 'dart:js_util';
-
 import 'package:dwds/data/debug_info.dart';
 import 'package:js/js.dart';
 

--- a/dwds/debug_extension_mv3/web/background.dart
+++ b/dwds/debug_extension_mv3/web/background.dart
@@ -53,6 +53,8 @@ void _registerListeners() {
   chrome.webNavigation.onCommitted
       .addListener(allowInterop(_detectNavigationAwayFromDartApp));
 
+  chrome.commands.onCommand.addListener(allowInterop(_maybeCopyAppId));
+
   // Detect clicks on the Dart Debug Extension icon.
   onExtensionIconClicked(
     allowInterop(
@@ -204,6 +206,15 @@ DebugInfo _addTabInfo(DebugInfo debugInfo, {required Tab tab}) {
       ..tabUrl = tab.url
       ..tabId = tab.id,
   );
+}
+
+Future<void> _maybeCopyAppId(String command, [Tab? tab]) async {
+  final currentTab = tab ?? await activeTab;
+  if (currentTab == null) return;
+  final debugInfo = await _fetchDebugInfo(currentTab.id);
+  final workspaceName = debugInfo?.workspaceName;
+  if (workspaceName == null) return;
+  // Send message to the copier.
 }
 
 Future<void> _updateIcon(int activeTabId) async {

--- a/dwds/debug_extension_mv3/web/background.dart
+++ b/dwds/debug_extension_mv3/web/background.dart
@@ -55,7 +55,6 @@ void _registerListeners() {
   chrome.webNavigation.onCommitted
       .addListener(allowInterop(_detectNavigationAwayFromDartApp));
 
-  debugLog('listening for commands...');
   chrome.commands.onCommand
       .addListener(allowInterop(_maybeSendCopyAppIdRequest));
 
@@ -73,7 +72,6 @@ void _registerListeners() {
 Future<void> _handleRuntimeMessages(
   dynamic jsRequest,
   MessageSender sender,
-  // ignore: avoid-unused-parameters
   Function sendResponse,
 ) async {
   if (jsRequest is! String) return;
@@ -162,9 +160,7 @@ Future<void> _handleRuntimeMessages(
     },
   );
 
-  final response = {'response': 'received'};
-  debugLog('sending back response');
-  sendResponse(jsify(response));
+  sendResponse(defaultResponse);
 }
 
 Future<void> _detectNavigationAwayFromDartApp(
@@ -217,13 +213,12 @@ DebugInfo _addTabInfo(DebugInfo debugInfo, {required Tab tab}) {
 }
 
 Future<bool> _maybeSendCopyAppIdRequest(String command, [Tab? tab]) async {
-  debugLog('==== Received $command command');
   if (command != 'copyAppId') return false;
   final tabId = (tab ?? await activeTab)?.id;
   if (tabId == null) return false;
   final debugInfo = await _fetchDebugInfo(tabId);
-  final workspaceName = debugInfo?.workspaceName ?? 'fake-workspace';
-  // if (workspaceName == null) return false;
+  final workspaceName = debugInfo?.workspaceName;
+  if (workspaceName == null) return false;
   final appId = '$workspaceName-$tabId';
   return sendTabsMessage(
     tabId: tabId,

--- a/dwds/debug_extension_mv3/web/background.dart
+++ b/dwds/debug_extension_mv3/web/background.dart
@@ -5,6 +5,8 @@
 @JS()
 library background;
 
+import 'dart:js_util';
+
 import 'package:dwds/data/debug_info.dart';
 import 'package:js/js.dart';
 
@@ -159,6 +161,10 @@ Future<void> _handleRuntimeMessages(
       _setWarningIcon();
     },
   );
+
+  final response = {'response': 'received'};
+  debugLog('sending back response');
+  sendResponse(jsify(response));
 }
 
 Future<void> _detectNavigationAwayFromDartApp(
@@ -216,8 +222,8 @@ Future<bool> _maybeSendCopyAppIdRequest(String command, [Tab? tab]) async {
   final tabId = (tab ?? await activeTab)?.id;
   if (tabId == null) return false;
   final debugInfo = await _fetchDebugInfo(tabId);
-  final workspaceName = debugInfo?.workspaceName;
-  if (workspaceName == null) return false;
+  final workspaceName = debugInfo?.workspaceName ?? 'fake-workspace';
+  // if (workspaceName == null) return false;
   final appId = '$workspaceName-$tabId';
   return sendTabsMessage(
     tabId: tabId,

--- a/dwds/debug_extension_mv3/web/chrome_api.dart
+++ b/dwds/debug_extension_mv3/web/chrome_api.dart
@@ -314,6 +314,13 @@ class Tabs {
 
   external dynamic remove(int tabId, void Function()? callback);
 
+  external Object sendMessage(
+    int tabId,
+    Object? message,
+    Object? options,
+    void Function() callback,
+  );
+
   external OnActivatedHandler get onActivated;
 
   external OnRemovedHandler get onRemoved;

--- a/dwds/debug_extension_mv3/web/chrome_api.dart
+++ b/dwds/debug_extension_mv3/web/chrome_api.dart
@@ -12,6 +12,7 @@ external Chrome get chrome;
 @JS()
 @anonymous
 class Chrome {
+  external Commands get commands;
   external Debugger get debugger;
   external Devtools get devtools;
   external Notifications get notifications;
@@ -24,6 +25,20 @@ class Chrome {
 
 /// chrome.debugger APIs:
 /// https://developer.chrome.com/docs/extensions/reference/debugger
+
+@JS()
+@anonymous
+class Commands {
+  external OnCommandHandler get onCommand;
+}
+
+@JS()
+@anonymous
+class OnCommandHandler {
+  external void addListener(
+    void Function(String commandName, [Tab? tab]) callback,
+  );
+}
 
 @JS()
 @anonymous

--- a/dwds/debug_extension_mv3/web/chrome_api.dart
+++ b/dwds/debug_extension_mv3/web/chrome_api.dart
@@ -243,7 +243,7 @@ class ConnectionHandler {
 @anonymous
 class OnMessageHandler {
   external void addListener(
-    void Function(dynamic, MessageSender, Function) callback,
+    dynamic Function(dynamic, MessageSender, Function) callback,
   );
 }
 

--- a/dwds/debug_extension_mv3/web/copier.dart
+++ b/dwds/debug_extension_mv3/web/copier.dart
@@ -21,6 +21,7 @@ void _registerListeners() {
     allowInterop(_handleRuntimeMessages),
   );
 }
+
 void _handleRuntimeMessages(
   dynamic jsRequest,
   MessageSender sender,

--- a/dwds/debug_extension_mv3/web/copier.dart
+++ b/dwds/debug_extension_mv3/web/copier.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@JS()
+library copier;
+
+import 'dart:html';
+
+import 'package:js/js.dart';
+
+void main() {
+  _registerListeners();
+}
+
+void _registerListeners() {}
+
+void _copyAppId(String appId) {
+  final clipboard = window.navigator.clipboard;
+  if (clipboard == null) return;
+  clipboard.writeText(appId);
+  _showCopiedMessage(appId);
+}
+
+void _showCopiedMessage(String appId) {}

--- a/dwds/debug_extension_mv3/web/copier.dart
+++ b/dwds/debug_extension_mv3/web/copier.dart
@@ -6,7 +6,6 @@
 library copier;
 
 import 'dart:html';
-import 'dart:js_util';
 
 import 'package:js/js.dart';
 
@@ -35,8 +34,7 @@ void _handleRuntimeMessages(
     messageHandler: _copyAppId,
   );
 
-  final response = {'response': 'received'};
-  sendResponse(jsify(response));
+  sendResponse(defaultResponse);
 }
 
 void _copyAppId(String appId) {

--- a/dwds/debug_extension_mv3/web/copier.dart
+++ b/dwds/debug_extension_mv3/web/copier.dart
@@ -6,10 +6,12 @@
 library copier;
 
 import 'dart:html';
+import 'dart:js_util';
 
 import 'package:js/js.dart';
 
 import 'chrome_api.dart';
+import 'logger.dart';
 import 'messaging.dart';
 
 void main() {
@@ -21,7 +23,6 @@ void _registerListeners() {
     allowInterop(_handleRuntimeMessages),
   );
 }
-
 void _handleRuntimeMessages(
   dynamic jsRequest,
   MessageSender sender,
@@ -35,19 +36,26 @@ void _handleRuntimeMessages(
     expectedRecipient: Script.copier,
     messageHandler: _copyAppId,
   );
+
+  final response = {'response': 'received'};
+  debugLog('sending back response');
+  sendResponse(jsify(response));
 }
 
 void _copyAppId(String appId) {
+  debugLog('RECEIVED $appId');
   final clipboard = window.navigator.clipboard;
+  debugLog('CLIPBOARD IS $clipboard');
   if (clipboard == null) return;
   clipboard.writeText(appId);
+  debugLog('WROTE TEXT');
   _showCopiedMessage(appId);
 }
 
 Future<void> _showCopiedMessage(String appId) async {
   final snackbar = document.createElement('div');
   snackbar.setInnerHtml('Copied $appId!');
-  snackbar.classes.add('snackbar snackbar--info show');
+  snackbar.classes.addAll(['snackbar', 'snackbar--info', 'show']);
   document.body?.append(snackbar);
   await Future.delayed(Duration(seconds: 2));
   snackbar.remove();

--- a/dwds/debug_extension_mv3/web/copier.dart
+++ b/dwds/debug_extension_mv3/web/copier.dart
@@ -11,7 +11,6 @@ import 'dart:js_util';
 import 'package:js/js.dart';
 
 import 'chrome_api.dart';
-import 'logger.dart';
 import 'messaging.dart';
 
 void main() {
@@ -26,7 +25,6 @@ void _registerListeners() {
 void _handleRuntimeMessages(
   dynamic jsRequest,
   MessageSender sender,
-  // ignore: avoid-unused-parameters
   Function sendResponse,
 ) {
   interceptMessage<String>(
@@ -38,25 +36,21 @@ void _handleRuntimeMessages(
   );
 
   final response = {'response': 'received'};
-  debugLog('sending back response');
   sendResponse(jsify(response));
 }
 
 void _copyAppId(String appId) {
-  debugLog('RECEIVED $appId');
   final clipboard = window.navigator.clipboard;
-  debugLog('CLIPBOARD IS $clipboard');
   if (clipboard == null) return;
   clipboard.writeText(appId);
-  debugLog('WROTE TEXT');
   _showCopiedMessage(appId);
 }
 
 Future<void> _showCopiedMessage(String appId) async {
   final snackbar = document.createElement('div');
-  snackbar.setInnerHtml('Copied $appId!');
+  snackbar.setInnerHtml('Copied app ID: <i>$appId</i>');
   snackbar.classes.addAll(['snackbar', 'snackbar--info', 'show']);
   document.body?.append(snackbar);
-  await Future.delayed(Duration(seconds: 2));
+  await Future.delayed(Duration(seconds: 4));
   snackbar.remove();
 }

--- a/dwds/debug_extension_mv3/web/manifest_mv2.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv2.json
@@ -32,10 +32,10 @@
   "commands": {
     "copyAppId": {
       "suggestedKey": {
-        "default": "Alt+D",
-        "mac": "Option+D"
+        "default": "Ctrl+Shift+7",
+        "mac": "Command+Shift+7"
       },
-      "description": "Copies the app ID to the clipboard."
+      "description": "Copy the app ID"
     }
   },
   "web_accessible_resources": ["debug_info.dart.js"],

--- a/dwds/debug_extension_mv3/web/manifest_mv2.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv2.json
@@ -24,7 +24,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["detector.dart.js"],
+      "js": ["detector.dart.js", "copier.dart.js"],
       "run_at": "document_end"
     }
   ],

--- a/dwds/debug_extension_mv3/web/manifest_mv2.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv2.json
@@ -28,6 +28,15 @@
       "run_at": "document_end"
     }
   ],
+  "commands": {
+    "copyAppId": {
+      "suggestedKey": {
+        "default": "Alt+D",
+        "mac": "Option+D"
+      },
+      "description": "Copies the app ID to the clipboard."
+    }
+  },
   "web_accessible_resources": ["debug_info.dart.js"],
   "options_page": "static_assets/settings.html"
 }

--- a/dwds/debug_extension_mv3/web/manifest_mv2.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv2.json
@@ -25,6 +25,7 @@
     {
       "matches": ["<all_urls>"],
       "js": ["detector.dart.js", "copier.dart.js"],
+      "css": ["static_assets/styles.css"],
       "run_at": "document_end"
     }
   ],

--- a/dwds/debug_extension_mv3/web/manifest_mv3.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv3.json
@@ -31,10 +31,20 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["detector.dart.js"],
+      "js": ["detector.dart.js", "copier.dart.js"],
+      "css": ["static_assets/styles.css"],
       "run_at": "document_end"
     }
   ],
+  "commands": {
+    "copyAppId": {
+      "suggestedKey": {
+        "default": "Ctrl+Shift+7",
+        "mac": "Command+Shift+7"
+      },
+      "description": "Copy the app ID"
+    }
+  },
   "web_accessible_resources": [
     {
       "matches": ["<all_urls>"],

--- a/dwds/debug_extension_mv3/web/messaging.dart
+++ b/dwds/debug_extension_mv3/web/messaging.dart
@@ -157,7 +157,7 @@ Future<bool> _sendMessage({
     body: body,
   ).toJSON();
   final completer = Completer<bool>();
-  final responseHandler = ([dynamic response]) {
+  void responseHandler([dynamic _]) {
     final error = chrome.runtime.lastError;
     if (error != null) {
       debugError(
@@ -165,7 +165,7 @@ Future<bool> _sendMessage({
       );
     }
     completer.complete(error != null);
-  };
+  }
   if (tabId != null) {
     chrome.tabs.sendMessage(
       tabId,

--- a/dwds/debug_extension_mv3/web/messaging.dart
+++ b/dwds/debug_extension_mv3/web/messaging.dart
@@ -7,12 +7,19 @@ library messaging;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:js_util';
 
 import 'package:js/js.dart';
 
 import 'chrome_api.dart';
 import 'data_serializers.dart';
 import 'logger.dart';
+
+// A default response to for the sendResponse callback.
+//
+// Prevents the message port from closing. See:
+// https://developer.chrome.com/docs/extensions/mv3/messaging/#simple
+final defaultResponse = jsify({'response': 'received'});
 
 enum Script {
   background,
@@ -153,7 +160,6 @@ Future<bool> sendTabsMessage({
     body: body,
   );
   final completer = Completer<bool>();
-  debugLog('sending tabs message');
   chrome.tabs.sendMessage(
     tabId,
     message.toJSON(),

--- a/dwds/debug_extension_mv3/web/messaging.dart
+++ b/dwds/debug_extension_mv3/web/messaging.dart
@@ -125,7 +125,7 @@ Future<bool> sendRuntimeMessage({
     message.toJSON(),
     // options
     null,
-    allowInterop(() {
+    allowInterop(([dynamic response]) {
       final error = chrome.runtime.lastError;
       if (error != null) {
         debugError(
@@ -158,7 +158,7 @@ Future<bool> sendTabsMessage({
     tabId,
     message.toJSON(),
     null,
-    allowInterop(() {
+    allowInterop(([dynamic response]) {
       final error = chrome.runtime.lastError;
       if (error != null) {
         debugError(

--- a/dwds/debug_extension_mv3/web/messaging.dart
+++ b/dwds/debug_extension_mv3/web/messaging.dart
@@ -15,7 +15,7 @@ import 'chrome_api.dart';
 import 'data_serializers.dart';
 import 'logger.dart';
 
-// A default response to for the sendResponse callback.
+// A default response for the sendResponse callback.
 //
 // Prevents the message port from closing. See:
 // https://developer.chrome.com/docs/extensions/mv3/messaging/#simple
@@ -166,6 +166,7 @@ Future<bool> _sendMessage({
     }
     completer.complete(error != null);
   }
+
   if (tabId != null) {
     chrome.tabs.sendMessage(
       tabId,

--- a/dwds/debug_extension_mv3/web/messaging.dart
+++ b/dwds/debug_extension_mv3/web/messaging.dart
@@ -16,6 +16,7 @@ import 'logger.dart';
 
 enum Script {
   background,
+  copier,
   debuggerPanel,
   detector;
 
@@ -27,6 +28,7 @@ enum Script {
 enum MessageType {
   isAuthenticated,
   connectFailure,
+  appId,
   debugInfo,
   debugStateChange,
   devToolsUrl,
@@ -122,6 +124,39 @@ Future<bool> sendRuntimeMessage({
     null,
     message.toJSON(),
     // options
+    null,
+    allowInterop(() {
+      final error = chrome.runtime.lastError;
+      if (error != null) {
+        debugError(
+          'Error sending $type to $recipient from $sender: ${error.message}',
+        );
+      }
+      completer.complete(error != null);
+    }),
+  );
+  return completer.future;
+}
+
+/// Send a message using the chrome.tabs.sendMessage API.
+Future<bool> sendTabsMessage({
+  required int tabId,
+  required MessageType type,
+  required String body,
+  required Script sender,
+  required Script recipient,
+}) {
+  final message = Message(
+    to: recipient,
+    from: sender,
+    type: type,
+    body: body,
+  );
+  final completer = Completer<bool>();
+  debugLog('sending tabs message');
+  chrome.tabs.sendMessage(
+    tabId,
+    message.toJSON(),
     null,
     allowInterop(() {
       final error = chrome.runtime.lastError;

--- a/dwds/debug_extension_mv3/web/static_assets/styles.css
+++ b/dwds/debug_extension_mv3/web/static_assets/styles.css
@@ -57,16 +57,16 @@ iframe {
 }
 
 .debugger-card > .mdl-card__title {
+  background: url("debugger_settings.png");
   background-position: center;
   background-repeat: no-repeat;
-  background: url("debugger_settings.png");
   height: 200px;
 }
 
 .inspector-card > .mdl-card__title {
+  background: url("inspect_widget.png");
   background-position: center;
   background-repeat: no-repeat;
-  background: url("inspect_widget.png");
   height: 300px;
 }
 
@@ -75,11 +75,13 @@ h6 {
 }
 
 .snackbar {
-  border-radius: 2px;
   bottom: 0px;
   color: #eeeeee;
+  font-family:  Roboto, 'Helvetica Neue', sans-serif;
+  left: 0px;
   padding: 16px;
   position: fixed;
+  right: 0px;
   text-align: center;
   visibility: hidden;
   width: 100%;
@@ -87,8 +89,8 @@ h6 {
 }
 
 .snackbar > a {
-  font-weight: bold;
   color: #eeeeee;
+  font-weight: bold;
 }
 
 .snackbar--info {


### PR DESCRIPTION
Work towards https://github.com/dart-lang/webdev/issues/2198

Expose a keyboard shortcut to copy the Dart app's ID. When copied, shows a banner at the bottom of the page notifying the user that the app ID has been copied. 

![Screenshot 2023-10-27 at 9 58 45 AM](https://github.com/dart-lang/webdev/assets/21270878/24c44462-1e85-4501-8279-9f05e327a972).
