### PR TITLE
Prepare a hotfix release of DWDS 21.0.0+1

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -460,150 +460,6 @@ jobs:
       - job_003
       - job_004
   job_012:
-    name: "unit_test; linux; Dart main; PKG: dwds; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test --tags=extension`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds;commands:command-test_1"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds
-            os:ubuntu-latest;pub-cache-hosted;sdk:main
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: main
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - id: dwds_pub_upgrade
-        name: dwds; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: dwds
-      - name: "dwds; Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &"
-        run: "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &"
-        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
-        working-directory: dwds
-      - name: "dwds; dart test --tags=extension"
-        run: "dart test --tags=extension"
-        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
-        working-directory: dwds
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_013:
-    name: "unit_test; linux; Dart main; PKG: dwds; `dart test --total-shards 3 --shard-index 0 --exclude-tags=extension`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds;commands:test_2"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds
-            os:ubuntu-latest;pub-cache-hosted;sdk:main
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: main
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - id: dwds_pub_upgrade
-        name: dwds; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: dwds
-      - name: "dwds; dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
-        working-directory: dwds
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_014:
-    name: "unit_test; linux; Dart main; PKG: dwds; `dart test --total-shards 3 --shard-index 1 --exclude-tags=extension`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds;commands:test_3"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds
-            os:ubuntu-latest;pub-cache-hosted;sdk:main
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: main
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - id: dwds_pub_upgrade
-        name: dwds; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: dwds
-      - name: "dwds; dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
-        working-directory: dwds
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_015:
-    name: "unit_test; linux; Dart main; PKG: dwds; `dart test --total-shards 3 --shard-index 2 --exclude-tags=extension`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds;commands:test_4"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds
-            os:ubuntu-latest;pub-cache-hosted;sdk:main
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: main
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - id: dwds_pub_upgrade
-        name: dwds; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: dwds
-      - name: "dwds; dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
-        working-directory: dwds
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_016:
     name: "unit_test; linux; Dart main; PKG: frontend_server_client; `dart test -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -638,7 +494,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_017:
+  job_013:
     name: "unit_test; linux; Dart main; PKG: test_common; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test --exclude-tags=release`"
     runs-on: ubuntu-latest
     steps:
@@ -677,7 +533,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_018:
+  job_014:
     name: "unit_test; windows; Dart dev; PKG: dwds; `dart test --tags=extension`"
     runs-on: windows-latest
     steps:
@@ -702,7 +558,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_019:
+  job_015:
     name: "unit_test; windows; Dart dev; PKG: dwds; `dart test --total-shards 3 --shard-index 0 --exclude-tags=extension`"
     runs-on: windows-latest
     steps:
@@ -727,7 +583,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_020:
+  job_016:
     name: "unit_test; windows; Dart dev; PKG: dwds; `dart test --total-shards 3 --shard-index 1 --exclude-tags=extension`"
     runs-on: windows-latest
     steps:
@@ -752,7 +608,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_021:
+  job_017:
     name: "unit_test; windows; Dart dev; PKG: dwds; `dart test --total-shards 3 --shard-index 2 --exclude-tags=extension`"
     runs-on: windows-latest
     steps:
@@ -777,7 +633,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_022:
+  job_018:
     name: "unit_test; windows; Dart dev; PKG: frontend_server_client; `dart test -j 1`"
     runs-on: windows-latest
     steps:
@@ -802,7 +658,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_023:
+  job_019:
     name: "unit_test; windows; Dart dev; PKG: webdev; `dart test -j 1`"
     runs-on: windows-latest
     steps:
@@ -827,7 +683,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_024:
+  job_020:
     name: "unit_test; windows; Dart dev; PKG: test_common; `dart test --exclude-tags=release`"
     runs-on: windows-latest
     steps:
@@ -852,107 +708,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_025:
-    name: "unit_test; windows; Dart main; PKG: dwds; `dart test --tags=extension`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: main
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - id: dwds_pub_upgrade
-        name: dwds; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: dwds
-      - name: "dwds; dart test --tags=extension"
-        run: "dart test --tags=extension"
-        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
-        working-directory: dwds
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_026:
-    name: "unit_test; windows; Dart main; PKG: dwds; `dart test --total-shards 3 --shard-index 0 --exclude-tags=extension`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: main
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - id: dwds_pub_upgrade
-        name: dwds; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: dwds
-      - name: "dwds; dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
-        working-directory: dwds
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_027:
-    name: "unit_test; windows; Dart main; PKG: dwds; `dart test --total-shards 3 --shard-index 1 --exclude-tags=extension`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: main
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - id: dwds_pub_upgrade
-        name: dwds; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: dwds
-      - name: "dwds; dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
-        working-directory: dwds
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_028:
-    name: "unit_test; windows; Dart main; PKG: dwds; `dart test --total-shards 3 --shard-index 2 --exclude-tags=extension`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: main
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - id: dwds_pub_upgrade
-        name: dwds; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: dwds
-      - name: "dwds; dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
-        working-directory: dwds
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_029:
+  job_021:
     name: "unit_test; windows; Dart main; PKG: frontend_server_client; `dart test -j 1`"
     runs-on: windows-latest
     steps:
@@ -977,7 +733,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_030:
+  job_022:
     name: "unit_test; windows; Dart main; PKG: test_common; `dart test --exclude-tags=release`"
     runs-on: windows-latest
     steps:
@@ -1002,7 +758,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_031:
+  job_023:
     name: "beta_cron; linux; Dart beta; PKG: dwds; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test -j 1`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -1060,15 +816,7 @@ jobs:
       - job_020
       - job_021
       - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-      - job_030
-  job_032:
+  job_024:
     name: "beta_cron; linux; Dart beta; PKG: webdev; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test -j 1`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -1126,15 +874,7 @@ jobs:
       - job_020
       - job_021
       - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-      - job_030
-  job_033:
+  job_025:
     name: "beta_cron; linux; Dart beta; PKG: dwds; `dart analyze .`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -1188,15 +928,7 @@ jobs:
       - job_020
       - job_021
       - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-      - job_030
-  job_034:
+  job_026:
     name: "beta_cron; linux; Dart beta; PKG: webdev; `dart analyze .`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -1250,15 +982,7 @@ jobs:
       - job_020
       - job_021
       - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-      - job_030
-  job_035:
+  job_027:
     name: "beta_cron; windows; Dart beta; PKG: dwds; `dart test -j 1`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
@@ -1302,15 +1026,7 @@ jobs:
       - job_020
       - job_021
       - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-      - job_030
-  job_036:
+  job_028:
     name: "beta_cron; windows; Dart beta; PKG: webdev; `dart test -j 1`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
@@ -1354,15 +1070,7 @@ jobs:
       - job_020
       - job_021
       - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-      - job_030
-  job_037:
+  job_029:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -1402,11 +1110,3 @@ jobs:
       - job_026
       - job_027
       - job_028
-      - job_029
-      - job_030
-      - job_031
-      - job_032
-      - job_033
-      - job_034
-      - job_035
-      - job_036

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.5.7
+# Created with package:mono_repo v6.5.3
 name: Dart CI
 on:
   push:
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable"
@@ -30,14 +30,14 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: stable
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.5.7
+        run: dart pub global activate mono_repo 6.5.3
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:dwds;commands:format-analyze_0-test_0"
@@ -55,12 +55,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:example-fixtures/_webdevSoundSmoke-frontend_server_client-frontend_server_common-test_common;commands:format-analyze_0"
@@ -93,12 +93,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: example_pub_upgrade
         name: example; dart pub upgrade
         run: dart pub upgrade
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:webdev;commands:format-analyze_0-test_7"
@@ -179,12 +179,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: webdev_pub_upgrade
         name: webdev; dart pub upgrade
         run: dart pub upgrade
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:dwds;commands:command-test_1"
@@ -217,12 +217,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -246,7 +246,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:dwds;commands:test_2"
@@ -256,12 +256,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:dwds;commands:test_3"
@@ -291,12 +291,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -316,7 +316,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:dwds;commands:test_4"
@@ -326,12 +326,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -351,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:frontend_server_client;commands:test_5"
@@ -361,12 +361,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: frontend_server_client_pub_upgrade
         name: frontend_server_client; dart pub upgrade
         run: dart pub upgrade
@@ -386,7 +386,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:test_common;commands:command-test_6"
@@ -396,12 +396,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: test_common_pub_upgrade
         name: test_common; dart pub upgrade
         run: dart pub upgrade
@@ -425,7 +425,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:webdev;commands:command-test_5"
@@ -435,12 +435,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: webdev_pub_upgrade
         name: webdev; dart pub upgrade
         run: dart pub upgrade
@@ -464,7 +464,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds;commands:command-test_1"
@@ -474,12 +474,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -503,7 +503,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds;commands:test_2"
@@ -513,12 +513,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -538,7 +538,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds;commands:test_3"
@@ -548,12 +548,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -573,7 +573,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:dwds;commands:test_4"
@@ -583,12 +583,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -608,7 +608,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:frontend_server_client;commands:test_5"
@@ -618,12 +618,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: frontend_server_client_pub_upgrade
         name: frontend_server_client; dart pub upgrade
         run: dart pub upgrade
@@ -643,7 +643,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:test_common;commands:command-test_6"
@@ -653,12 +653,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: test_common_pub_upgrade
         name: test_common; dart pub upgrade
         run: dart pub upgrade
@@ -682,7 +682,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:webdev;commands:command-test_5"
@@ -692,12 +692,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: webdev_pub_upgrade
         name: webdev; dart pub upgrade
         run: dart pub upgrade
@@ -721,12 +721,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -746,12 +746,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -771,12 +771,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -796,12 +796,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -821,12 +821,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: frontend_server_client_pub_upgrade
         name: frontend_server_client; dart pub upgrade
         run: dart pub upgrade
@@ -846,12 +846,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: webdev_pub_upgrade
         name: webdev; dart pub upgrade
         run: dart pub upgrade
@@ -871,12 +871,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: test_common_pub_upgrade
         name: test_common; dart pub upgrade
         run: dart pub upgrade
@@ -896,12 +896,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -921,12 +921,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -946,12 +946,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -971,12 +971,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -996,12 +996,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: frontend_server_client_pub_upgrade
         name: frontend_server_client; dart pub upgrade
         run: dart pub upgrade
@@ -1021,12 +1021,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: webdev_pub_upgrade
         name: webdev; dart pub upgrade
         run: dart pub upgrade
@@ -1046,12 +1046,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: main
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: test_common_pub_upgrade
         name: test_common; dart pub upgrade
         run: dart pub upgrade
@@ -1072,7 +1072,7 @@ jobs:
     if: "github.event_name == 'schedule'"
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:dwds;commands:command-test_5"
@@ -1082,12 +1082,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: beta
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -1140,7 +1140,7 @@ jobs:
     if: "github.event_name == 'schedule'"
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:webdev;commands:command-test_5"
@@ -1150,12 +1150,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: beta
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: webdev_pub_upgrade
         name: webdev; dart pub upgrade
         run: dart pub upgrade
@@ -1208,7 +1208,7 @@ jobs:
     if: "github.event_name == 'schedule'"
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:dwds;commands:analyze_1"
@@ -1218,12 +1218,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: beta
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -1272,7 +1272,7 @@ jobs:
     if: "github.event_name == 'schedule'"
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:beta;packages:webdev;commands:analyze_1"
@@ -1282,12 +1282,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: beta
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: webdev_pub_upgrade
         name: webdev; dart pub upgrade
         run: dart pub upgrade
@@ -1336,12 +1336,12 @@ jobs:
     if: "github.event_name == 'schedule'"
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: beta
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: dwds_pub_upgrade
         name: dwds; dart pub upgrade
         run: dart pub upgrade
@@ -1390,12 +1390,12 @@ jobs:
     if: "github.event_name == 'schedule'"
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: beta
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - id: webdev_pub_upgrade
         name: webdev; dart pub upgrade
         run: dart pub upgrade

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -678,45 +678,6 @@ jobs:
       - job_003
       - job_004
   job_018:
-    name: "unit_test; linux; Dart main; PKG: webdev; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test -j 1`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:webdev;commands:command-test_5"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:webdev
-            os:ubuntu-latest;pub-cache-hosted;sdk:main
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: main
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - id: webdev_pub_upgrade
-        name: webdev; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: webdev
-      - name: "webdev; Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &"
-        run: "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &"
-        if: "always() && steps.webdev_pub_upgrade.conclusion == 'success'"
-        working-directory: webdev
-      - name: "webdev; dart test -j 1"
-        run: dart test -j 1
-        if: "always() && steps.webdev_pub_upgrade.conclusion == 'success'"
-        working-directory: webdev
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_019:
     name: "unit_test; windows; Dart dev; PKG: dwds; `dart test --tags=extension`"
     runs-on: windows-latest
     steps:
@@ -741,7 +702,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_020:
+  job_019:
     name: "unit_test; windows; Dart dev; PKG: dwds; `dart test --total-shards 3 --shard-index 0 --exclude-tags=extension`"
     runs-on: windows-latest
     steps:
@@ -766,7 +727,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_021:
+  job_020:
     name: "unit_test; windows; Dart dev; PKG: dwds; `dart test --total-shards 3 --shard-index 1 --exclude-tags=extension`"
     runs-on: windows-latest
     steps:
@@ -791,7 +752,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_022:
+  job_021:
     name: "unit_test; windows; Dart dev; PKG: dwds; `dart test --total-shards 3 --shard-index 2 --exclude-tags=extension`"
     runs-on: windows-latest
     steps:
@@ -816,7 +777,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_023:
+  job_022:
     name: "unit_test; windows; Dart dev; PKG: frontend_server_client; `dart test -j 1`"
     runs-on: windows-latest
     steps:
@@ -841,7 +802,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_024:
+  job_023:
     name: "unit_test; windows; Dart dev; PKG: webdev; `dart test -j 1`"
     runs-on: windows-latest
     steps:
@@ -866,7 +827,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_025:
+  job_024:
     name: "unit_test; windows; Dart dev; PKG: test_common; `dart test --exclude-tags=release`"
     runs-on: windows-latest
     steps:
@@ -891,7 +852,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_026:
+  job_025:
     name: "unit_test; windows; Dart main; PKG: dwds; `dart test --tags=extension`"
     runs-on: windows-latest
     steps:
@@ -916,7 +877,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_027:
+  job_026:
     name: "unit_test; windows; Dart main; PKG: dwds; `dart test --total-shards 3 --shard-index 0 --exclude-tags=extension`"
     runs-on: windows-latest
     steps:
@@ -941,7 +902,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_028:
+  job_027:
     name: "unit_test; windows; Dart main; PKG: dwds; `dart test --total-shards 3 --shard-index 1 --exclude-tags=extension`"
     runs-on: windows-latest
     steps:
@@ -966,7 +927,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_029:
+  job_028:
     name: "unit_test; windows; Dart main; PKG: dwds; `dart test --total-shards 3 --shard-index 2 --exclude-tags=extension`"
     runs-on: windows-latest
     steps:
@@ -991,7 +952,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_030:
+  job_029:
     name: "unit_test; windows; Dart main; PKG: frontend_server_client; `dart test -j 1`"
     runs-on: windows-latest
     steps:
@@ -1016,32 +977,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_031:
-    name: "unit_test; windows; Dart main; PKG: webdev; `dart test -j 1`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: main
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - id: webdev_pub_upgrade
-        name: webdev; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: webdev
-      - name: "webdev; dart test -j 1"
-        run: dart test -j 1
-        if: "always() && steps.webdev_pub_upgrade.conclusion == 'success'"
-        working-directory: webdev
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_032:
+  job_030:
     name: "unit_test; windows; Dart main; PKG: test_common; `dart test --exclude-tags=release`"
     runs-on: windows-latest
     steps:
@@ -1066,7 +1002,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_033:
+  job_031:
     name: "beta_cron; linux; Dart beta; PKG: dwds; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test -j 1`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -1132,9 +1068,7 @@ jobs:
       - job_028
       - job_029
       - job_030
-      - job_031
-      - job_032
-  job_034:
+  job_032:
     name: "beta_cron; linux; Dart beta; PKG: webdev; `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`, `dart test -j 1`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -1200,9 +1134,7 @@ jobs:
       - job_028
       - job_029
       - job_030
-      - job_031
-      - job_032
-  job_035:
+  job_033:
     name: "beta_cron; linux; Dart beta; PKG: dwds; `dart analyze .`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -1264,9 +1196,7 @@ jobs:
       - job_028
       - job_029
       - job_030
-      - job_031
-      - job_032
-  job_036:
+  job_034:
     name: "beta_cron; linux; Dart beta; PKG: webdev; `dart analyze .`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -1328,9 +1258,7 @@ jobs:
       - job_028
       - job_029
       - job_030
-      - job_031
-      - job_032
-  job_037:
+  job_035:
     name: "beta_cron; windows; Dart beta; PKG: dwds; `dart test -j 1`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
@@ -1382,9 +1310,7 @@ jobs:
       - job_028
       - job_029
       - job_030
-      - job_031
-      - job_032
-  job_038:
+  job_036:
     name: "beta_cron; windows; Dart beta; PKG: webdev; `dart test -j 1`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
@@ -1436,9 +1362,7 @@ jobs:
       - job_028
       - job_029
       - job_030
-      - job_031
-      - job_032
-  job_039:
+  job_037:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -1486,5 +1410,3 @@ jobs:
       - job_034
       - job_035
       - job_036
-      - job_037
-      - job_038

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 21.0.0+1
+
+- Fix a null cast error when debugging a `Class` from VS Code. - [#2303](https://github.com/dart-lang/webdev/pull/2303)
+
 ## 21.0.0
 
 - Update Dart SDK constraint to `>=3.2.0-36.0.dev <4.0.0`. - [#2207](https://github.com/dart-lang/webdev/pull/2207)

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -96,10 +96,9 @@ class ClassHelper extends Domain {
       throw ChromeDebugException(e.json, evalContents: expression);
     }
 
-    final classDescriptor = result.value as Map<String, dynamic>;
+    final classDescriptor = _mapify(result.value);
     final methodRefs = <FuncRef>[];
-    final methodDescriptors =
-        classDescriptor['methods'] as Map<String, dynamic>;
+    final methodDescriptors = _mapify(classDescriptor['methods']);
     methodDescriptors.forEach((name, descriptor) {
       final methodId = 'methods|$classId|$name';
       methodRefs.add(
@@ -118,7 +117,7 @@ class ClassHelper extends Domain {
     });
     final fieldRefs = <FieldRef>[];
 
-    final fieldDescriptors = classDescriptor['fields'] as Map<String, dynamic>;
+    final fieldDescriptors = _mapify(classDescriptor['fields']);
     fieldDescriptors.forEach((name, descriptor) {
       final classMetaData = ClassMetaData(
         runtimeKind: RuntimeObjectKind.type,
@@ -168,4 +167,7 @@ class ClassHelper extends Domain {
       superClass: superClassRef,
     );
   }
+
+  Map<String, dynamic> _mapify(dynamic map) =>
+      (map as Map<String, dynamic>?) ?? <String, dynamic>{};
 }

--- a/dwds/lib/src/debugging/location.dart
+++ b/dwds/lib/src/debugging/location.dart
@@ -78,7 +78,7 @@ class DartLocation {
   int get hashCode => Object.hashAll([uri, line, column]);
 
   @override
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     if (other is! DartLocation) {
       return false;
     }

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '21.0.0';
+const packageVersion = '21.0.0+1';

--- a/dwds/mono_pkg.yaml
+++ b/dwds/mono_pkg.yaml
@@ -15,7 +15,6 @@ stages:
       - test: --tags=extension
       sdk:
         - dev
-        - main
       os:
         - linux
      # Windows extension tests:
@@ -23,7 +22,6 @@ stages:
       - test: --tags=extension
       sdk:
         - dev
-        - main
       os:
         - windows
     # First test shard:
@@ -31,7 +29,6 @@ stages:
       - test: --total-shards 3 --shard-index 0 --exclude-tags=extension
       sdk:
         - dev
-        - main
       os: 
         - linux
         - windows
@@ -40,7 +37,6 @@ stages:
       - test: --total-shards 3 --shard-index 1 --exclude-tags=extension
       sdk:
         - dev
-        - main
       os: 
         - linux
         - windows
@@ -49,7 +45,6 @@ stages:
       - test: --total-shards 3 --shard-index 2 --exclude-tags=extension
       sdk:
         - dev
-        - main
       os: 
         - linux
         - windows

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 21.0.0
+version: 21.0.0+1
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM
   service protocol.

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -11,6 +11,7 @@ import 'package:dwds/src/utilities/conversions.dart';
 import 'package:dwds/src/utilities/globals.dart';
 import 'package:test/test.dart';
 import 'package:test_common/test_sdk_configuration.dart';
+import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
@@ -160,6 +161,10 @@ void main() {
     final names =
         properties.map((p) => p.name).where((x) => x != '__proto__').toList();
     final expected = [
+      if (dartSdkIsAtLeast(
+        newDdcTypeSystemVersion,
+      ))
+        '\$ti',
       '_privateField',
       'abstractField',
       'closure',

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -11,7 +11,6 @@ import 'package:dwds/src/utilities/conversions.dart';
 import 'package:dwds/src/utilities/globals.dart';
 import 'package:test/test.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
@@ -161,10 +160,6 @@ void main() {
     final names =
         properties.map((p) => p.name).where((x) => x != '__proto__').toList();
     final expected = [
-      if (dartSdkIsAtLeast(
-        newDdcTypeSystemVersion,
-      ))
-        '\$ti',
       '_privateField',
       'abstractField',
       'closure',

--- a/dwds/test/instances/class_inspection_test.dart
+++ b/dwds/test/instances/class_inspection_test.dart
@@ -1,0 +1,127 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['daily'])
+@TestOn('vm')
+@Timeout(Duration(minutes: 2))
+
+import 'package:test/test.dart';
+import 'package:test_common/logging.dart';
+import 'package:test_common/test_sdk_configuration.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../fixtures/context.dart';
+import '../fixtures/project.dart';
+import '../fixtures/utilities.dart';
+import 'common/test_inspector.dart';
+
+void main() {
+  // Enable verbose logging for debugging.
+  final debug = false;
+
+  final provider = TestSdkConfigurationProvider(
+    verbose: debug,
+  );
+
+  final context =
+      TestContext(TestProject.testExperimentWithSoundNullSafety, provider);
+  final testInspector = TestInspector(context);
+
+  late VmService service;
+  late Stream<Event> stream;
+  late String isolateId;
+  late ScriptRef mainScript;
+
+  onBreakPoint(breakPointId, body) => testInspector.onBreakPoint(
+        stream,
+        isolateId,
+        mainScript,
+        breakPointId,
+        body,
+      );
+
+  getObject(instanceId) => service.getObject(isolateId, instanceId);
+
+  group('Class |', () {
+    tearDownAll(provider.dispose);
+
+    for (var compilationMode in CompilationMode.values) {
+      group('$compilationMode |', () {
+        setUpAll(() async {
+          setCurrentLogWriter(debug: debug);
+          await context.setUp(
+            testSettings: TestSettings(
+              compilationMode: compilationMode,
+              enableExpressionEvaluation: true,
+              verboseCompiler: debug,
+            ),
+          );
+          service = context.debugConnection.vmService;
+
+          final vm = await service.getVM();
+          isolateId = vm.isolates!.first.id!;
+          final scripts = await service.getScripts(isolateId);
+
+          await service.streamListen('Debug');
+          stream = service.onEvent('Debug');
+
+          mainScript = scripts.scripts!
+              .firstWhere((each) => each.uri!.contains('main.dart'));
+        });
+
+        tearDownAll(() async {
+          await context.tearDown();
+        });
+
+        setUp(() => setCurrentLogWriter(debug: debug));
+        tearDown(() => service.resume(isolateId));
+
+        group('calling getObject for an existent class', () {
+          test('returns the correct class representation', () async {
+            await onBreakPoint('testClass1Case1', (event) async {
+              // classes|dart:core|Object_Diagnosticable
+              final result = await getObject(
+                'classes|org-dartlang-app:///web/main.dart|GreeterClass',
+              );
+              final clazz = result as Class?;
+              expect(clazz!.name, equals('GreeterClass'));
+              expect(
+                clazz.fields!.map((field) => field.name),
+                unorderedEquals([
+                  'greeteeName',
+                  'useFrench',
+                ]),
+              );
+              expect(
+                clazz.functions!.map((fn) => fn.name),
+                containsAll([
+                  'sayHello',
+                  'greetInEnglish',
+                  'greetInFrench',
+                ]),
+              );
+            });
+          });
+        });
+
+        group('calling getObject for a non-existent class', () {
+          // TODO(https://github.com/dart-lang/webdev/issues/2297): Ideally we
+          // should throw an error in this case for the client to catch instead
+          // of returning an empty class.
+          test('returns an empty class representation', () async {
+            await onBreakPoint('testClass1Case1', (event) async {
+              final result = await getObject(
+                'classes|dart:core|Object_Diagnosticable',
+              );
+              final clazz = result as Class?;
+              expect(clazz!.name, equals('Object_Diagnosticable'));
+              expect(clazz.fields, isEmpty);
+              expect(clazz.functions, isEmpty);
+            });
+          });
+        });
+      });
+    }
+  });
+}

--- a/dwds/test/instances/class_inspection_test.dart
+++ b/dwds/test/instances/class_inspection_test.dart
@@ -13,7 +13,6 @@ import 'package:vm_service/vm_service.dart';
 
 import '../fixtures/context.dart';
 import '../fixtures/project.dart';
-import '../fixtures/utilities.dart';
 import 'common/test_inspector.dart';
 
 void main() {
@@ -51,11 +50,9 @@ void main() {
         setUpAll(() async {
           setCurrentLogWriter(debug: debug);
           await context.setUp(
-            testSettings: TestSettings(
-              compilationMode: compilationMode,
-              enableExpressionEvaluation: true,
-              verboseCompiler: debug,
-            ),
+            compilationMode: compilationMode,
+            enableExpressionEvaluation: true,
+            verboseCompiler: debug,
           );
           service = context.debugConnection.vmService;
 

--- a/dwds/test/instances/common/instance_common.dart
+++ b/dwds/test/instances/common/instance_common.dart
@@ -7,7 +7,6 @@ import 'package:dwds/src/utilities/globals.dart';
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
@@ -74,12 +73,7 @@ void runTypeSystemVerificationTests({
         );
         expect(
           remoteObject.json['className'],
-          canaryFeatures ||
-                  dartSdkIsAtLeast(
-                    newDdcTypeSystemVersion,
-                  )
-              ? 'dart_rti.Rti.new'
-              : 'Function',
+          canaryFeatures ? 'dart_rti.Rti.new' : 'Function',
         );
       });
     });

--- a/dwds/test/instances/common/instance_common.dart
+++ b/dwds/test/instances/common/instance_common.dart
@@ -7,6 +7,7 @@ import 'package:dwds/src/utilities/globals.dart';
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
+import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
@@ -73,7 +74,12 @@ void runTypeSystemVerificationTests({
         );
         expect(
           remoteObject.json['className'],
-          canaryFeatures ? 'dart_rti.Rti.new' : 'Function',
+          canaryFeatures ||
+                  dartSdkIsAtLeast(
+                    newDdcTypeSystemVersion,
+                  )
+              ? 'dart_rti.Rti.new'
+              : 'Function',
         );
       });
     });

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -9,6 +9,7 @@ import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
+import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'fixtures/context.dart';
@@ -203,7 +204,18 @@ void main() {
       final variableNames = variables.keys.toList()..sort();
       expect(
         variableNames,
-        ['closureLocalInsideMethod', 'local', 'parameter', 'this'],
+        [
+          // TODO(https://github.com/dart-lang/webdev/issues/2316): Make sure T
+          // doesn't show up here.
+          if (dartSdkIsAtLeast(
+            newDdcTypeSystemVersion,
+          ))
+            'T',
+          'closureLocalInsideMethod',
+          'local',
+          'parameter',
+          'this',
+        ],
       );
     });
 
@@ -213,7 +225,15 @@ void main() {
       await expectDartVariables(variables);
 
       final variableNames = variables.keys.toList()..sort();
-      expect(variableNames, ['this']);
+      expect(variableNames, [
+        // TODO(https://github.com/dart-lang/webdev/issues/2316): Make sure T
+        // doesn't show up here.
+        if (dartSdkIsAtLeast(
+          newDdcTypeSystemVersion,
+        ))
+          'T',
+        'this',
+      ]);
     });
 
     test('variables in extension method', () async {

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -9,7 +9,6 @@ import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'fixtures/context.dart';
@@ -204,18 +203,7 @@ void main() {
       final variableNames = variables.keys.toList()..sort();
       expect(
         variableNames,
-        [
-          // TODO(https://github.com/dart-lang/webdev/issues/2316): Make sure T
-          // doesn't show up here.
-          if (dartSdkIsAtLeast(
-            newDdcTypeSystemVersion,
-          ))
-            'T',
-          'closureLocalInsideMethod',
-          'local',
-          'parameter',
-          'this',
-        ],
+        ['closureLocalInsideMethod', 'local', 'parameter', 'this'],
       );
     });
 
@@ -225,15 +213,7 @@ void main() {
       await expectDartVariables(variables);
 
       final variableNames = variables.keys.toList()..sort();
-      expect(variableNames, [
-        // TODO(https://github.com/dart-lang/webdev/issues/2316): Make sure T
-        // doesn't show up here.
-        if (dartSdkIsAtLeast(
-          newDdcTypeSystemVersion,
-        ))
-          'T',
-        'this',
-      ]);
+      expect(variableNames, ['this']);
     });
 
     test('variables in extension method', () async {

--- a/fixtures/_experimentSound/web/main.dart
+++ b/fixtures/_experimentSound/web/main.dart
@@ -20,6 +20,8 @@ void main() {
     testPattern([3.14, 'b']);
     testPattern([0, 1]);
     testPattern2();
+    print('Classes');
+    testClass();
   });
 
   document.body!.appendText('Program is running!');
@@ -55,6 +57,11 @@ void printNestedNamedLocalRecord() {
   print(record); // Breakpoint: printNestedNamedLocalRecord
 }
 
+void testClass() {
+  final greeter = GreeterClass(greeteeName: 'Charlie Brown');
+  greeter.sayHello();
+}
+
 String testPattern(Object obj) {
   switch (obj) {
     case [var a, int n] || [int n, var a] when n == 1 && a is String:
@@ -72,4 +79,26 @@ String testPattern2() {
   final [firstCat, secondCat] = cats;
   print(firstCat); // Breakpoint: testPattern2Case2
   return '$dog, $firstCat, $secondCat';
+}
+
+class GreeterClass {
+  final String greeteeName;
+  final bool useFrench;
+
+  GreeterClass({
+    this.greeteeName = 'Snoopy',
+    this.useFrench = false,
+  });
+
+  void sayHello() {
+    useFrench ? greetInFrench() : greetInEnglish();
+  }
+
+  void greetInEnglish() {
+    print('Hello $greeteeName'); // Breakpoint: testClass1Case1
+  }
+
+  void greetInFrench() {
+    print('Bonjour $greeteeName');
+  }
 }

--- a/frontend_server_client/test/frontend_sever_client_test.dart
+++ b/frontend_server_client/test/frontend_sever_client_test.dart
@@ -111,8 +111,7 @@ String get message => p.join('hello', 'world');
 
     expect(await stdoutLines.next, p.join('goodbye', 'world'));
     expect(await process.exitCode, 0);
-    // TODO(https://github.com/dart-lang/webdev/issues/2315): Fix and re-enable.
-  }, skip: true);
+  });
 
   test('can handle compile errors and reload fixes', () async {
     var entrypoint = p.join(packageRoot, 'bin', 'main.dart');
@@ -175,8 +174,7 @@ String get message => p.join('hello', 'world');
 
     expect(await stdoutLines.next, p.join('goodbye', 'world'));
     expect(await process.exitCode, 0);
-    // TODO(https://github.com/dart-lang/webdev/issues/2315): Fix and re-enable.
-  }, skip: true);
+  });
 
   test('can compile and recompile a dartdevc app', () async {
     var entrypoint =

--- a/frontend_server_client/test/frontend_sever_client_test.dart
+++ b/frontend_server_client/test/frontend_sever_client_test.dart
@@ -111,7 +111,8 @@ String get message => p.join('hello', 'world');
 
     expect(await stdoutLines.next, p.join('goodbye', 'world'));
     expect(await process.exitCode, 0);
-  });
+    // TODO(https://github.com/dart-lang/webdev/issues/2315): Fix and re-enable.
+  }, skip: true);
 
   test('can handle compile errors and reload fixes', () async {
     var entrypoint = p.join(packageRoot, 'bin', 'main.dart');
@@ -174,7 +175,8 @@ String get message => p.join('hello', 'world');
 
     expect(await stdoutLines.next, p.join('goodbye', 'world'));
     expect(await process.exitCode, 0);
-  });
+    // TODO(https://github.com/dart-lang/webdev/issues/2315): Fix and re-enable.
+  }, skip: true);
 
   test('can compile and recompile a dartdevc app', () async {
     var entrypoint =

--- a/test_common/lib/utilities.dart
+++ b/test_common/lib/utilities.dart
@@ -1,12 +1,16 @@
 // Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 
 const webdevDirName = 'webdev';
 const dwdsDirName = 'dwds';
 const fixturesDirName = 'fixtures';
+
+const newDdcTypeSystemVersion = '3.3.0-242.0.dev';
 
 /// The path to the webdev directory in the local machine, e.g.
 /// '/workstation/webdev'.
@@ -60,4 +64,10 @@ String absolutePath({
     return p.normalize(p.join(fixturesPath, pathFromFixtures));
   }
   throw Exception('Expected a path parameter.');
+}
+
+bool dartSdkIsAtLeast(String sdkVersion) {
+  final expectedVersion = Version.parse(sdkVersion);
+  final actualVersion = Version.parse(Platform.version.split(' ')[0]);
+  return actualVersion >= expectedVersion;
 }

--- a/test_common/lib/utilities.dart
+++ b/test_common/lib/utilities.dart
@@ -1,16 +1,12 @@
 // Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:pub_semver/pub_semver.dart';
 
 const webdevDirName = 'webdev';
 const dwdsDirName = 'dwds';
 const fixturesDirName = 'fixtures';
-
-const newDdcTypeSystemVersion = '3.3.0-242.0.dev';
 
 /// The path to the webdev directory in the local machine, e.g.
 /// '/workstation/webdev'.
@@ -64,10 +60,4 @@ String absolutePath({
     return p.normalize(p.join(fixturesPath, pathFromFixtures));
   }
   throw Exception('Expected a path parameter.');
-}
-
-bool dartSdkIsAtLeast(String sdkVersion) {
-  final expectedVersion = Version.parse(sdkVersion);
-  final actualVersion = Version.parse(Platform.version.split(' ')[0]);
-  return actualVersion >= expectedVersion;
 }

--- a/test_common/pubspec.yaml
+++ b/test_common/pubspec.yaml
@@ -10,9 +10,9 @@ dependencies:
   file: ">=6.0.0 <8.0.0"
   logging: ^1.0.1
   path: ^1.8.1
-  pub_semver: ^2.1.1
   test: ^1.21.1
 
 dev_dependencies:
   lints: ^2.0.0
   pubspec_parse: ^1.2.2
+  pub_semver: ^2.1.1

--- a/test_common/pubspec.yaml
+++ b/test_common/pubspec.yaml
@@ -10,9 +10,9 @@ dependencies:
   file: ">=6.0.0 <8.0.0"
   logging: ^1.0.1
   path: ^1.8.1
+  pub_semver: ^2.1.1
   test: ^1.21.1
 
 dev_dependencies:
   lints: ^2.0.0
   pubspec_parse: ^1.2.2
-  pub_semver: ^2.1.1

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.5.7
+# Created with package:mono_repo v6.5.3
 
 # Support built in commands on windows out of the box.
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")

--- a/webdev/mono_pkg.yaml
+++ b/webdev/mono_pkg.yaml
@@ -12,12 +12,10 @@ stages:
       - test: -j 1
       sdk:
         - dev
-        - main
     - test: -j 1
       os: windows
       sdk:
         - dev
-        - main
   - beta_cron:
     - analyze: .
       sdk: beta


### PR DESCRIPTION
We would like to hotfix this version of DWDS into Flutter stable to resolve https://github.com/dart-lang/webdev/issues/2297

This hotfix cherry-picks the following changes on top of DWDS version 21.0.0:
- https://github.com/dart-lang/webdev/pull/2303
- https://github.com/dart-lang/webdev/pull/2310

I've disabled testing against the main branch of the Dart SDK for DWDS. The Github action is incorrectly pulling an old version of Dart (from November) from https://storage.googleapis.com/dart-archive/channels/be/raw/latest instead of https://storage.googleapis.com/dart-archive/channels/main/raw/latest