### PR TITLE
Fix getProperties invocation passing length for all objects.

### DIFF
--- a/dwds/lib/src/debugging/instance.dart
+++ b/dwds/lib/src/debugging/instance.dart
@@ -268,7 +268,9 @@ class InstanceHelper extends Domain {
       objectId,
       offset: offset,
       count: count,
-      length: metaData.length,
+      length: metaData.kind != InstanceKind.kPlainInstance
+          ? metaData.length
+          : null,
     );
 
     final dartProperties = await _dartFieldsFor(properties, remoteObject);


### PR DESCRIPTION
The vm_service [Instance](https://github.com/dart-lang/sdk/blob/main/pkg/vm_service/lib/src/vm_service.dart#L4621) spec specifies that the `length` property specifies that `length` should be the number of non-static fields for plain objects. In order to align with the VM we've updated the DDC debugger API to include this value of `length` on plain objects.

However, [`getProperties`](https://github.com/dart-lang/webdev/blob/main/dwds/lib/src/debugging/inspector.dart#L578) is assuming that if a length is provided then it should do a range check with the provided `offset` and `count`. This was causing the `getProperties` code to exit early with no value. 

To fix this we only pass the `length` to `getProperties` if the `kind` of the object being inspected is not a plain object. Plain objects should never need a range check.

Fixes https://github.com/dart-lang/webdev/issues/2479.