### PR TITLE
Re-enable skipped frontend_server_client test cases

### DIFF
--- a/frontend_server_client/test/frontend_server_client_test.dart
+++ b/frontend_server_client/test/frontend_server_client_test.dart
@@ -117,8 +117,6 @@ String get message => p.join('hello', 'world');
       expect(await stdoutLines.next, p.join('goodbye', 'world'));
       expect(await process.exitCode, 0);
     },
-    // Issue: https://github.com/dart-lang/webdev/issues/2377
-    skip: Platform.isWindows,
   );
 
   test(
@@ -186,8 +184,6 @@ String get message => p.join('hello', 'world');
       expect(await stdoutLines.next, p.join('goodbye', 'world'));
       expect(await process.exitCode, 0);
     },
-    // Issue: https://github.com/dart-lang/webdev/issues/2377
-    skip: Platform.isWindows,
   );
 
   test('can compile and recompile a dartdevc app', () async {


### PR DESCRIPTION
I believe that the issue causing the timeouts was fixed in https://github.com/dart-lang/sdk/commit/69b801f73f7b26adb661257ecab862eca6dcf7dd.

Fixes: https://github.com/dart-lang/webdev/issues/2377