### PR TITLE
Remove unused scripting code and permission

### DIFF
--- a/dwds/debug_extension_mv3/web/manifest_mv3.json
+++ b/dwds/debug_extension_mv3/web/manifest_mv3.json
@@ -17,13 +17,7 @@
       "https://cider-v-test.corp.google.com/*"
     ]
   },
-  "permissions": [
-    "debugger",
-    "notifications",
-    "scripting",
-    "storage",
-    "webNavigation"
-  ],
+  "permissions": ["debugger", "notifications", "storage", "webNavigation"],
   "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.dart.js"

--- a/dwds/debug_extension_mv3/web/utils.dart
+++ b/dwds/debug_extension_mv3/web/utils.dart
@@ -88,23 +88,6 @@ void displayNotification(
   );
 }
 
-Future<bool> injectScript(String scriptName, {required int tabId}) async {
-  if (isMV3) {
-    await promiseToFuture(
-      _executeScriptMV3(
-        _InjectDetails(
-          target: Target(tabId: tabId),
-          files: [scriptName],
-        ),
-      ),
-    );
-    return true;
-  } else {
-    debugWarn('Script injection is only supported in Manifest V3.');
-    return false;
-  }
-}
-
 void onExtensionIconClicked(void Function(Tab) callback) {
   if (isMV3) {
     _onExtensionIconClickedMV3(callback);
@@ -188,18 +171,4 @@ external void _setExtensionIconMV3(IconInfo iconInfo, Function? callback);
 class IconInfo {
   external String get path;
   external factory IconInfo({required String path});
-}
-
-@JS('chrome.scripting.executeScript')
-external Object _executeScriptMV3(_InjectDetails details);
-
-@JS()
-@anonymous
-class _InjectDetails {
-  external Target get target;
-  external List<String>? get files;
-  external factory _InjectDetails({
-    Target target,
-    List<String>? files,
-  });
 }


### PR DESCRIPTION
Follow up to https://github.com/dart-lang/webdev/pull/2293

We can also delete the scripting code (which is no longer used) and therefore remove the unnecessary `scripting` permission from the manifest.