### PR TITLE
Updating the legacy loader to use the new DDC module loader API

### DIFF
--- a/dwds/lib/src/loaders/legacy.dart
+++ b/dwds/lib/src/loaders/legacy.dart
@@ -180,7 +180,11 @@ class LegacyStrategy extends LoadStrategy {
     return '''
 $_baseUrlScript
 var scripts = ${const JsonEncoder.withIndent(" ").convert(scripts)};
-window.\$dartLoader.loadScripts(scripts);
+window.\$dartLoader.loadConfig.loadScriptFn = function(loader) {
+  loader.addScriptsToQueue(scripts, null);
+  loader.loadEnqueuedModules();
+};
+window.\$dartLoader.loader.nextAttempt();
 ''';
   }
 


### PR DESCRIPTION
A small patch to the LegacyStrategy.

See the new API here (though in-review internally): https://dart-review.googlesource.com/c/sdk/+/338422

This is part of a greater effort to deprecate the AMD module system: https://github.com/dart-lang/sdk/issues/52361