### PR TITLE
Pin DCM to latest version

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -19,7 +19,7 @@ jobs:
           wget -qO- https://dcm.dev/pgp-key.public | sudo gpg --dearmor -o /usr/share/keyrings/dcm.gpg
           echo 'deb [signed-by=/usr/share/keyrings/dcm.gpg arch=amd64] https://dcm.dev/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
           sudo apt-get update
-          sudo apt-get install dcm
+          sudo apt-get install dcm=1.16.2-1 # To avoid errors add `-1` (build number) to the version
           sudo chmod +x /usr/bin/dcm
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3


### PR DESCRIPTION
This is equivalent to what Devtools did a while back: https://github.com/flutter/devtools/pull/6703

It ensures that we don't get new DCM failures on PRs when DCM is updated
