### PR TITLE
Add `libraryRoot` and `packageConfigLoader` to the `LoadStrategy`

### DIFF
--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -113,7 +113,6 @@ abstract class LoadStrategy {
   /// Returns `null` if not a google3 app.
   String? g3RelativePath(String absolutePath);
 
-
   /// Returns a loader to read the content of the package configuration.
   ///
   /// The package configuration URIs will be resolved relative to

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -120,7 +120,7 @@ abstract class LoadStrategy {
   /// [packageConfigPath], but the loader can read the config from a different
   /// location.
   ///
-  /// If null, the default loader will read from `packageConfigPath`.
+  /// If null, the default loader will read from [packageConfigPath].
   Future<Uint8List?> Function(Uri uri)? get packageConfigLoader => null;
 
   /// The absolute path to the app's package configuration.

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:dwds/src/debugging/metadata/provider.dart';
 import 'package:dwds/src/readers/asset_reader.dart';
 import 'package:dwds/src/services/expression_compiler.dart';
@@ -40,6 +42,10 @@ abstract class LoadStrategy {
   /// The snippet should be a reference to a function that takes a single
   /// argument which is the module name to load.
   String get loadModuleSnippet;
+
+  /// The relative root path for library paths. The current directory will be
+  /// used if this is not overridden.
+  String? get libraryRoot => null;
 
   /// The reload configuration for this strategy, e.g. liveReload.
   ReloadConfiguration get reloadConfiguration;
@@ -106,6 +112,16 @@ abstract class LoadStrategy {
   ///
   /// Returns `null` if not a google3 app.
   String? g3RelativePath(String absolutePath);
+
+
+  /// Returns a loader to read the content of the package configuration.
+  ///
+  /// The package configuration URIs will be resolved relative to
+  /// [packageConfigPath], but the loader can read the config from a different
+  /// location.
+  ///
+  /// If null, the default loader will read from `packageConfigPath`.
+  Future<Uint8List?> Function(Uri uri)? get packageConfigLoader => null;
 
   /// The absolute path to the app's package configuration.
   String get packageConfigPath {

--- a/dwds/lib/src/utilities/dart_uri.dart
+++ b/dwds/lib/src/utilities/dart_uri.dart
@@ -211,6 +211,7 @@ class DartUri {
   static Future<void> _loadPackageConfig(Uri uri) async {
     _packageConfig = await loadPackageConfigUri(
       uri,
+      loader: globalToolConfiguration.loadStrategy.packageConfigLoader,
       onError: (e) {
         _logger.warning('Cannot read packages spec: $uri', e);
       },
@@ -237,7 +238,9 @@ class DartUri {
         // Both currentDirectoryUri and the libraryUri path should have '/'
         // separators, so we can join them as url paths to get the absolute file
         // url.
-        libraryPath = p.url.join(currentDirectoryUri, uri.path.substring(1));
+        final libraryRoot = globalToolConfiguration.loadStrategy.libraryRoot;
+        libraryPath = p.url
+            .join(libraryRoot ?? currentDirectoryUri, uri.path.substring(1));
         break;
       case 'package':
         libraryPath = _packageConfig?.resolve(uri)?.toString();


### PR DESCRIPTION
The library root and package config loader are necessary to support test debugging internally. 
