### PR TITLE
Fixing Set runtime type names in DDC

### DIFF
--- a/dwds/test/instances/common/instance_inspection_common.dart
+++ b/dwds/test/instances/common/instance_inspection_common.dart
@@ -295,7 +295,7 @@ void runTests({
           final instanceId = instanceRef.id!;
           expect(
             await getObject(instanceId),
-            matchSetInstance(type: '_HashSet<int>'),
+            matchSetInstance(type: 'LinkedSet<int>'),
           );
 
           expect(


### PR DESCRIPTION
Fixes tests that break due to https://dart-review.googlesource.com/c/sdk/+/373327

DDC now represents `_HashSet` object as `LinkedSet` in its internal representation (no implementation changes).