### PR TITLE
Move DWDS launch event

### DIFF
--- a/dwds/lib/dart_web_debug_service.dart
+++ b/dwds/lib/dart_web_debug_service.dart
@@ -131,8 +131,6 @@ class Dwds {
       debugSettings.launchDevToolsInNewWindow,
     );
 
-    _maybeEmitDwdsLaunchEvent(toolConfiguration);
-
     return Dwds._(
       injected.middleware,
       devTools,
@@ -140,18 +138,6 @@ class Dwds {
       assetReader,
       debugSettings.enableDebugging,
     );
-  }
-
-  static void _maybeEmitDwdsLaunchEvent(ToolConfiguration toolConfiguration) {
-    if (toolConfiguration.appMetadata.codeRunner != null) {
-      emitEvent(
-        DwdsEvent.dwdsLaunch(
-          codeRunner: toolConfiguration.appMetadata.codeRunner!,
-          isFlutterApp:
-              toolConfiguration.loadStrategy.buildSettings.isFlutterApp,
-        ),
-      );
-    }
   }
 
   bool shouldPauseIsolatesOnStart(String appId) =>

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -525,6 +525,10 @@ class DevHandler {
             ');',
       },
     );
+
+    // Notify that DWDS has been launched and a debug connection has been made:
+    _maybeEmitDwdsLaunchEvent();
+
     return appDebugService;
   }
 
@@ -689,6 +693,18 @@ class DevHandler {
       emitEvent(
         DwdsEvent.dwdsAttach(
           client: request.client!,
+          isFlutterApp:
+              globalToolConfiguration.loadStrategy.buildSettings.isFlutterApp,
+        ),
+      );
+    }
+  }
+
+  static void _maybeEmitDwdsLaunchEvent() {
+    if (globalToolConfiguration.appMetadata.codeRunner != null) {
+      emitEvent(
+        DwdsEvent.dwdsLaunch(
+          codeRunner: globalToolConfiguration.appMetadata.codeRunner!,
           isFlutterApp:
               globalToolConfiguration.loadStrategy.buildSettings.isFlutterApp,
         ),


### PR DESCRIPTION
Follow up to https://github.com/dart-lang/webdev/pull/2418

In google3, the buildSettings are not actually created until the app's entrypoint is loaded, which means that this was throwing a null-pointer exception. 

Instead, we send the dwds launch event only once we have a debug connection with the app (which ensures that we have loaded the entrypoint).
