### PR TITLE
Fix TestSdkConfigurationProvider.dispose

### DIFF
--- a/test_common/lib/test_sdk_configuration.dart
+++ b/test_common/lib/test_sdk_configuration.dart
@@ -80,7 +80,9 @@ class TestSdkConfigurationProvider extends SdkConfigurationProvider {
       }
     } catch (e, s) {
       _logger.warning('Failed delete SDK directory copy', e, s);
-      dispose(retry: false);
+      if (retry) {
+        dispose(retry: false);
+      }
     }
   }
 }


### PR DESCRIPTION
CI was hanging on my PR (https://github.com/dart-lang/webdev/actions/runs/7224561961/job/19690368821?pr=2307) and it looks like this change will fix it.