### PR TITLE
Implement `setFlag` for 'pause_isolates_on_start'

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 23.4.0-wip
 
-- Adding tests for constants in DDC after a hot restart - [#2349](https://github.com/dart-lang/webdev/pull/2349)
-- Renaming `dart_library.js` to `ddc_module_loader.js` to match SDK naming changes - [#2360](https://github.com/dart-lang/webdev/pull/2360)
+- Rename `dart_library.js` to `ddc_module_loader.js` to match SDK naming changes. - [#2360](https://github.com/dart-lang/webdev/pull/2360)
+- Implement `setFlag` when it is called with `pause_isolates_on_start`. - [#2373](https://github.com/dart-lang/webdev/pull/2373)
 
 ## 23.3.0
 

--- a/dwds/lib/dart_web_debug_service.dart
+++ b/dwds/lib/dart_web_debug_service.dart
@@ -47,6 +47,9 @@ class Dwds {
   StreamController<DebugConnection> get extensionDebugConnections =>
       _devHandler.extensionDebugConnections;
 
+  bool get shouldPauseIsolatesOnStart => _shouldPauseIsolatesOnStart;
+  bool _shouldPauseIsolatesOnStart = false;
+
   Future<void> stop() async {
     await _devTools?.close();
     await _devHandler.close();
@@ -56,7 +59,11 @@ class Dwds {
   Future<DebugConnection> debugConnection(AppConnection appConnection) async {
     if (!_enableDebugging) throw StateError('Debugging is not enabled.');
     final appDebugServices = await _devHandler.loadAppServices(appConnection);
-    await appDebugServices.chromeProxyService.isInitialized;
+    final chromeProxyService = appDebugServices.chromeProxyService;
+    await chromeProxyService.isInitialized;
+    chromeProxyService.pauseIsolatesOnStartStream.listen((value) {
+      _shouldPauseIsolatesOnStart = value;
+    });
     return DebugConnection(appDebugServices);
   }
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -91,6 +91,14 @@ class ChromeProxyService implements VmServiceInterface {
 
   StreamSubscription<ConsoleAPIEvent>? _consoleSubscription;
 
+  final _pauseIsolatesOnStartController = StreamController<bool>.broadcast();
+
+  /// A global stream of the value of the [_pauseIsolatesOnStartFlag].
+  ///
+  /// The flag's value can be updated during runtime.
+  Stream<bool> get pauseIsolatesOnStartStream =>
+      _pauseIsolatesOnStartController.stream;
+
   final _disabledBreakpoints = <Breakpoint>{};
   final _previousBreakpoints = <Breakpoint>{};
 
@@ -1195,8 +1203,22 @@ ${globalToolConfiguration.loadStrategy.loadModuleSnippet}("dart_sdk").developer.
   }
 
   @override
-  Future<Success> setFlag(String name, String value) {
-    return _rpcNotSupportedFuture('setFlag');
+  Future<Success> setFlag(String name, String value) => wrapInErrorHandlerAsync(
+        'setFlag',
+        () => _setFlag(name, value),
+      );
+
+  Future<Success> _setFlag(String name, String value) async {
+    if (!_supportedVmServiceFlags.contains(name)) {
+      return _rpcNotSupportedFuture('setFlag');
+    }
+
+    if (name == _pauseIsolatesOnStartFlag) {
+      assert(value == 'true' || value == 'false');
+      _pauseIsolatesOnStartController.sink.add(value == 'true' ? true : false);
+    }
+
+    return Success();
   }
 
   @override
@@ -1657,3 +1679,10 @@ const _stderrTypes = ['error'];
 
 /// The `type`s of [ConsoleAPIEvent]s that are treated as `stdout` logs.
 const _stdoutTypes = ['log', 'info', 'warning'];
+
+const _pauseIsolatesOnStartFlag = 'pause_isolates_on_start';
+
+/// The flags that can be set at runtime via [setFlag].
+const _supportedVmServiceFlags = {
+  _pauseIsolatesOnStartFlag,
+};

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -1215,7 +1215,7 @@ ${globalToolConfiguration.loadStrategy.loadModuleSnippet}("dart_sdk").developer.
 
     if (name == _pauseIsolatesOnStartFlag) {
       assert(value == 'true' || value == 'false');
-      _pauseIsolatesOnStartController.sink.add(value == 'true' ? true : false);
+      _pauseIsolatesOnStartController.sink.add(value == 'true');
     }
 
     return Success();

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -2063,6 +2063,34 @@ void main() {
       await expectLater(service.streamCancel(''), throwsRPCError);
     });
 
+    group('setFlag', () {
+      test('pause_isolates_on_start set to true', () {
+        final service = context.service;
+        expect(
+          service.setFlag('pause_isolates_on_start', 'true'),
+          completion(_isSuccess),
+        );
+        expect(context.dwds!.shouldPauseIsolatesOnStart, equals(true));
+      });
+
+      test('pause_isolates_on_start set to false', () {
+        final service = context.service;
+        expect(
+          service.setFlag('pause_isolates_on_start', 'false'),
+          completion(_isSuccess),
+        );
+        expect(context.dwds!.shouldPauseIsolatesOnStart, equals(false));
+      });
+
+      test('pause_isolates_on_start set to invalid value', () {
+        final service = context.service;
+        expect(
+          service.setFlag('pause_isolates_on_start', 'pizza'),
+          throwsRPCError,
+        );
+      });
+    });
+
     group('streamListen/onEvent', () {
       late ChromeProxyService service;
 

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -10,6 +10,7 @@ import 'package:build_daemon/client.dart';
 import 'package:build_daemon/data/build_status.dart';
 import 'package:build_daemon/data/build_target.dart';
 import 'package:dwds/asset_reader.dart';
+import 'package:dwds/dart_web_debug_service.dart';
 import 'package:dwds/src/connections/app_connection.dart';
 import 'package:dwds/src/connections/debug_connection.dart';
 import 'package:dwds/src/debugging/webkit_debugger.dart';
@@ -74,6 +75,8 @@ class TestContext {
 
   TestServer get testServer => _testServer!;
   TestServer? _testServer;
+
+  Dwds? get dwds => _testServer?.dwds;
 
   BuildDaemonClient get daemonClient => _daemonClient!;
   BuildDaemonClient? _daemonClient;


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/5265, https://github.com/dart-lang/webdev/issues/2257

This is part of a series of changes to fix the "phantom breakpoints" issue described here: https://github.com/dart-lang/webdev/issues/2257#issuecomment-1942909830 