### PR TITLE
Log a single error message when async or sync frame calculation fails

### DIFF
--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -54,6 +54,8 @@ class Debugger extends Domain {
   final Locations _locations;
   final SkipLists _skipLists;
 
+  int _frameErrorCount = 0;
+
   Debugger._(
     this._remoteDebugger,
     this._streamNotify,
@@ -465,13 +467,21 @@ class Debugger extends Domain {
       try {
         dartFrame.vars = await variablesFor(frame);
       } catch (e) {
-        logger.warning(
-          'Error calculating Dart variables for frame $frameIndex: $e',
-        );
+        _frameErrorCount++;
       }
     }
 
     return dartFrame;
+  }
+
+  /// Can be called after [calculateDartFrameFor] to log any errors.
+  void logAnyFrameErrors({required String frameType}) {
+    if (_frameErrorCount > 0) {
+      logger.warning(
+        'Error calculating Dart variables for $_frameErrorCount $frameType frames.',
+      );
+    }
+    _frameErrorCount = 0;
   }
 
   void _scriptParsedHandler(ScriptParsedEvent e) {

--- a/dwds/lib/src/debugging/frame_computer.dart
+++ b/dwds/lib/src/debugging/frame_computer.dart
@@ -73,6 +73,7 @@ class FrameComputer {
         logger.warning('Error calculating sync frame: $e');
       }
     }
+    debugger.logAnyFrameErrors(frameType: 'sync');
   }
 
   Future<void> _collectAsyncFrames({int? limit}) async {
@@ -129,6 +130,7 @@ class FrameComputer {
             logger.warning('Error calculating async frame: $e');
           }
         }
+        debugger.logAnyFrameErrors(frameType: 'async');
       }
 
       // Async frames are no longer on the stack - we don't have local variable


### PR DESCRIPTION
Follow-up to https://github.com/dart-lang/webdev/pull/2408, where we began logging frame calculation errors.

When this happens, it seems that a lot of frames are unable to be calculated, not just a few (see screenshot below). This PR adds logic to keep track of the error count, and log that instead (to avoid spamming the console).


![Screenshot 2024-05-10 at 10 26 24 AM](https://github.com/dart-lang/webdev/assets/21270878/77855ddc-dc74-47c4-a358-a5df76f1c544)
