### PR TITLE
Remove old code from before the new Dart Debug Extension

### DIFF
--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -626,7 +626,7 @@ class DevHandler {
     );
 
     emitEvent(DwdsEvent.devtoolsLaunch());
-    // Send the DevTools URI to the Dart Debug Extension so that if can open it:
+    // Send the DevTools URI to the Dart Debug Extension so that it can open it:
     final devToolsUri = _constructDevToolsUri(
       encodedUri,
       ideQueryParam: 'ChromeDevTools',

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -625,27 +625,13 @@ class DevHandler {
       devToolsStart: DateTime.now(),
     );
 
-    // TODO(elliette): Remove handling requests from the MV2 extension after
-    // MV3 release.
-    // If we only want the URI, this means the Dart Debug Extension should
-    // handle how to open it. Therefore return early before opening a new
-    // tab or window:
-    if (devToolsRequest.uriOnly ?? false) {
-      final devToolsUri = _constructDevToolsUri(
-        encodedUri,
-        ideQueryParam: 'ChromeDevTools',
-      );
-      return extensionDebugger.sendEvent('dwds.devtoolsUri', devToolsUri);
-    }
-
-    // Otherwise, launch DevTools in a new tab / window:
-    await _launchDevTools(
-      extensionDebugger,
-      _constructDevToolsUri(
-        encodedUri,
-        ideQueryParam: 'DebugExtension',
-      ),
+    emitEvent(DwdsEvent.devtoolsLaunch());
+    // Send the DevTools URI to the Dart Debug Extension so that if can open it:
+    final devToolsUri = _constructDevToolsUri(
+      encodedUri,
+      ideQueryParam: 'ChromeDevTools',
     );
+    return extensionDebugger.sendEvent('dwds.devtoolsUri', devToolsUri);
   }
 
   DevTools _ensureDevTools() {


### PR DESCRIPTION
- removes no longer necessary code
- makes sure that the "launch devtools" event is sent when the debug extension starts debugging
