### PR TITLE
replace deprecated __proto__ from js code

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 24.2.0-wip
-- Replace deprecated JS code - [#2500](https://github.com/dart-lang/webdev/pull/2500)
+- Replace deprecated JS code `this.__proto__` with `Object.getPrototypeOf(this)` - [#2500](https://github.com/dart-lang/webdev/pull/2500)
 
 ## 24.1.0
 

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 24.2.0-wip
+- Replace deprecated JS code - [#2500](https://github.com/dart-lang/webdev/pull/2500)
 
 ## 24.1.0
 

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -215,7 +215,7 @@ class AppInspector implements AppInspectorInterface {
     // We use the JS pseudo-variable 'arguments' to get the list of all arguments.
     final send = '''
         function () {
-          if (!(Object.getPrototypeOf(this))) { return 'Instance of PlainJavaScriptObject';}
+          if (!Object.getPrototypeOf(this)) { return 'Instance of PlainJavaScriptObject';}
           return ${globalToolConfiguration.loadStrategy.loadModuleSnippet}("dart_sdk").dart.dsendRepl(this, "$methodName", arguments);
         }
         ''';

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -215,7 +215,7 @@ class AppInspector implements AppInspectorInterface {
     // We use the JS pseudo-variable 'arguments' to get the list of all arguments.
     final send = '''
         function () {
-          if (!(this.__proto__)) { return 'Instance of PlainJavaScriptObject';}
+          if (!(Object.getPrototypeOf(this))) { return 'Instance of PlainJavaScriptObject';}
           return ${globalToolConfiguration.loadStrategy.loadModuleSnippet}("dart_sdk").dart.dsendRepl(this, "$methodName", arguments);
         }
         ''';


### PR DESCRIPTION
Replaced deprecated code `this.__proto__` from js code with Object.getPrototypeOf(this).

https://github.com/dart-lang/webdev/issues/2118