### PR TITLE
Disable `frontend_server_client_test` on windows

### DIFF
--- a/frontend_server_client/mono_pkg.yaml
+++ b/frontend_server_client/mono_pkg.yaml
@@ -11,4 +11,5 @@ stages:
         - dev
         - main
       os:
+        - windows
         - linux

--- a/frontend_server_client/mono_pkg.yaml
+++ b/frontend_server_client/mono_pkg.yaml
@@ -11,5 +11,4 @@ stages:
         - dev
         - main
       os:
-        - windows
         - linux

--- a/frontend_server_client/test/frontend_server_client_test.dart
+++ b/frontend_server_client/test/frontend_server_client_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-@TestOn('!windows')
 import 'dart:convert';
 import 'dart:io';
 
@@ -112,7 +111,10 @@ String get message => p.join('hello', 'world');
 
     expect(await stdoutLines.next, p.join('goodbye', 'world'));
     expect(await process.exitCode, 0);
-  });
+    },
+    // Issue: https://github.com/dart-lang/webdev/issues/2377
+    skip: Platform.isWindows,
+  );
 
   test('can handle compile errors and reload fixes', () async {
     var entrypoint = p.join(packageRoot, 'bin', 'main.dart');

--- a/frontend_server_client/test/frontend_server_client_test.dart
+++ b/frontend_server_client/test/frontend_server_client_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+@TestOn('!windows')
 import 'dart:convert';
 import 'dart:io';
 

--- a/frontend_server_client/test/frontend_server_client_test.dart
+++ b/frontend_server_client/test/frontend_server_client_test.dart
@@ -119,68 +119,74 @@ String get message => p.join('hello', 'world');
     skip: Platform.isWindows,
   );
 
-  test('can handle compile errors and reload fixes', () async {
-    var entrypoint = p.join(packageRoot, 'bin', 'main.dart');
-    var entrypointFile = File(entrypoint);
-    var originalContent = await entrypointFile.readAsString();
-    // append two compile errors to the bottom
-    await entrypointFile
-        .writeAsString('$originalContent\nint foo = 1.0;\nString bar = 4;');
+  test(
+    'can handle compile errors and reload fixes',
+    () async {
+      var entrypoint = p.join(packageRoot, 'bin', 'main.dart');
+      var entrypointFile = File(entrypoint);
+      var originalContent = await entrypointFile.readAsString();
+      // append two compile errors to the bottom
+      await entrypointFile
+          .writeAsString('$originalContent\nint foo = 1.0;\nString bar = 4;');
 
-    client = await FrontendServerClient.start(
-        entrypoint, p.join(packageRoot, 'out.dill'), vmPlatformDill);
-    var result = await client.compile();
+      client = await FrontendServerClient.start(
+          entrypoint, p.join(packageRoot, 'out.dill'), vmPlatformDill);
+      var result = await client.compile();
 
-    client.accept();
-    expect(result.errorCount, 2);
-    expect(result.compilerOutputLines,
-        allOf(contains('int foo = 1.0;'), contains('String bar = 4;')));
-    expect(
-        result.newSources,
-        containsAll([
-          File(entrypoint).uri,
-          packageConfig.resolve(Uri.parse('package:path/path.dart')),
-        ]));
-    expect(result.removedSources, isEmpty);
-    expect(result.dillOutput, isNotNull);
-    expect(File(result.dillOutput!).existsSync(), true);
+      client.accept();
+      expect(result.errorCount, 2);
+      expect(result.compilerOutputLines,
+          allOf(contains('int foo = 1.0;'), contains('String bar = 4;')));
+      expect(
+          result.newSources,
+          containsAll([
+            File(entrypoint).uri,
+            packageConfig.resolve(Uri.parse('package:path/path.dart')),
+          ]));
+      expect(result.removedSources, isEmpty);
+      expect(result.dillOutput, isNotNull);
+      expect(File(result.dillOutput!).existsSync(), true);
 
-    var process = await Process.start(Platform.resolvedExecutable, [
-      '--observe',
-      '--no-pause-isolates-on-exit',
-      '--pause-isolates-on-start',
-      result.dillOutput!
-    ]);
-    addTearDown(process.kill);
-    var stdoutLines = StreamQueue(
-        process.stdout.transform(utf8.decoder).transform(const LineSplitter()));
+      var process = await Process.start(Platform.resolvedExecutable, [
+        '--observe',
+        '--no-pause-isolates-on-exit',
+        '--pause-isolates-on-start',
+        result.dillOutput!
+      ]);
+      addTearDown(process.kill);
+      var stdoutLines = StreamQueue(process.stdout
+          .transform(utf8.decoder)
+          .transform(const LineSplitter()));
 
-    var observatoryLine = await stdoutLines.next;
-    var observatoryUri =
-        '${observatoryLine.split(' ').last.replaceFirst('http', 'ws')}ws';
-    var vmService = await vmServiceConnectUri(observatoryUri);
-    var isolate = await waitForIsolatesAndResume(vmService);
+      var observatoryLine = await stdoutLines.next;
+      var observatoryUri =
+          '${observatoryLine.split(' ').last.replaceFirst('http', 'ws')}ws';
+      var vmService = await vmServiceConnectUri(observatoryUri);
+      var isolate = await waitForIsolatesAndResume(vmService);
 
-    // The program actually runs regardless of the errors, as they don't affect
-    // the runtime behavior.
-    await expectLater(stdoutLines, emitsThrough(p.join('hello', 'world')));
+      // The program actually runs regardless of the errors, as they don't affect
+      // the runtime behavior.
+      await expectLater(stdoutLines, emitsThrough(p.join('hello', 'world')));
 
-    await entrypointFile
-        .writeAsString(originalContent.replaceFirst('hello', 'goodbye'));
-    result = await client.compile([entrypointFile.uri]);
-    client.accept();
-    expect(result.errorCount, 0);
-    expect(result.compilerOutputLines, isEmpty);
-    expect(result.newSources, isEmpty);
-    expect(result.removedSources, isEmpty);
-    expect(result.dillOutput, isNotNull);
-    expect(File(result.dillOutput!).existsSync(), true);
+      await entrypointFile
+          .writeAsString(originalContent.replaceFirst('hello', 'goodbye'));
+      result = await client.compile([entrypointFile.uri]);
+      client.accept();
+      expect(result.errorCount, 0);
+      expect(result.compilerOutputLines, isEmpty);
+      expect(result.newSources, isEmpty);
+      expect(result.removedSources, isEmpty);
+      expect(result.dillOutput, isNotNull);
+      expect(File(result.dillOutput!).existsSync(), true);
 
-    await vmService.reloadSources(isolate.id!, rootLibUri: result.dillOutput);
+      await vmService.reloadSources(isolate.id!, rootLibUri: result.dillOutput);
 
-    expect(await stdoutLines.next, p.join('goodbye', 'world'));
-    expect(await process.exitCode, 0);
-  });
+      expect(await stdoutLines.next, p.join('goodbye', 'world'));
+      expect(await process.exitCode, 0);
+    },
+    // Issue: https://github.com/dart-lang/webdev/issues/2377
+    skip: Platform.isWindows,
+  );
 
   test('can compile and recompile a dartdevc app', () async {
     var entrypoint =


### PR DESCRIPTION
Disable the `frontend_server_client_test` on windows. 

This test has begun failing with a timeout error, see https://github.com/dart-lang/webdev/actions/runs/8034050792
