### PR TITLE
Webdev integration_test should not check for string messages that come from pub

### DIFF
--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -89,10 +89,8 @@ void main() {
           var process = await testRunner
               .runWebDev([command], workingDirectory: d.sandbox);
 
-          await checkProcessStdout(process, [
-            'webdev could not run for this project.',
-            'You must have a dependency on `build_runner` in `pubspec.yaml`.'
-          ]);
+          await checkProcessStdout(
+              process, ['webdev could not run for this project.']);
           await process.shouldExit(78);
         });
 
@@ -110,10 +108,8 @@ void main() {
           var process = await testRunner
               .runWebDev(['serve'], workingDirectory: d.sandbox);
 
-          await checkProcessStdout(process, [
-            'webdev could not run for this project.',
-            'You must have a dependency on `build_web_compilers` in `pubspec.yaml`.'
-          ]);
+          await checkProcessStdout(
+              process, ['webdev could not run for this project.']);
           await process.shouldExit(78);
         });
 
@@ -137,8 +133,7 @@ void main() {
               ['serve', '--no-build-web-compilers'],
               workingDirectory: d.sandbox);
 
-          // Fails since this is a fake package
-          await process.shouldExit(255);
+          await process.shouldExit(78);
         });
       });
 
@@ -183,20 +178,8 @@ void main() {
               var process = await testRunner
                   .runWebDev(['serve'], workingDirectory: d.sandbox);
 
-              if (entry.key == 'build_daemon') {
-                await checkProcessStdout(process, [
-                  'webdev could not run for this project.',
-                  'This version of webdev does not support the `build_daemon`'
-                ]);
-              } else {
-                await checkProcessStdout(process, [
-                  'webdev could not run for this project.',
-                  // See https://github.com/dart-lang/linter/issues/965
-                  // ignore: prefer_adjacent_string_concatenation
-                  'The `${entry.key}` version – $version – ' +
-                      'is not within the allowed constraint – $supportedRange.'
-                ]);
-              }
+              await checkProcessStdout(
+                  process, ['webdev could not run for this project.']);
 
               await process.shouldExit(78);
             });
@@ -208,12 +191,8 @@ void main() {
         var process =
             await testRunner.runWebDev(['serve'], workingDirectory: d.sandbox);
 
-        await checkProcessStdout(process, [
-          'webdev could not run for this project.',
-          // TODO(https://github.com/dart-lang/webdev/issues/2393): Uncomment
-          // this line:
-          // 'Found no `pubspec.yaml` file',
-        ]);
+        await checkProcessStdout(
+            process, ['webdev could not run for this project.']);
         await process.shouldExit(78);
       });
 
@@ -225,13 +204,10 @@ void main() {
           var process = await testRunner
               .runWebDev(['serve'], workingDirectory: d.sandbox);
 
-          await checkProcessStdout(process, [
-            'webdev could not run for this project.',
-            'No pubspec.lock file found, please run "$pubCommand get" first.'
-          ]);
+          await checkProcessStdout(
+              process, ['webdev could not run for this project.']);
           await process.shouldExit(78);
         },
-        skip: 'https://github.com/dart-lang/webdev/issues/2050',
       );
 
       test('should fail if there has been a dependency change', () async {
@@ -252,15 +228,10 @@ dependencies:
         var process =
             await testRunner.runWebDev(['serve'], workingDirectory: d.sandbox);
 
-        await checkProcessStdout(process, [
-          'webdev could not run for this project.',
-          // See https://github.com/dart-lang/linter/issues/965
-          // ignore: prefer_adjacent_string_concatenation
-          'The pubspec.yaml file has changed since the pubspec.lock file ' +
-              'was generated, please run "$pubCommand get" again.'
-        ]);
+        await checkProcessStdout(
+            process, ['webdev could not run for this project.']);
         await process.shouldExit(78);
-      }, skip: 'https://github.com/dart-lang/webdev/issues/2050');
+      });
     });
   }
 }

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -3,21 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'test_utils.dart';
 
 void main() {
-  var sdkVersion = Version.parse(Platform.version.split(' ')[0]);
-  var firstSdkVersionWithoutPub = Version(2, 15, 0, pre: '0');
-
-  var pubCommand =
-      sdkVersion.compareTo(firstSdkVersionWithoutPub) < 0 ? 'pub' : 'dart pub';
-
   final testRunner = TestRunner();
   setUpAll(testRunner.setUpAll);
   tearDownAll(testRunner.tearDownAll);
@@ -145,19 +137,15 @@ void main() {
               var webCompilersVersion = _supportedWebCompilersVersion;
               var buildDaemonVersion = _supportedBuildDaemonVersion;
 
-              late String supportedRange;
               switch (entry.key) {
                 case 'build_runner':
                   buildRunnerVersion = version;
-                  supportedRange = '^$_supportedBuildRunnerVersion';
                   break;
                 case 'build_web_compilers':
                   webCompilersVersion = version;
-                  supportedRange = '^$_supportedWebCompilersVersion';
                   break;
                 case 'build_daemon':
                   buildDaemonVersion = version;
-                  supportedRange = '^$_supportedBuildDaemonVersion';
               }
 
               await d.file('pubspec.yaml', _pubspecYaml).create();

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -81,8 +81,7 @@ void main() {
           var process = await testRunner
               .runWebDev([command], workingDirectory: d.sandbox);
 
-          await checkProcessStdout(
-              process, ['webdev could not run for this project.']);
+          await checkProcessStdout(process, ['webdev could not run']);
           await process.shouldExit(78);
         });
 
@@ -100,8 +99,7 @@ void main() {
           var process = await testRunner
               .runWebDev(['serve'], workingDirectory: d.sandbox);
 
-          await checkProcessStdout(
-              process, ['webdev could not run for this project.']);
+          await checkProcessStdout(process, ['webdev could not run']);
           await process.shouldExit(78);
         });
 
@@ -125,7 +123,7 @@ void main() {
               ['serve', '--no-build-web-compilers'],
               workingDirectory: d.sandbox);
 
-          await process.shouldExit(78);
+          await process.shouldExit();
         });
       });
 
@@ -166,8 +164,7 @@ void main() {
               var process = await testRunner
                   .runWebDev(['serve'], workingDirectory: d.sandbox);
 
-              await checkProcessStdout(
-                  process, ['webdev could not run for this project.']);
+              await checkProcessStdout(process, ['webdev could not run']);
 
               await process.shouldExit(78);
             });
@@ -179,8 +176,7 @@ void main() {
         var process =
             await testRunner.runWebDev(['serve'], workingDirectory: d.sandbox);
 
-        await checkProcessStdout(
-            process, ['webdev could not run for this project.']);
+        await checkProcessStdout(process, ['webdev could not run']);
         await process.shouldExit(78);
       });
 
@@ -192,8 +188,7 @@ void main() {
           var process = await testRunner
               .runWebDev(['serve'], workingDirectory: d.sandbox);
 
-          await checkProcessStdout(
-              process, ['webdev could not run for this project.']);
+          await checkProcessStdout(process, ['webdev could not run']);
           await process.shouldExit(78);
         },
       );
@@ -216,8 +211,7 @@ dependencies:
         var process =
             await testRunner.runWebDev(['serve'], workingDirectory: d.sandbox);
 
-        await checkProcessStdout(
-            process, ['webdev could not run for this project.']);
+        await checkProcessStdout(process, ['webdev could not run']);
         await process.shouldExit(78);
       });
     });


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/2404,  https://github.com/dart-lang/webdev/issues/2050

Whenever pub updates the failure messages for proper package validation, this integration test fails because we are checking string messages that come from `pub`, not `webdev`. This removes validating that the messages from pub are what is expected, since we don't control those messages in the first place (and therefore shouldn't be testing them). 