### PR TITLE
Fix reading `pause_isolates_on_start` value from the DWDS

### DIFF
--- a/dwds/lib/dart_web_debug_service.dart
+++ b/dwds/lib/dart_web_debug_service.dart
@@ -47,9 +47,6 @@ class Dwds {
   StreamController<DebugConnection> get extensionDebugConnections =>
       _devHandler.extensionDebugConnections;
 
-  bool get shouldPauseIsolatesOnStart => _shouldPauseIsolatesOnStart;
-  bool _shouldPauseIsolatesOnStart = false;
-
   Future<void> stop() async {
     await _devTools?.close();
     await _devHandler.close();
@@ -61,9 +58,6 @@ class Dwds {
     final appDebugServices = await _devHandler.loadAppServices(appConnection);
     final chromeProxyService = appDebugServices.chromeProxyService;
     await chromeProxyService.isInitialized;
-    chromeProxyService.pauseIsolatesOnStartStream.listen((value) {
-      _shouldPauseIsolatesOnStart = value;
-    });
     return DebugConnection(appDebugServices);
   }
 
@@ -145,4 +139,7 @@ class Dwds {
       debugSettings.enableDebugging,
     );
   }
+
+  bool shouldPauseIsolatesOnStart(String appId) =>
+      _devHandler.shouldPauseIsolatesOnStart(appId);
 }

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -121,6 +121,9 @@ class DevHandler {
         _servicesByAppId.clear();
       }();
 
+  bool shouldPauseIsolatesOnStart(String appId) =>
+      _servicesByAppId[appId]?.chromeProxyService.pauseIsolatesOnStart ?? false;
+
   void _emitBuildResults(BuildResult result) {
     if (result.status != BuildStatus.succeeded) return;
     for (var injectedConnection in _injectedConnections) {

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -98,14 +98,6 @@ class ChromeProxyService implements VmServiceInterface {
   /// This value can be updated at runtime via [setFlag].
   bool get pauseIsolatesOnStart => _pauseIsolatesOnStart;
 
-  final _pauseIsolatesOnStartController = StreamController<bool>.broadcast();
-
-  /// A global stream of the value of the [_pauseIsolatesOnStartFlag].
-  ///
-  /// The flag's value can be updated during runtime.
-  Stream<bool> get pauseIsolatesOnStartStream =>
-      _pauseIsolatesOnStartController.stream;
-
   final _resumeAfterHotRestartEventsController =
       StreamController<String>.broadcast();
 
@@ -1227,7 +1219,6 @@ ${globalToolConfiguration.loadStrategy.loadModuleSnippet}("dart_sdk").developer.
     if (name == _pauseIsolatesOnStartFlag) {
       assert(value == 'true' || value == 'false');
       _pauseIsolatesOnStart = value == 'true';
-      _pauseIsolatesOnStartController.sink.add(_pauseIsolatesOnStart);
     }
 
     return Success();

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -2064,34 +2064,30 @@ void main() {
     });
 
     group('setFlag', () {
-      test('pause_isolates_on_start set to true', () async {
+      test('pause_isolates_on_start set to true', () {
         final service = context.service;
         expect(
           service.setFlag('pause_isolates_on_start', 'true'),
           completion(_isSuccess),
         );
-        // Re-try until sucess because the value doesn't get updated
-        // synchronously (it is sent over a stream):
-        final pauseIsolatesOnStart = await retryFn(
-          () => context.dwds!.shouldPauseIsolatesOnStart,
-          expectedResult: true,
+        final appId = context.appConnection.request.appId;
+        expect(
+          context.dwds!.shouldPauseIsolatesOnStart(appId),
+          equals(true),
         );
-        expect(pauseIsolatesOnStart, equals(true));
       });
 
-      test('pause_isolates_on_start set to false', () async {
+      test('pause_isolates_on_start set to false', () {
         final service = context.service;
         expect(
           service.setFlag('pause_isolates_on_start', 'false'),
           completion(_isSuccess),
         );
-        // Re-try until sucess because the value doesn't get updated
-        // synchronously (it is sent over a stream):
-        final pauseIsolatesOnStart = await retryFn(
-          () => context.dwds!.shouldPauseIsolatesOnStart,
-          expectedResult: false,
+        final appId = context.appConnection.request.appId;
+        expect(
+          context.dwds!.shouldPauseIsolatesOnStart(appId),
+          equals(false),
         );
-        expect(pauseIsolatesOnStart, equals(false));
       });
 
       test('pause_isolates_on_start set to invalid value', () {


### PR DESCRIPTION
Follow up to https://github.com/dart-lang/webdev/pull/2373

The `debugConnection` method (in which we were listening to the `pauseIsolatesOnStartStream`) is actually only called from test code. 🤦‍♀️ 

This allows us to actually access the `pause_isolates_on_start` flag value in the `Dwds` class.

Work towards https://github.com/flutter/devtools/issues/7231



