### PR TITLE
Register a restart handler directly over the VM service connection

### DIFF
--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -28,6 +28,7 @@ typedef VmResponse = Map<String, Object?>;
 
 enum _NamespacedServiceExtension {
   extDwdsEmitEvent(method: 'ext.dwds.emitEvent'),
+  extDwdsRestart(method: 'ext.dwds.restart'),
   extDwdsScreenshot(method: 'ext.dwds.screenshot'),
   extDwdsSendEvent(method: 'ext.dwds.sendEvent'),
   flutterListViews(method: '_flutter.listViews');
@@ -193,6 +194,8 @@ class DwdsVmClient {
       response = await _flutterListViewsHandler(chromeProxyService);
     } else if (method == _NamespacedServiceExtension.extDwdsEmitEvent.method) {
       response = _extDwdsEmitEventHandler(request);
+    } else if (method == _NamespacedServiceExtension.extDwdsRestart.method) {
+      response = await _extDwdsRestartHandler(chromeProxyService);
     } else if (method == _NamespacedServiceExtension.extDwdsSendEvent.method) {
       response = await _extDwdsSendEventHandler(request, dwdsStats);
     } else if (method == _NamespacedServiceExtension.extDwdsScreenshot.method) {
@@ -259,6 +262,13 @@ class DwdsVmClient {
       }
     }
 
+    return {'result': Success().toJson()};
+  }
+
+  static Future<Map<String, Object>> _extDwdsRestartHandler(
+    ChromeProxyService chromeProxyService,
+  ) async {
+    await _fullReload(chromeProxyService);
     return {'result': Success().toJson()};
   }
 


### PR DESCRIPTION
This is a workaround for a Cider bug, see b/342668928 for details.