### PR TITLE
Filter out internal type properties from the new DDC type system

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 23.3.0-wip
 
+- Filter out internal type properties from the new DDC type system. - [#2348](https://github.com/dart-lang/webdev/pull/2348)
+
 ## 23.2.0
 
 - Send untruncated `dart:developer` logs to debugging clients. - [#2333](https://github.com/dart-lang/webdev/pull/2333)

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -63,7 +63,6 @@ Future<List<Property>> visibleVariables({
   }
 
   allProperties.removeWhere((property) {
-    // print('looking at $property');
     final value = property.value;
     if (value == null) return true;
 
@@ -77,7 +76,6 @@ Future<List<Property>> visibleVariables({
     // We should never see a raw JS class. The only case where this happens is a
     // Dart generic function, where the type arguments get passed in as
     // parameters. Hide those.
-    // print('looking at $name');
     return (type == 'function' && description.startsWith('class ')) ||
         previousDdcTemporaryVariableRegExp.hasMatch(name) ||
         ddcTemporaryVariableRegExp.hasMatch(name) ||

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -20,11 +20,11 @@ final ddcTemporaryTypeVariableRegExp = RegExp(r'^__t[\$\w*]+$');
 final previousDdcTemporaryVariableRegExp =
     RegExp(r'^(t[0-9]+\$?[0-9]*|__t[\$\w*]+)$');
 
-/// Find the visible Dart properties from a JS Scope Chain, coming from the
+/// Find the visible Dart variables from a JS Scope Chain, coming from the
 /// scopeChain attribute of a Chrome CallFrame corresponding to [frame].
 ///
 /// See chromedevtools.github.io/devtools-protocol/tot/Debugger#type-CallFrame.
-Future<List<Property>> visibleProperties({
+Future<List<Property>> visibleVariables({
   required AppInspectorInterface inspector,
   required WipCallFrame frame,
 }) async {
@@ -63,6 +63,7 @@ Future<List<Property>> visibleProperties({
   }
 
   allProperties.removeWhere((property) {
+    // print('looking at $property');
     final value = property.value;
     if (value == null) return true;
 
@@ -76,6 +77,7 @@ Future<List<Property>> visibleProperties({
     // We should never see a raw JS class. The only case where this happens is a
     // Dart generic function, where the type arguments get passed in as
     // parameters. Hide those.
+    // print('looking at $name');
     return (type == 'function' && description.startsWith('class ')) ||
         previousDdcTemporaryVariableRegExp.hasMatch(name) ||
         ddcTemporaryVariableRegExp.hasMatch(name) ||

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -405,7 +405,7 @@ class Debugger extends Domain {
   Future<List<BoundVariable>> variablesFor(WipCallFrame frame) async {
     // TODO(alanknight): Can these be moved to dart_scope.dart?
     final properties =
-        await visibleProperties(inspector: inspector, frame: frame);
+        await visibleVariables(inspector: inspector, frame: frame);
     final boundVariables = await Future.wait(
       properties.map(_boundVariable),
     );

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -609,7 +609,7 @@ class AppInspector implements AppInspectorInterface {
     // Filter out any RTI objects from the new DDC type system. See:
     // https://github.com/dart-lang/webdev/issues/2316
     final isRtiObject =
-        property.value?.className?.startsWith('dart_rti') ?? false;
+        property.value?.className?.startsWith('dart_rti.Rti') ?? false;
     return !isRtiObject;
   }
 

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -601,7 +601,16 @@ class AppInspector implements AppInspectorInterface {
     );
     return jsProperties
         .map<Property>((each) => Property(each as Map<String, dynamic>))
+        .where(_isVisibleProperty)
         .toList();
+  }
+
+  bool _isVisibleProperty(Property property) {
+    // Filter out any RTI objects from the new DDC type system. See:
+    // https://github.com/dart-lang/webdev/issues/2316
+    final isRtiObject =
+        property.value?.className?.startsWith('dart_rti') ?? false;
+    return !isRtiObject;
   }
 
   /// Calculate the number of available elements in the range.

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -11,7 +11,6 @@ import 'package:dwds/src/debugging/inspector.dart';
 import 'package:dwds/src/utilities/conversions.dart';
 import 'package:test/test.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 

--- a/dwds/test/inspector_test.dart
+++ b/dwds/test/inspector_test.dart
@@ -161,10 +161,6 @@ void main() {
     final names =
         properties.map((p) => p.name).where((x) => x != '__proto__').toList();
     final expected = [
-      if (dartSdkIsAtLeast(
-        newDdcTypeSystemVersion,
-      ))
-        '\$ti',
       '_privateField',
       'abstractField',
       'closure',

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -208,12 +208,6 @@ void main() {
       expect(
         variableNames,
         [
-          // TODO(https://github.com/dart-lang/webdev/issues/2316): Make sure T
-          // doesn't show up here.
-          if (dartSdkIsAtLeast(
-            newDdcTypeSystemVersion,
-          ))
-            'T',
           'closureLocalInsideMethod',
           'local',
           'parameter',
@@ -229,12 +223,6 @@ void main() {
 
       final variableNames = variables.keys.toList()..sort();
       expect(variableNames, [
-        // TODO(https://github.com/dart-lang/webdev/issues/2316): Make sure T
-        // doesn't show up here.
-        if (dartSdkIsAtLeast(
-          newDdcTypeSystemVersion,
-        ))
-          'T',
         'this',
       ]);
     });

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -9,7 +9,6 @@ import 'package:dwds/src/services/chrome_proxy_service.dart';
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'fixtures/context.dart';

--- a/fixtures/_test/example/scopes/main.dart
+++ b/fixtures/_test/example/scopes/main.dart
@@ -93,6 +93,7 @@ class MyTestClass<T> extends MyAbstractClass {
   String hello() => message;
 
   String Function(String) methodWithVariables() {
+    print('Test class is of type $T');
     var local = '$message + something';
     print(local);
     return (String parameter) {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/2316, https://github.com/dart-lang/webdev/issues/2340

Filter out internal type representations and type fields from the new DDC type system. 



