### PR TITLE
Send a `kPausePostRequest` after restarting to notify clients to resume

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix bug where debugging clients are not aware of service extensions when connecting to a new web app. - [#2388](https://github.com/dart-lang/webdev/pull/2388)
 - Respect the value of `pause_isolates_on_start` during page-refreshes. - [#2431](https://github.com/dart-lang/webdev/pull/2431)
+- Fix issue where DAP clients wouldn't resume after a restart. - [#2441](https://github.com/dart-lang/webdev/pull/2441)
 
 ## 24.0.0
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -99,6 +99,9 @@ class ChromeProxyService implements VmServiceInterface {
   /// This value can be updated at runtime via [setFlag].
   bool get pauseIsolatesOnStart => _pauseIsolatesOnStart;
 
+  /// Whether or not the connected app has a pending restart.
+  bool get hasPendingRestart => _resumeAfterRestartEventsController.hasListener;
+
   final _resumeAfterRestartEventsController =
       StreamController<String>.broadcast();
 
@@ -350,6 +353,20 @@ class ChromeProxyService implements VmServiceInterface {
           timestamp: timestamp,
           isolate: isolateRef,
         )..extensionRPC = extensionRpc,
+      );
+    }
+
+    // If the new isolate was created as part of a restart, send a
+    // kPausePostRequest event to notify client that the app is paused so that
+    // it can resume:
+    if (hasPendingRestart) {
+      _streamNotify(
+        'Debug',
+        Event(
+          kind: EventKind.kPausePostRequest,
+          timestamp: timestamp,
+          isolate: isolateRef,
+        ),
       );
     }
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/55860

DAP is waiting for a `kPausePostRequest` after restarting to know to resume the isolate. DWDS was never sending this event, so the app was never resumed: https://github.com/dart-lang/sdk/blob/6549a66a50c7a732e51df68322c604936057ecea/pkg/dds/lib/src/dap/isolate_manager.dart#L644
