### PR TITLE
Do not notify clients when we remove breakpoints before triggering a hot restart 

### DIFF
--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -249,7 +249,6 @@ class Debugger extends Domain {
   }) async {
     column ??= 0;
     final breakpoint = await _breakpoints.add(scriptId, line, column);
-    print('BREAKPOINT IS ${breakpoint.id}');
     _notifyBreakpoint(breakpoint);
     return breakpoint;
   }
@@ -316,7 +315,6 @@ class Debugger extends Domain {
   }
 
   void _notifyBreakpoint(Breakpoint breakpoint) {
-    print('NOTIFY BREAKPOINT ${breakpoint.id} WAS ADDED');
     final event = Event(
       kind: EventKind.kBreakpointAdded,
       timestamp: DateTime.now().millisecondsSinceEpoch,
@@ -326,22 +324,15 @@ class Debugger extends Domain {
     _streamNotify('Debug', event);
   }
 
-  Future<void> setBreakpointsActive(bool active) async {
-    print(active ? 'activating breakpoints' : 'de activating breakpoints');
-    await _remoteDebugger.sendCommand(
-      'Debugger.setBreakpointsActive',
-      params: {
-        'active': active,
-      },
-    );
-  }
-
   /// Remove a Dart breakpoint.
+  ///
+  /// [notifyClients] should only ever be false during a hot-restart, so that we
+  /// don't notify clients of the breakpoints we've removed before resuming and
+  /// then hot-restarting.
   Future<Success> removeBreakpoint(
     String breakpointId, {
     notifyClients = true,
   }) async {
-    print('REMOVING A BREAKPOINT');
     print(StackTrace.current);
     if (_breakpoints.breakpointFor(breakpointId) == null) {
       throwInvalidParam(

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -313,7 +313,7 @@ Future<void> _disableBreakpointsAndResume(
   if (isolateId == null) {
     throw StateError('No active isolate to resume.');
   }
-  await chromeProxyService.disableBreakpoints();
+  await chromeProxyService.disableBreakpointsForHotRestart();
   try {
     // Any checks for paused status result in race conditions or hangs
     // at this point:

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -375,6 +375,8 @@ class ChromeProxyService implements VmServiceInterface {
     _consoleSubscription = null;
   }
 
+  /// This should only ever be called before a hot-restart when we are disabling
+  /// all breakpoints before resuming and then starting the restart.
   Future<void> disableBreakpointsForHotRestart() async {
     if (!_isIsolateRunning) return;
     final isolate = inspector.isolate;
@@ -386,14 +388,6 @@ class ChromeProxyService implements VmServiceInterface {
     }
   }
 
-  // Future<void> disableBreakpoints() async {
-  //   await (await debuggerFuture).setBreakpointsActive(false);
-  // }
-
-  // Future<void> enableBreakpoints() async {
-  //   await (await debuggerFuture).setBreakpointsActive(true);
-  // }
-
   @override
   Future<Breakpoint> addBreakpoint(
     String isolateId,
@@ -401,7 +395,6 @@ class ChromeProxyService implements VmServiceInterface {
     int line, {
     int? column,
   }) {
-    print('ADDING BREAKPOINT AT $line');
     return wrapInErrorHandlerAsync(
       'addBreakpoint',
       () => _addBreakpoint(isolateId, scriptId, line),

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -375,16 +375,24 @@ class ChromeProxyService implements VmServiceInterface {
     _consoleSubscription = null;
   }
 
-  Future<void> disableBreakpoints() async {
-    _disabledBreakpoints.clear();
+  Future<void> disableBreakpointsForHotRestart() async {
     if (!_isIsolateRunning) return;
     final isolate = inspector.isolate;
 
     _disabledBreakpoints.addAll(isolate.breakpoints ?? []);
     for (var breakpoint in isolate.breakpoints?.toList() ?? []) {
-      await (await debuggerFuture).removeBreakpoint(breakpoint.id);
+      await (await debuggerFuture)
+          .removeBreakpoint(breakpoint.id, notifyClients: false);
     }
   }
+
+  // Future<void> disableBreakpoints() async {
+  //   await (await debuggerFuture).setBreakpointsActive(false);
+  // }
+
+  // Future<void> enableBreakpoints() async {
+  //   await (await debuggerFuture).setBreakpointsActive(true);
+  // }
 
   @override
   Future<Breakpoint> addBreakpoint(
@@ -393,6 +401,7 @@ class ChromeProxyService implements VmServiceInterface {
     int line, {
     int? column,
   }) {
+    print('ADDING BREAKPOINT AT $line');
     return wrapInErrorHandlerAsync(
       'addBreakpoint',
       () => _addBreakpoint(isolateId, scriptId, line),


### PR DESCRIPTION
Before triggering a hot-restart, DWDS:
- removes all current breakpoints (so that they don't get hit when resuming)
- resumes the isolate (in case it was paused when the hot restart was triggered)

However, this means that the debugging client (e.g. DevTools) is notified that the breakpoints have been removed before the hot-restart happens. Therefore, it cannot re-establish the breakpoints because it believes they don't exist. 

This PR makes sure that when we remove the breakpoints for a hot-restart, we do not notify the client of their removal.


