### PR TITLE
Hide more temporary variables when debugging

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Respect the value of `pause_isolates_on_start` during page-refreshes. - [#2431](https://github.com/dart-lang/webdev/pull/2431)
 - Fix issue where DAP clients wouldn't resume after a restart. - [#2441](https://github.com/dart-lang/webdev/pull/2441)
 - Add implementation for the VM Service's `getFlagList` API. - [#2438](https://github.com/dart-lang/webdev/pull/2438)
+- Hide more variables from the local scope when debugging. These variables were synthetically added by the compiler to
+  support late local variables and don't appear in the original source code. - [#2445](https://github.com/dart-lang/webdev/pull/2445)
 
 ## 24.0.0
 

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -12,7 +12,15 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 /// TODO(annagrin) - use an alternative way to identify
 /// synthetic variables.
 /// Issue: https://github.com/dart-lang/sdk/issues/44262
-final ddcTemporaryVariableRegExp = RegExp(r'^t(\$[0-9]*)+\w*$');
+final ddcTemporaryVariableRegExp = RegExp(
+    // Starts with t$
+    r'^t\$'
+    // followed by anything
+    r'.*'
+    // or,
+    r'|'
+    // anything that contains the sequence '$35'.
+    r'.*\$35.*');
 final ddcTemporaryTypeVariableRegExp = RegExp(r'^__t[\$\w*]+$');
 
 /// Temporary variable regex before SDK changes for patterns.

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -71,6 +71,14 @@ void main() {
         ddcTemporaryVariableRegExp.hasMatch(r't$36$350$354$35isSet'),
         isTrue,
       );
+      expect(
+        ddcTemporaryVariableRegExp.hasMatch(r't$36$35variable$35isSet'),
+        isTrue,
+      );
+      expect(
+        ddcTemporaryVariableRegExp.hasMatch(r'synthetic$35variable'),
+        isTrue,
+      );
       expect(ddcTemporaryTypeVariableRegExp.hasMatch(r'__t$TL'), isTrue);
       expect(ddcTemporaryTypeVariableRegExp.hasMatch(r'__t$StringN'), isTrue);
       expect(
@@ -84,6 +92,7 @@ void main() {
       expect(ddcTemporaryVariableRegExp.hasMatch(r't10'), isFalse);
       expect(ddcTemporaryVariableRegExp.hasMatch(r't10foo'), isFalse);
       expect(ddcTemporaryVariableRegExp.hasMatch(r'ten'), isFalse);
+      expect(ddcTemporaryVariableRegExp.hasMatch(r'my$3635variable'), isFalse);
     });
   });
 


### PR DESCRIPTION
Some variables created by DDC that are not present in the original source code were being shown by the debugger in the local scope.

Update the regular expression used to detect temporary variable names. It has been simplified to: if the variable starts with 't$' or contains '$35' then it should be hidden.

DDC names it's temporary variables to start with the characters `t$`. Hiding all of these does hide some valid variable names that could appear in the original source, but that is the status quo and not being changed here. In addition some names that are created by the CFE and added to the program contain an illegal character '#' which DDC replaces as '$35'. Variables with this sequence in the name can't appear in the original source so we hide them as well.

This should hide variables synthetically added to support late local variables.