### PR TITLE
Remove accidentally committed `print` statements

### DIFF
--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -744,10 +744,8 @@ class _Breakpoints extends Domain {
     int line,
     int column,
   ) async {
-    print('creating breakpoint at $scriptId:$line:$column)');
     final dartScript = inspector.scriptWithId(scriptId);
     final dartScriptUri = dartScript?.uri;
-    print('dart script uri is $dartScriptUri');
     Location? location;
     if (dartScriptUri != null) {
       final dartUri = DartUri(dartScriptUri, root);


### PR DESCRIPTION
Accidentally submitted `print` statements in https://github.com/dart-lang/webdev/pull/2371, this simply removes them. 

Follow-up will be to add a lint that catches this.
