### PR TITLE
Use var/final consistently across repository

### DIFF
--- a/_analysis_config/lib/analysis_options.yaml
+++ b/_analysis_config/lib/analysis_options.yaml
@@ -29,6 +29,7 @@ linter:
     - only_throw_errors
     - package_api_docs
     - package_prefixed_library_names
+    - prefer_final_in_for_each
     - prefer_final_locals
     - prefer_single_quotes
     # - prefer_relative_imports

--- a/_analysis_config/lib/analysis_options.yaml
+++ b/_analysis_config/lib/analysis_options.yaml
@@ -25,16 +25,16 @@ linter:
     - join_return_with_assignment
     - library_names
     - literal_only_boolean_expressions
+    - omit_local_variable_types
+    - only_throw_errors
     - package_api_docs
     - package_prefixed_library_names
-    # - prefer_final_locals
-    # - prefer_relative_imports
+    - prefer_final_locals
     - prefer_single_quotes
+    # - prefer_relative_imports
     - prefer_void_to_null
     - test_types_in_equals
     - throw_in_finally
-    - omit_local_variable_types
-    - only_throw_errors
     - unawaited_futures
     - unnecessary_lambdas
     - unnecessary_parenthesis

--- a/dwds/analysis_options.yaml
+++ b/dwds/analysis_options.yaml
@@ -10,5 +10,4 @@ analyzer:
 linter:
   rules:
     - always_use_package_imports
-    - prefer_final_locals
     - require_trailing_commas

--- a/dwds/debug_extension/web/detector.dart
+++ b/dwds/debug_extension/web/detector.dart
@@ -78,7 +78,7 @@ void _detectMultipleDartAppsCallback(
   List<dynamic> mutations,
   MutationObserver observer,
 ) {
-  for (var mutation in mutations) {
+  for (final mutation in mutations) {
     if (_isMultipleAppsMutation(mutation)) {
       _sendMessageToBackgroundScript(
         type: MessageType.multipleAppsDetected,

--- a/dwds/lib/src/debugging/classes.dart
+++ b/dwds/lib/src/debugging/classes.dart
@@ -22,7 +22,7 @@ class ClassHelper extends Domain {
       classRefForString,
       classRefForUnknown,
     ];
-    for (var classRef in staticClasses) {
+    for (final classRef in staticClasses) {
       final classId = classRef.id;
       if (classId != null) {
         _classes[classId] = Class(

--- a/dwds/lib/src/debugging/dart_scope.dart
+++ b/dwds/lib/src/debugging/dart_scope.dart
@@ -56,7 +56,7 @@ Future<List<Property>> visibleVariables({
 
   // Iterate to least specific scope last to help preserve order in the local
   // variables view when stepping.
-  for (var scope in filterScopes(frame).reversed) {
+  for (final scope in filterScopes(frame).reversed) {
     final objectId = scope.object.objectId;
     if (objectId != null) {
       final properties = await inspector.getProperties(objectId);

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -538,7 +538,7 @@ class AppInspector implements AppInspectorInterface {
     // breakpoints. This is because the token positions are derived from the
     // DDC source maps which Chrome also uses.
     final tokenPositions = <int>[
-      for (var location in mappedLocations) location.tokenPos,
+      for (final location in mappedLocations) location.tokenPos,
     ];
     tokenPositions.sort();
 
@@ -710,11 +710,11 @@ class AppInspector implements AppInspectorInterface {
       // for them.
       final userLibraries =
           _userLibraryUris(isolate.libraries ?? <LibraryRef>[]);
-      for (var uri in userLibraries) {
+      for (final uri in userLibraries) {
         final parts = scripts[uri];
         final scriptRefs = [
           ScriptRef(uri: uri, id: createId()),
-          for (var part in parts ?? []) ScriptRef(uri: part, id: createId()),
+          for (final part in parts ?? []) ScriptRef(uri: part, id: createId()),
         ];
         final libraryRef = await _libraryHelper.libraryRefFor(uri);
         final libraryId = libraryRef?.id;
@@ -723,7 +723,7 @@ class AppInspector implements AppInspectorInterface {
             libraryId,
             () => <ScriptRef>[],
           );
-          for (var scriptRef in scriptRefs) {
+          for (final scriptRef in scriptRefs) {
             final scriptId = scriptRef.id;
             final scriptUri = scriptRef.uri;
             if (scriptId != null && scriptUri != null) {

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -56,7 +56,7 @@ class LibraryHelper extends Domain {
     final libraries = await globalToolConfiguration.loadStrategy
         .metadataProviderFor(inspector.appConnection.request.entrypointPath)
         .libraries;
-    for (var library in libraries) {
+    for (final library in libraries) {
       _libraryRefsById[library] =
           LibraryRef(id: library, name: library, uri: library);
     }

--- a/dwds/lib/src/debugging/location.dart
+++ b/dwds/lib/src/debugging/location.dart
@@ -227,7 +227,7 @@ class Locations {
     int column,
   ) {
     Location? bestLocation;
-    for (var location in locations) {
+    for (final location in locations) {
       if (location.dartLocation.line == line &&
           location.dartLocation.column >= column) {
         bestLocation ??= location;
@@ -255,7 +255,7 @@ class Locations {
   ) {
     column ??= 0;
     Location? bestLocation;
-    for (var location in locations) {
+    for (final location in locations) {
       if (location.jsLocation.compareToLine(line, column) <= 0) {
         bestLocation ??= location;
         if (location.jsLocation.compareTo(bestLocation.jsLocation) > 0) {
@@ -277,16 +277,16 @@ class Locations {
     tokenPosTable = <List<int>>[];
     final locations = await locationsForDart(serverPath);
     final lineNumberToLocation = <int, Set<Location>>{};
-    for (var location in locations) {
+    for (final location in locations) {
       lineNumberToLocation
           .putIfAbsent(location.dartLocation.line, () => <Location>{})
           .add(location);
     }
-    for (var lineNumber in lineNumberToLocation.keys) {
+    for (final lineNumber in lineNumberToLocation.keys) {
       final locations = lineNumberToLocation[lineNumber]!;
       tokenPosTable.add([
         lineNumber,
-        for (var location in locations) ...[
+        for (final location in locations) ...[
           location.tokenPos,
           location.dartLocation.column,
         ],
@@ -341,8 +341,8 @@ class Locations {
       final mapping = parse(sourceMapContents);
       if (mapping is SingleMapping) {
         // Create TokenPos for each entry in the source map.
-        for (var lineEntry in mapping.lines) {
-          for (var entry in lineEntry.entries) {
+        for (final lineEntry in mapping.lines) {
+          for (final entry in lineEntry.entries) {
             final location = _locationForSourceMapEntry(
               lineEntry: lineEntry,
               entry: entry,
@@ -357,7 +357,7 @@ class Locations {
           }
         }
       }
-      for (var location in result) {
+      for (final location in result) {
         _sourceToLocation
             .putIfAbsent(
               location.dartLocation.uri.serverPath,

--- a/dwds/lib/src/debugging/metadata/module_metadata.dart
+++ b/dwds/lib/src/debugging/metadata/module_metadata.dart
@@ -161,7 +161,7 @@ class ModuleMetadata {
           '\n    ${ModuleMetadataVersion.previous.version}');
     }
 
-    for (var l in _readRequiredList(json, 'libraries')) {
+    for (final l in _readRequiredList(json, 'libraries')) {
       addLibrary(LibraryMetadata.fromJson(l as Map<String, dynamic>));
     }
   }
@@ -173,7 +173,7 @@ class ModuleMetadata {
       'closureName': closureName,
       'sourceMapUri': sourceMapUri,
       'moduleUri': moduleUri,
-      'libraries': [for (var lib in libraries.values) lib.toJson()],
+      'libraries': [for (final lib in libraries.values) lib.toJson()],
       'soundNullSafety': soundNullSafety,
     };
   }

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -189,7 +189,7 @@ class MetadataProvider {
         final merged = await _assetReader.metadataContents(serverPath);
         if (merged != null) {
           _addSdkMetadata();
-          for (var contents in merged.split('\n')) {
+          for (final contents in merged.split('\n')) {
             try {
               if (contents.isEmpty ||
                   contents.startsWith('// intentionally empty:')) {
@@ -227,7 +227,7 @@ class MetadataProvider {
     _modulePathToModule[modulePath] = metadata.name;
     _moduleToModulePath[metadata.name] = modulePath;
 
-    for (var library in metadata.libraries.values) {
+    for (final library in metadata.libraries.values) {
       if (library.importUri.startsWith('file:/')) {
         throw AbsoluteImportUriException(library.importUri);
       }
@@ -235,7 +235,7 @@ class MetadataProvider {
       _scripts[library.importUri] = [];
 
       _scriptToModule[library.importUri] = metadata.name;
-      for (var path in library.partUris) {
+      for (final path in library.partUris) {
         // Parts in metadata are relative to the library Uri directory.
         final partPath = p.url.join(p.dirname(library.importUri), path);
         _scripts[library.importUri]!.add(partPath);
@@ -247,7 +247,7 @@ class MetadataProvider {
   void _addSdkMetadata() {
     final moduleName = 'dart_sdk';
 
-    for (var lib in sdkLibraries) {
+    for (final lib in sdkLibraries) {
       _libraries.add(lib);
       _scripts[lib] = [];
       _scriptToModule[lib] = moduleName;

--- a/dwds/lib/src/debugging/modules.dart
+++ b/dwds/lib/src/debugging/modules.dart
@@ -80,7 +80,7 @@ class Modules {
     final libraryToScripts = await provider.scripts;
     final scriptToModule = await provider.scriptToModule;
 
-    for (var library in libraryToScripts.keys) {
+    for (final library in libraryToScripts.keys) {
       final scripts = libraryToScripts[library]!;
       final libraryServerPath = library.startsWith('dart:')
           ? library
@@ -93,7 +93,7 @@ class Modules {
         _sourceToLibrary[libraryServerPath] = Uri.parse(library);
         _libraryToModule[library] = module;
 
-        for (var script in scripts) {
+        for (final script in scripts) {
           final scriptServerPath = script.startsWith('dart:')
               ? script
               : DartUri(script, _root).serverPath;

--- a/dwds/lib/src/debugging/skip_list.dart
+++ b/dwds/lib/src/debugging/skip_list.dart
@@ -30,7 +30,7 @@ class SkipLists {
     final ranges = <Map<String, dynamic>>[];
     var startLine = 0;
     var startColumn = 0;
-    for (var location in sortedLocations) {
+    for (final location in sortedLocations) {
       var endLine = location.jsLocation.line;
       var endColumn = location.jsLocation.column;
       // Stop before the known location.

--- a/dwds/lib/src/dwds_vm_client.dart
+++ b/dwds/lib/src/dwds_vm_client.dart
@@ -235,7 +235,7 @@ class DwdsVmClient {
     return <String, Object>{
       'result': <String, Object>{
         'views': <Object>[
-          for (var isolate in isolates ?? [])
+          for (final isolate in isolates ?? [])
             <String, Object>{
               'id': isolate.id,
               'isolate': isolate.toJson(),

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -109,10 +109,10 @@ class DevHandler {
       };
 
   Future<void> close() => _closed ??= () async {
-        for (var sub in _subs) {
+        for (final sub in _subs) {
           await sub.cancel();
         }
-        for (var handler in _sseHandlers.values) {
+        for (final handler in _sseHandlers.values) {
           handler.shutdown();
         }
         await Future.wait(
@@ -123,7 +123,7 @@ class DevHandler {
 
   void _emitBuildResults(BuildResult result) {
     if (result.status != BuildStatus.succeeded) return;
-    for (var injectedConnection in _injectedConnections) {
+    for (final injectedConnection in _injectedConnections) {
       injectedConnection.sink.add(jsonEncode(serializers.serialize(result)));
     }
   }
@@ -137,7 +137,7 @@ class DevHandler {
     ExecutionContext? executionContext;
     WipConnection? tabConnection;
     final appInstanceId = appConnection.request.instanceId;
-    for (var tab in await chromeConnection.getTabs()) {
+    for (final tab in await chromeConnection.getTabs()) {
       if (tab.isChromeExtension || tab.isBackgroundPage) continue;
 
       final connection = tabConnection = await tab.connect();
@@ -162,7 +162,7 @@ class DevHandler {
       // before events are received.
       safeUnawaited(Future.microtask(connection.runtime.enable));
 
-      await for (var contextId in contextIds) {
+      await for (final contextId in contextIds) {
         final result = await connection.sendCommand('Runtime.evaluate', {
           'expression': r'window["$dartAppInstanceId"];',
           'contextId': contextId,

--- a/dwds/lib/src/loaders/build_runner_require.dart
+++ b/dwds/lib/src/loaders/build_runner_require.dart
@@ -68,7 +68,7 @@ class BuildRunnerRequireStrategyProvider {
     }
 
     return {
-      for (var entry in digests.entries)
+      for (final entry in digests.entries)
         if (modules.containsKey(entry.key))
           modules[entry.key]!: entry.value as String,
     };
@@ -88,7 +88,7 @@ class BuildRunnerRequireStrategyProvider {
   ) async {
     final modulePathToModule = await metadataProvider.modulePathToModule;
     final relativePath = stripLeadingSlashes(serverPath);
-    for (var e in modulePathToModule.entries) {
+    for (final e in modulePathToModule.entries) {
       if (stripTopLevelDirectory(e.key) == relativePath) {
         return e.value;
       }
@@ -129,7 +129,7 @@ class BuildRunnerRequireStrategyProvider {
   ) async {
     final modules = await metadataProvider.modules;
     final result = <String, ModuleInfo>{};
-    for (var module in modules) {
+    for (final module in modules) {
       final serverPath = await _serverPathForModule(metadataProvider, module);
       if (serverPath == null) {
         _logger.warning('No module info found for module $module');

--- a/dwds/lib/src/loaders/frontend_server_ddc.dart
+++ b/dwds/lib/src/loaders/frontend_server_ddc.dart
@@ -102,7 +102,7 @@ class FrontendServerDdcStrategyProvider {
   ) async {
     final modules = await metadataProvider.moduleToModulePath;
     final result = <String, ModuleInfo>{};
-    for (var module in modules.keys) {
+    for (final module in modules.keys) {
       final modulePath = modules[module]!;
       result[module] = ModuleInfo(
         // TODO: Save locations of full kernel files in ddc metadata.

--- a/dwds/lib/src/loaders/frontend_server_require.dart
+++ b/dwds/lib/src/loaders/frontend_server_require.dart
@@ -100,7 +100,7 @@ class FrontendServerRequireStrategyProvider {
   ) async {
     final modules = await metadataProvider.moduleToModulePath;
     final result = <String, ModuleInfo>{};
-    for (var module in modules.keys) {
+    for (final module in modules.keys) {
       final modulePath = modules[module]!;
       result[module] = ModuleInfo(
         // TODO: Save locations of full kernel files in ddc metadata.

--- a/dwds/lib/src/readers/frontend_server_asset_reader.dart
+++ b/dwds/lib/src/readers/frontend_server_asset_reader.dart
@@ -111,7 +111,7 @@ class FrontendServerAssetReader implements AssetReader {
     final sourceContents = map.readAsBytesSync();
     final sourceInfo =
         jsonDecode(json.readAsStringSync()) as Map<String, dynamic>;
-    for (var key in sourceInfo.keys) {
+    for (final key in sourceInfo.keys) {
       final info = sourceInfo[key];
       _mapContents[key] = utf8.decode(
         sourceContents

--- a/dwds/lib/src/servers/extension_debugger.dart
+++ b/dwds/lib/src/servers/extension_debugger.dart
@@ -101,7 +101,7 @@ class ExtensionDebugger implements RemoteDebugger {
             _notificationController.sink.add(WipEvent(map));
           }
         } else if (message is BatchedEvents) {
-          for (var event in message.events) {
+          for (final event in message.events) {
             final map = {
               'method': json.decode(event.method),
               'params': json.decode(event.params),

--- a/dwds/lib/src/services/batched_expression_evaluator.dart
+++ b/dwds/lib/src/services/batched_expression_evaluator.dart
@@ -76,7 +76,7 @@ class BatchedExpressionEvaluator extends ExpressionEvaluator {
     Map<String, String>? scope;
     var currentRequests = <EvaluateRequest>[];
 
-    for (var request in requests) {
+    for (final request in requests) {
       libraryUri ??= request.libraryUri;
       isolateId ??= request.isolateId;
       scope ??= request.scope;

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -350,7 +350,7 @@ class ChromeProxyService implements VmServiceInterface {
     // TODO: We shouldn't need to fire these events since they exist on the
     // isolate, but devtools doesn't recognize extensions after a page refresh
     // otherwise.
-    for (var extensionRpc in inspector.isolate.extensionRPCs ?? []) {
+    for (final extensionRpc in inspector.isolate.extensionRPCs ?? []) {
       _streamNotify(
         'Isolate',
         Event(
@@ -411,7 +411,7 @@ class ChromeProxyService implements VmServiceInterface {
     if (!_isIsolateRunning) return;
     final isolate = inspector.isolate;
 
-    for (var breakpoint in isolate.breakpoints?.toList() ?? []) {
+    for (final breakpoint in isolate.breakpoints?.toList() ?? []) {
       await (await debuggerFuture).removeBreakpoint(breakpoint.id);
     }
   }
@@ -1429,7 +1429,7 @@ ${globalToolConfiguration.loadStrategy.loadModuleSnippet}("dart_sdk").developer.
   /// Parses the [BatchedDebugEvents] and emits corresponding Dart VM Service
   /// protocol [Event]s.
   void parseBatchedDebugEvents(BatchedDebugEvents debugEvents) {
-    for (var debugEvent in debugEvents.events) {
+    for (final debugEvent in debugEvents.events) {
       parseDebugEvent(debugEvent);
     }
   }
@@ -1590,7 +1590,7 @@ ${globalToolConfiguration.loadStrategy.loadModuleSnippet}("dart_sdk").developer.
 
   Map<String, RemoteObject> _fetchAbbreviatedLogParams(Map? logObject) {
     final logParams = <String, RemoteObject>{};
-    for (dynamic property in logObject?['preview']?['properties'] ?? []) {
+    for (final dynamic property in logObject?['preview']?['properties'] ?? []) {
       if (property is Map<String, dynamic> && property['name'] != null) {
         logParams[property['name'] as String] = RemoteObject(property);
       }

--- a/dwds/lib/src/services/expression_compiler_service.dart
+++ b/dwds/lib/src/services/expression_compiler_service.dart
@@ -132,7 +132,7 @@ class _Compiler {
     final response = await _send({
       'command': 'UpdateDeps',
       'inputs': [
-        for (var moduleName in modules.keys)
+        for (final moduleName in modules.keys)
           {
             'path': modules[moduleName]!.fullDillPath,
             'summaryPath': modules[moduleName]!.summaryPath,

--- a/dwds/lib/src/services/expression_evaluator.dart
+++ b/dwds/lib/src/services/expression_evaluator.dart
@@ -471,7 +471,7 @@ class ExpressionEvaluator {
     final scope = <String, String>{};
 
     void collectVariables(Iterable<chrome.Property> variables) {
-      for (var p in variables) {
+      for (final p in variables) {
         final name = p.name;
         final value = p.value;
         // TODO: null values represent variables optimized by v8.
@@ -487,7 +487,7 @@ class ExpressionEvaluator {
 
     // skip library and main scope
     final scopeChain = filterScopes(frame).reversed;
-    for (var scope in scopeChain) {
+    for (final scope in scopeChain) {
       final objectId = scope.object.objectId;
       if (objectId != null) {
         final scopeProperties = await _inspector.getProperties(objectId);

--- a/dwds/lib/src/services/javascript_builder.dart
+++ b/dwds/lib/src/services/javascript_builder.dart
@@ -42,7 +42,7 @@ class JsBuilder {
 
   void writeMultiLineExpression(Iterable<String> lines) {
     var i = 0;
-    for (var line in lines) {
+    for (final line in lines) {
       if (i == 0) {
         writeLine(line);
       } else if (i < lines.length - 1) {

--- a/dwds/lib/src/utilities/dart_uri.dart
+++ b/dwds/lib/src/utilities/dart_uri.dart
@@ -187,7 +187,7 @@ class DartUri {
 
   /// Record all of the libraries, indexed by their absolute file: URI.
   static void recordAbsoluteUris(Iterable<String> libraryUris) {
-    for (var uri in libraryUris) {
+    for (final uri in libraryUris) {
       _recordAbsoluteUri(uri);
       if (globalToolConfiguration.appMetadata.isInternalBuild) {
         _recordG3RelativeUri(uri);

--- a/dwds/test/chrome_proxy_service_test.dart
+++ b/dwds/test/chrome_proxy_service_test.dart
@@ -731,7 +731,7 @@ void main() {
       test('Scripts', () async {
         final scripts = await service.getScripts(isolate.id!);
         assert(scripts.scripts!.isNotEmpty);
-        for (var scriptRef in scripts.scripts!) {
+        for (final scriptRef in scripts.scripts!) {
           final script =
               await service.getObject(isolate.id!, scriptRef.id!) as Script;
           final serverPath = DartUri(script.uri!, 'hello_world/').serverPath;
@@ -2295,11 +2295,11 @@ void main() {
             ]),
           );
 
-          for (var data in batch1) {
+          for (final data in batch1) {
             await context.tabConnection.runtime.evaluate(emitDebugEvent(data));
           }
           await Future.delayed(delay);
-          for (var data in batch2) {
+          for (final data in batch2) {
             await context.tabConnection.runtime.evaluate(emitDebugEvent(data));
           }
         });
@@ -2383,7 +2383,7 @@ void main() {
             isolateEventStream,
             emitsInOrder(extensions.map(eventMatcher)),
           );
-          for (var extension in extensions) {
+          for (final extension in extensions) {
             await context.tabConnection.runtime
                 .evaluate(emitRegisterEvent(extension));
           }

--- a/dwds/test/debug_extension_test.dart
+++ b/dwds/test/debug_extension_test.dart
@@ -57,7 +57,7 @@ void main() async {
     );
   }
 
-  for (var useSse in [true, false]) {
+  for (final useSse in [true, false]) {
     group(useSse ? 'SSE' : 'WebSockets', () {
       group('Without encoding', () {
         setUp(() async {
@@ -89,7 +89,7 @@ void main() async {
         });
 
         test('can close DevTools and relaunch', () async {
-          for (var window in await context.webDriver.windows.toList()) {
+          for (final window in await context.webDriver.windows.toList()) {
             await context.webDriver.driver.switchTo.window(window);
             if (await context.webDriver.title == 'Dart DevTools') {
               await window.close();
@@ -192,7 +192,7 @@ void main() async {
         });
 
         test('can close DevTools and relaunch', () async {
-          for (var window in await context.webDriver.windows.toList()) {
+          for (final window in await context.webDriver.windows.toList()) {
             await context.webDriver.driver.switchTo.window(window);
             if (await context.webDriver.title == 'Dart DevTools') {
               await window.close();

--- a/dwds/test/evaluate_common.dart
+++ b/dwds/test/evaluate_common.dart
@@ -289,7 +289,7 @@ void testAll({
             await onBreakPoint(mainScript, 'extension', (event) async {
               final stack = await context.service.getStack(isolateId);
               final scope = _getFrameVariables(stack.frames!.first);
-              for (var p in scope.entries) {
+              for (final p in scope.entries) {
                 final name = p.key;
                 final value = p.value as InstanceRef;
                 final result =
@@ -330,7 +330,7 @@ void testAll({
 
             // Type
             final instance = await getInstance(instanceRef);
-            for (var field in instance.fields!) {
+            for (final field in instance.fields!) {
               final name = field.decl!.name;
               final fieldInstance =
                   await getInstance(field.value as InstanceRef);
@@ -883,7 +883,7 @@ void testAll({
 
 Map<String?, InstanceRef?> _getFrameVariables(Frame frame) {
   return <String?, InstanceRef?>{
-    for (var variable in frame.vars!)
+    for (final variable in frame.vars!)
       variable.name: variable.value as InstanceRef?,
   };
 }

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -588,7 +588,7 @@ class TestContext {
     final extensionTabs = (await connection.getTabs()).where((tab) {
       return tab.isChromeExtension;
     });
-    for (var tab in extensionTabs) {
+    for (final tab in extensionTabs) {
       final tabConnection = await tab.connect();
       final response =
           await tabConnection.runtime.evaluate('window.isDartDebugExtension');

--- a/dwds/test/frontend_server_circular_evaluate_test.dart
+++ b/dwds/test/frontend_server_circular_evaluate_test.dart
@@ -23,7 +23,7 @@ void main() async {
   tearDownAll(provider.dispose);
 
   group('Context with circular dependencies |', () {
-    for (var indexBaseMode in IndexBaseMode.values) {
+    for (final indexBaseMode in IndexBaseMode.values) {
       group(
         'with ${indexBaseMode.name} |',
         () {

--- a/dwds/test/frontend_server_ddc_and_canary_evaluate_test.dart
+++ b/dwds/test/frontend_server_ddc_and_canary_evaluate_test.dart
@@ -26,10 +26,10 @@ void main() async {
   );
   tearDownAll(provider.dispose);
 
-  for (var useDebuggerModuleNames in [false, true]) {
+  for (final useDebuggerModuleNames in [false, true]) {
     group('Debugger module names: $useDebuggerModuleNames |', () {
       group('DDC module system and canary |', () {
-        for (var indexBaseMode in IndexBaseMode.values) {
+        for (final indexBaseMode in IndexBaseMode.values) {
           group(
             'with ${indexBaseMode.name} |',
             () {

--- a/dwds/test/frontend_server_ddc_evaluate_test.dart
+++ b/dwds/test/frontend_server_ddc_evaluate_test.dart
@@ -27,10 +27,10 @@ void main() async {
   );
   tearDownAll(provider.dispose);
 
-  for (var useDebuggerModuleNames in [false, true]) {
+  for (final useDebuggerModuleNames in [false, true]) {
     group('Debugger module names: $useDebuggerModuleNames |', () {
       group('DDC module system |', () {
-        for (var indexBaseMode in IndexBaseMode.values) {
+        for (final indexBaseMode in IndexBaseMode.values) {
           group(
             'with ${indexBaseMode.name} |',
             () {

--- a/dwds/test/frontend_server_evaluate_test.dart
+++ b/dwds/test/frontend_server_evaluate_test.dart
@@ -23,9 +23,9 @@ void main() async {
   final provider = TestSdkConfigurationProvider(verbose: debug);
   tearDownAll(provider.dispose);
 
-  for (var useDebuggerModuleNames in [false, true]) {
+  for (final useDebuggerModuleNames in [false, true]) {
     group('Debugger module names: $useDebuggerModuleNames |', () {
-      for (var indexBaseMode in IndexBaseMode.values) {
+      for (final indexBaseMode in IndexBaseMode.values) {
         group(
           'with ${indexBaseMode.name} |',
           () {

--- a/dwds/test/instances/class_inspection_test.dart
+++ b/dwds/test/instances/class_inspection_test.dart
@@ -46,7 +46,7 @@ void main() {
   group('Class |', () {
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       group('$compilationMode |', () {
         setUpAll(() async {
           setCurrentLogWriter(debug: debug);

--- a/dwds/test/instances/common/instance_common.dart
+++ b/dwds/test/instances/common/instance_common.dart
@@ -327,7 +327,7 @@ void runTests({
         final fieldNames =
             instance.fields!.map((boundField) => boundField.name).toList();
         expect(boundFieldNames, fieldNames);
-        for (var field in instance.fields!) {
+        for (final field in instance.fields!) {
           expect(field.name, isNotNull);
           expect(field.decl!.declaredType, isNotNull);
         }

--- a/dwds/test/instances/common/patterns_inspection_common.dart
+++ b/dwds/test/instances/common/patterns_inspection_common.dart
@@ -120,7 +120,7 @@ void runTests({
     test('stepping through pattern match', () async {
       await onBreakPoint('callTestPattern1', (Event event) async {
         var previousLocation = event.topFrame!.location;
-        for (var step in [
+        for (final step in [
           // Make sure we step into the callee.
           for (var i = 0; i < 4; i++) 'Into',
           // Make a few steps inside the callee.

--- a/dwds/test/instances/common/test_inspector.dart
+++ b/dwds/test/instances/common/test_inspector.dart
@@ -91,7 +91,7 @@ class TestInspector {
     }
 
     final fieldValues = <dynamic, Object?>{};
-    for (var p in fieldRefs.entries) {
+    for (final p in fieldRefs.entries) {
       fieldValues[p.key] = _getValue(p.value) ??
           await getFields(
             isolateId,
@@ -112,7 +112,7 @@ class TestInspector {
         cls.functions?.where((f) => f.isGetter ?? false).toList() ?? [];
 
     final results = await Future.wait([
-      for (var getter in getters)
+      for (final getter in getters)
         service.evaluate(isolateId, instanceRef.id!, getter.name!),
     ]);
 
@@ -162,7 +162,7 @@ class TestInspector {
     Frame frame,
   ) async {
     final refs = <String, InstanceRef>{
-      for (var variable in frame.vars!)
+      for (final variable in frame.vars!)
         variable.name!: variable.value as InstanceRef,
     };
     final instances = <String, Instance>{};

--- a/dwds/test/instances/instance_canary_test.dart
+++ b/dwds/test/instances/instance_canary_test.dart
@@ -24,7 +24,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTypeSystemVerificationTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/instance_inspection_canary_test.dart
+++ b/dwds/test/instances/instance_inspection_canary_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/instance_inspection_test.dart
+++ b/dwds/test/instances/instance_inspection_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/instance_test.dart
+++ b/dwds/test/instances/instance_test.dart
@@ -24,7 +24,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTypeSystemVerificationTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/patterns_inspection_canary_test.dart
+++ b/dwds/test/instances/patterns_inspection_canary_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/patterns_inspection_test.dart
+++ b/dwds/test/instances/patterns_inspection_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/record_inspection_canary_test.dart
+++ b/dwds/test/instances/record_inspection_canary_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/record_inspection_test.dart
+++ b/dwds/test/instances/record_inspection_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/record_type_inspection_canary_test.dart
+++ b/dwds/test/instances/record_type_inspection_canary_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/record_type_inspection_test.dart
+++ b/dwds/test/instances/record_type_inspection_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/type_inspection_canary_test.dart
+++ b/dwds/test/instances/type_inspection_canary_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/instances/type_inspection_test.dart
+++ b/dwds/test/instances/type_inspection_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
     tearDownAll(provider.dispose);
 
-    for (var compilationMode in CompilationMode.values) {
+    for (final compilationMode in CompilationMode.values) {
       runTests(
         provider: provider,
         compilationMode: compilationMode,

--- a/dwds/test/listviews_test.dart
+++ b/dwds/test/listviews_test.dart
@@ -35,7 +35,7 @@ void main() {
 
       final expected = <String, Object>{
         'views': <Object>[
-          for (var isolate in isolates)
+          for (final isolate in isolates)
             <String, Object?>{
               'id': isolate.id,
               'isolate': isolate.toJson(),

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -107,7 +107,7 @@ void main() {
     expect(metadata.moduleUri, 'foo/web/main.ddc.js');
     final libraries = metadata.libraries;
     expect(libraries.length, 1);
-    for (var lib in libraries.values) {
+    for (final lib in libraries.values) {
       expect(lib.name, 'main');
       expect(lib.importUri, 'org-dartlang-app:///web/main.dart');
       final parts = lib.partUris;

--- a/dwds/test/puppeteer/extension_common.dart
+++ b/dwds/test/puppeteer/extension_common.dart
@@ -46,7 +46,7 @@ void testAll({
       extensionPath = await buildDebugExtension(isMV3: isMV3);
     });
 
-    for (var useSse in [true, false]) {
+    for (final useSse in [true, false]) {
       group(useSse ? 'connected with SSE:' : 'connected with WebSockets:', () {
         late Browser browser;
         Worker? worker;
@@ -334,7 +334,7 @@ void testAll({
     }
 
     group('connected to an externally-built', () {
-      for (var isFlutterApp in [true, false]) {
+      for (final isFlutterApp in [true, false]) {
         group(isFlutterApp ? 'Flutter app:' : 'Dart app:', () {
           late Browser browser;
           Worker? worker;
@@ -425,7 +425,7 @@ void testAll({
     group('connected to an internally-built', () {
       late Page appTab;
 
-      for (var isFlutterApp in [true, false]) {
+      for (final isFlutterApp in [true, false]) {
         group(isFlutterApp ? 'Flutter app:' : 'Dart app:', () {
           late Browser browser;
           Worker? worker;

--- a/dwds/test/puppeteer/test_utils.dart
+++ b/dwds/test/puppeteer/test_utils.dart
@@ -100,7 +100,7 @@ Future<Worker> getServiceWorker(Browser browser) async {
     worker.client,
     worker.url,
     onConsoleApiCalled: (type, jsHandles, _) {
-      for (var handle in jsHandles) {
+      for (final handle in jsHandles) {
         _saveConsoleMsg(
           source: ConsoleSource.worker,
           type: '$type',

--- a/dwds/test/skip_list_test.dart
+++ b/dwds/test/skip_list_test.dart
@@ -93,7 +93,7 @@ void main() {
     test('contains the provided id', () {
       final id = '123';
       final skipList = skipLists.compute(id, {});
-      for (var range in skipList) {
+      for (final range in skipList) {
         expect(range['scriptId'], id);
       }
     });

--- a/dwds/test/variable_scope_test.dart
+++ b/dwds/test/variable_scope_test.dart
@@ -148,7 +148,7 @@ void main() {
     Future<void> expectDartVariables(
       Map<String?, InstanceRef?> variables,
     ) async {
-      for (var name in variables.keys) {
+      for (final name in variables.keys) {
         final instance = await getInstance(variables[name]!);
         expectDartObject(name!, instance);
       }
@@ -156,7 +156,7 @@ void main() {
 
     Map<String?, InstanceRef?> getFrameVariables(Frame frame) {
       return <String?, InstanceRef?>{
-        for (var variable in frame.vars!)
+        for (final variable in frame.vars!)
           variable.name: variable.value as InstanceRef?,
       };
     }

--- a/dwds/test/web/batched_stream_test.dart
+++ b/dwds/test/web/batched_stream_test.dart
@@ -67,7 +67,7 @@ void main() {
       final inputAdded = controller.sink.addStream(inputController.stream);
 
       final input = List<int>.generate(size, (index) => index);
-      for (var e in input) {
+      for (final e in input) {
         inputController.sink.add(e);
         await Future.delayed(delay);
       }

--- a/dwds/web/reloader/require_restarter.dart
+++ b/dwds/web/reloader/require_restarter.dart
@@ -121,7 +121,7 @@ class RequireRestarter implements Restarter {
 
     final newDigests = await _getDigests();
     final modulesToLoad = <String>[];
-    for (var moduleId in newDigests.keys) {
+    for (final moduleId in newDigests.keys) {
       if (!_lastKnownDigests.containsKey(moduleId)) {
         print('Error during script reloading, refreshing the page. \n'
             'Unable to find an existing digest for module: $moduleId.');
@@ -267,7 +267,7 @@ class RequireRestarter implements Restarter {
         graphs.stronglyConnectedComponents(allModules, _moduleParents);
     _moduleOrdering.clear();
     for (var i = 0; i < stronglyConnectedComponents.length; i++) {
-      for (var module in stronglyConnectedComponents[i]) {
+      for (final module in stronglyConnectedComponents[i]) {
         _moduleOrdering[module] = i;
       }
     }

--- a/fixtures/_experimentSound/web/main.dart
+++ b/fixtures/_experimentSound/web/main.dart
@@ -64,9 +64,11 @@ void testClass() {
 
 String testPattern(Object obj) {
   switch (obj) {
-    case [var a, int n] || [int n, var a] when n == 1 && a is String:
+    case [final a, final int n] || [final int n, final a]
+        when n == 1 && a is String:
       return a.toString(); // Breakpoint: testPatternCase1
-    case [double n, var a] || [var a, double n] when (n - 3.14).abs() < 0.001:
+    case [final double n, final a] || [final a, final double n]
+        when (n - 3.14).abs() < 0.001:
       return a.toString(); // Breakpoint: testPatternCase2
     default:
       return 'default'; // Breakpoint: testPatternDefault

--- a/fixtures/_testPackageSound/web/main.dart
+++ b/fixtures/_testPackageSound/web/main.dart
@@ -14,7 +14,7 @@ import 'package:_test_sound/library.dart';
 
 extension NumberParsing on String {
   int parseInt() {
-    var ret = int.parse(this);
+    final ret = int.parse(this);
     return ret; // Breakpoint: extension
   }
 }
@@ -75,22 +75,22 @@ void printGeneric<T>(T formal) {
 }
 
 void printLocal() {
-  var local = 42;
+  final local = 42;
   print('Local is: $local'); // Breakpoint: printLocal
 }
 
 void printFieldFromLibraryClass() {
-  var instance = TestLibraryClass(1, 2); // Breakpoint: createLibraryObject
+  final instance = TestLibraryClass(1, 2); // Breakpoint: createLibraryObject
   print('$instance'); // Breakpoint: printFieldFromLibraryClass
 }
 
 void printFieldFromLibraryPartClass() {
-  var instance = TestLibraryPartClass(1, 2);
+  final instance = TestLibraryPartClass(1, 2);
   print('$instance'); // Breakpoint: printFieldFromLibraryPartClass
 }
 
 void printFieldMain() {
-  var instance = MainClass(2, 1);
+  final instance = MainClass(2, 1);
   print('$instance'); // Breakpoint: printFieldMain
 }
 
@@ -103,22 +103,22 @@ void printFromTestPackage() {
 }
 
 void printFromTestLibrary() {
-  var local = 23;
+  final local = 23;
   print(testLibraryFunction(local));
 }
 
 void printFromTestLibraryPart() {
-  var local = 23;
+  final local = 23;
   print(testLibraryPartFunction(local));
 }
 
 void printCallExtension() {
-  var local = '23';
+  final local = '23';
   print(local.parseInt());
 }
 
 void printLoopVariable() {
-  var list = <String>['1'];
+  final list = <String>['1'];
   for (var item in list) {
     print(item); // Breakpoint: printLoopVariable
   }
@@ -147,9 +147,9 @@ void printEnclosingObject(EnclosingClass o) {
 }
 
 void printStream() {
-  var controller = StreamController<int>();
-  var stream = controller.stream.asBroadcastStream();
-  var subscription = stream.listen(print);
+  final controller = StreamController<int>();
+  final stream = controller.stream.asBroadcastStream();
+  final subscription = stream.listen(print);
   controller.sink.add(0);
   subscription.cancel(); // Breakpoint: printStream
 }
@@ -185,26 +185,26 @@ void printFrame1() {
 }
 
 void printLargeScope() {
-  var t0 = 0;
-  var t1 = 1;
-  var t2 = 2;
-  var t3 = 3;
-  var t4 = 4;
-  var t5 = 5;
-  var t6 = 6;
-  var t7 = 7;
-  var t8 = 8;
-  var t9 = 9;
-  var t10 = 10;
-  var t11 = 11;
-  var t12 = 12;
-  var t13 = 13;
-  var t14 = 14;
-  var t15 = 15;
-  var t16 = 16;
-  var t17 = 17;
-  var t18 = 18;
-  var t19 = 19;
+  final t0 = 0;
+  final t1 = 1;
+  final t2 = 2;
+  final t3 = 3;
+  final t4 = 4;
+  final t5 = 5;
+  final t6 = 6;
+  final t7 = 7;
+  final t8 = 8;
+  final t9 = 9;
+  final t10 = 10;
+  final t11 = 11;
+  final t12 = 12;
+  final t13 = 13;
+  final t14 = 14;
+  final t15 = 15;
+  final t16 = 16;
+  final t17 = 17;
+  final t18 = 18;
+  final t19 = 19;
 
   print('$t0 $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10, '
       '$t11, $t12, $t13, $t14, $t15, $t16, $t17, $t18, $t19'); // Breakpoint: printLargeScope

--- a/fixtures/_testSound/example/hello_world/main.dart
+++ b/fixtures/_testSound/example/hello_world/main.dart
@@ -18,7 +18,7 @@ part 'part.dart';
 // dwds/test/chrome_proxy_service_test.dart
 
 final topLevelList = () {
-  var l = List.filled(1001, 5);
+  final l = List.filled(1001, 5);
   l[4] = 100;
   return l;
 }();
@@ -37,7 +37,7 @@ void main() async {
 
   // long running to test evaluateInFrame
   Timer.periodic(const Duration(seconds: 1), (_) {
-    var local = 42;
+    final local = 42;
     print(local); // Breakpoint: printLocal
   });
 
@@ -101,13 +101,13 @@ void printCount() {
 }
 
 void asyncCall() async {
-  var now = DateTime.now();
+  final now = DateTime.now();
 
   await Future.delayed(Duration.zero);
 
-  var then = DateTime.now(); // Breakpoint: asyncCall
+  final then = DateTime.now(); // Breakpoint: asyncCall
   // ignore: unused_local_variable
-  var diff = then.difference(now);
+  final diff = then.difference(now);
 }
 
 void throwsException() {

--- a/fixtures/_testSound/example/scopes/main.dart
+++ b/fixtures/_testSound/example/scopes/main.dart
@@ -28,7 +28,8 @@ void staticFunction(int formal) {
 }
 
 void staticAsyncFunction(String value) async {
-  var myLocal = await 'a local value';
+  // ignore: unused_local_variable
+  final myLocal = await 'a local value';
   print(value); // Breakpoint: staticAsyncFunction
 }
 
@@ -36,7 +37,7 @@ void staticAsyncLoopFunction(String value) async {
   Function? f;
   for (var i in [1, 2, 3]) {
     print(i);
-    var myLocal = await 'my local value';
+    final myLocal = await 'my local value';
     f ??= () {
       print(value);
       print(i);
@@ -48,9 +49,9 @@ void staticAsyncLoopFunction(String value) async {
 
 void main() async {
   print('Initial print from scopes app');
-  var local = 'local in main';
-  var intLocalInMain = 42;
-  var testClass = MyTestClass();
+  final local = 'local in main';
+  final intLocalInMain = 42;
+  final testClass = MyTestClass();
   Object? localThatsNull;
   identityMap['a'] = 1;
   identityMap['b'] = 2;
@@ -59,7 +60,7 @@ void main() async {
   notAList.add(7);
 
   String nestedFunction<T>(T parameter, Object aClass) {
-    var another = int.tryParse('$parameter');
+    final another = int.tryParse('$parameter');
     return '$local: parameter, $another'; // Breakpoint: nestedFunction
   }
 
@@ -68,7 +69,7 @@ void main() async {
   }
 
   Timer.periodic(const Duration(seconds: 1), (Timer t) {
-    var ticks = t.tick;
+    final ticks = t.tick;
     // ignore: unused_local_variable, prefer_typing_uninitialized_variables
     var closureLocal;
     libraryPublicFinal.printCount();
@@ -79,12 +80,12 @@ void main() async {
     print(nestedFunction('$ticks ${testClass.message}', Timer));
     print(localThatsNull);
     print(libraryNull);
-    var localList = libraryPublic;
+    final localList = libraryPublic;
     print(localList);
     localList.add('abc');
-    var f = testClass.methodWithVariables();
+    final f = testClass.methodWithVariables();
     print(f('parameter'));
-    var num = '1234'.someExtensionMethod();
+    final num = '1234'.someExtensionMethod();
     print('$num');
   });
 
@@ -96,7 +97,7 @@ void main() async {
 
 String libraryFunction(String arg) {
   print('calling a library function with $arg');
-  var concat = 'some constant plus $arg plus whatever';
+  final concat = 'some constant plus $arg plus whatever';
   print(concat);
   return concat;
 }
@@ -118,11 +119,11 @@ class MyTestClass<T> extends MyAbstractClass {
   String hello() => message;
 
   String Function(String) methodWithVariables() {
-    var local = '$message + something';
+    final local = '$message + something';
     print(local);
     return (String parameter) {
       // Be sure to use a field from this, so it isn't entirely optimized away.
-      var closureLocalInsideMethod = '$message/$local/$parameter';
+      final closureLocalInsideMethod = '$message/$local/$parameter';
       print(closureLocalInsideMethod);
       return closureLocalInsideMethod; // Breakpoint: nestedClosure
     };
@@ -184,7 +185,7 @@ class NotReallyAList extends ListBase<Object?> {
 
 extension NumberParsing on String {
   int someExtensionMethod() {
-    var ret = int.parse(this);
+    final ret = int.parse(this);
     return ret; // Breakpoint: extension
   }
 }

--- a/fixtures/_webdevSoundSmoke/web/scopes_main.dart
+++ b/fixtures/_webdevSoundSmoke/web/scopes_main.dart
@@ -27,9 +27,9 @@ void staticFunction(int formal) {
 
 void main() async {
   print('Initial print from scopes app');
-  var local = 'local in main';
-  var intLocalInMain = 42;
-  var testClass = MyTestClass();
+  final local = 'local in main';
+  final intLocalInMain = 42;
+  final testClass = MyTestClass();
   Object? localThatsNull;
   identityMap['a'] = 1;
   identityMap['b'] = 2;
@@ -38,7 +38,7 @@ void main() async {
   notAList.add(7);
 
   String nestedFunction<T>(T parameter, Object aClass) {
-    var another = int.tryParse('$parameter');
+    final another = int.tryParse('$parameter');
     return '$local: parameter, $another'; // Breakpoint: nestedFunction
   }
 
@@ -47,7 +47,7 @@ void main() async {
   }
 
   Timer.periodic(const Duration(seconds: 1), (Timer t) {
-    var ticks = t.tick;
+    final ticks = t.tick;
     // ignore: unused_local_variable, prefer_typing_uninitialized_variables
     var closureLocal;
     libraryPublicFinal.printCount();
@@ -56,10 +56,10 @@ void main() async {
     print(nestedFunction('$ticks ${testClass.message}', Timer));
     print(localThatsNull);
     print(libraryNull);
-    var localList = libraryPublic;
+    final localList = libraryPublic;
     print(localList);
     localList.add('abc');
-    var f = testClass.methodWithVariables();
+    final f = testClass.methodWithVariables();
     print(f('parameter'));
   });
 
@@ -71,7 +71,7 @@ void main() async {
 
 String libraryFunction(String arg) {
   print('calling a library function with $arg');
-  var concat = 'some constant plus $arg plus whatever';
+  final concat = 'some constant plus $arg plus whatever';
   print(concat);
   return concat;
 }
@@ -89,11 +89,11 @@ class MyTestClass<T> {
   String hello() => message;
 
   String Function(String) methodWithVariables() {
-    var local = '$message + something';
+    final local = '$message + something';
     print(local);
     return (String parameter) {
       // Be sure to use a field from this, so it isn't entirely optimized away.
-      var closureLocalInsideMethod = '$message/$local/$parameter';
+      final closureLocalInsideMethod = '$message/$local/$parameter';
       print(closureLocalInsideMethod);
       return closureLocalInsideMethod; // Breakpoint: nestedClosure
     };

--- a/frontend_server_client/lib/src/dartdevc_frontend_server_client.dart
+++ b/frontend_server_client/lib/src/dartdevc_frontend_server_client.dart
@@ -118,7 +118,7 @@ class DartDevcFrontendServerClient implements FrontendServerClient {
     final sourceBytes = File(result.jsSourcesOutput!).readAsBytesSync();
     final sourceMapBytes = File(result.jsSourceMapsOutput!).readAsBytesSync();
 
-    for (var entry in manifest.entries) {
+    for (final entry in manifest.entries) {
       final metadata = entry.value as Map<String, dynamic>;
       final sourceOffsets = metadata['code'] as List;
       _assets[entry.key] =

--- a/frontend_server_client/lib/src/dartdevc_frontend_server_client.dart
+++ b/frontend_server_client/lib/src/dartdevc_frontend_server_client.dart
@@ -70,7 +70,7 @@ class DartDevcFrontendServerClient implements FrontendServerClient {
     bool verbose = false,
     bool printIncrementalDependencies = true,
   }) async {
-    var feServer = await FrontendServerClient.start(
+    final feServer = await FrontendServerClient.start(
       entrypoint,
       outputDillPath,
       platformKernel ?? _dartdevcPlatformKernel,
@@ -119,11 +119,11 @@ class DartDevcFrontendServerClient implements FrontendServerClient {
     final sourceMapBytes = File(result.jsSourceMapsOutput!).readAsBytesSync();
 
     for (var entry in manifest.entries) {
-      var metadata = entry.value as Map<String, dynamic>;
-      var sourceOffsets = metadata['code'] as List;
+      final metadata = entry.value as Map<String, dynamic>;
+      final sourceOffsets = metadata['code'] as List;
       _assets[entry.key] =
           sourceBytes.sublist(sourceOffsets[0] as int, sourceOffsets[1] as int);
-      var sourceMapOffsets = metadata['sourcemap'] as List;
+      final sourceMapOffsets = metadata['sourcemap'] as List;
       _assets['${entry.key}.map'] = sourceMapBytes.sublist(
           sourceMapOffsets[0] as int, sourceMapOffsets[1] as int);
     }
@@ -195,11 +195,11 @@ class DartDevcFrontendServerClient implements FrontendServerClient {
   /// assets if available.
   void _resetAssets() {
     _assets.clear();
-    var bootstrapJs = _bootstrapJs;
+    final bootstrapJs = _bootstrapJs;
     if (bootstrapJs != null) {
       _assets['$_entrypoint.js'] = Uint8List.fromList(utf8.encode(bootstrapJs));
     }
-    var mainModuleJs = _mainModuleJs;
+    final mainModuleJs = _mainModuleJs;
     if (mainModuleJs != null) {
       _assets['$_entrypoint.bootstrap.js'] =
           Uint8List.fromList(utf8.encode(mainModuleJs));

--- a/frontend_server_client/lib/src/frontend_server_client.dart
+++ b/frontend_server_client/lib/src/frontend_server_client.dart
@@ -129,13 +129,13 @@ class FrontendServerClient {
         ],
       );
     }
-    var feServerStdoutLines = StreamQueue(feServer.stdout
+    final feServerStdoutLines = StreamQueue(feServer.stdout
         .transform(utf8.decoder)
         .transform(const LineSplitter()));
 
     // The frontend_server doesn't appear to recursively create files, so we
     //  need to make sure the output dir already exists.
-    var outputDir = Directory(p.dirname(outputDillPath));
+    final outputDir = Directory(p.dirname(outputDillPath));
     if (!await outputDir.exists()) await outputDir.create();
 
     return FrontendServerClient._(
@@ -176,14 +176,14 @@ class FrontendServerClient {
     _state = _ClientState.compiling;
 
     try {
-      var command = StringBuffer('$action $_entrypoint');
+      final command = StringBuffer('$action $_entrypoint');
       if (action == 'recompile') {
         if (invalidatedUris == null || invalidatedUris.isEmpty) {
           throw StateError(
               'Subsequent compile invocations must provide a non-empty list '
               'of invalidated uris.');
         }
-        var boundaryKey = generateUuidV4();
+        final boundaryKey = generateUuidV4();
         command.writeln(' $boundaryKey');
         for (var uri in invalidatedUris) {
           command.writeln('$uri');
@@ -194,14 +194,14 @@ class FrontendServerClient {
       _sendCommand(command.toString());
       var state = _CompileState.started;
       late String feBoundaryKey;
-      var newSources = <Uri>{};
-      var removedSources = <Uri>{};
-      var compilerOutputLines = <String>[];
+      final newSources = <Uri>{};
+      final removedSources = <Uri>{};
+      final compilerOutputLines = <String>[];
       var errorCount = 0;
       String? outputDillPath;
       while (
           state != _CompileState.done && await _feServerStdoutLines.hasNext) {
-        var line = await _nextInputLine();
+        final line = await _nextInputLine();
         switch (state) {
           case _CompileState.started:
             assert(line.startsWith('result'));
@@ -218,12 +218,12 @@ class FrontendServerClient {
           case _CompileState.gettingSourceDiffs:
             if (line.startsWith(feBoundaryKey)) {
               state = _CompileState.done;
-              var parts = line.split(' ');
+              final parts = line.split(' ');
               outputDillPath = parts.getRange(1, parts.length - 1).join(' ');
               errorCount = int.parse(parts.last);
               continue;
             }
-            var diffUri = Uri.parse(line.substring(1));
+            final diffUri = Uri.parse(line.substring(1));
             if (line.startsWith('+')) {
               newSources.add(diffUri);
             } else if (line.startsWith('-')) {
@@ -301,7 +301,7 @@ class FrontendServerClient {
     var rejectState = _RejectState.started;
     while (rejectState != _RejectState.done &&
         await _feServerStdoutLines.hasNext) {
-      var line = await _nextInputLine();
+      final line = await _nextInputLine();
       switch (rejectState) {
         case _RejectState.started:
           if (!line.startsWith('result')) {
@@ -341,8 +341,8 @@ class FrontendServerClient {
   /// Stop the service gracefully (using the shutdown command)
   Future<int> shutdown() async {
     _sendCommand('quit');
-    var timer = Timer(const Duration(seconds: 1), _feServer.kill);
-    var exitCode = await _feServer.exitCode;
+    final timer = Timer(const Duration(seconds: 1), _feServer.kill);
+    final exitCode = await _feServer.exitCode;
     timer.cancel();
     await _feServerStdoutLines.cancel();
     return exitCode;
@@ -358,7 +358,7 @@ class FrontendServerClient {
   /// Sends [command] to the [_feServer] via stdin, and logs it if [_verbose].
   void _sendCommand(String command) {
     if (_verbose) {
-      var lines = const LineSplitter().convert(command);
+      final lines = const LineSplitter().convert(command);
       for (var line in lines) {
         print('>> $line');
       }
@@ -368,7 +368,7 @@ class FrontendServerClient {
 
   /// Reads a line from [_feServerStdoutLines] and logs it if [_verbose].
   Future<String> _nextInputLine() async {
-    var line = await _feServerStdoutLines.next;
+    final line = await _feServerStdoutLines.next;
     if (_verbose) print('<< $line');
     return line;
   }

--- a/frontend_server_client/lib/src/frontend_server_client.dart
+++ b/frontend_server_client/lib/src/frontend_server_client.dart
@@ -76,7 +76,7 @@ class FrontendServerClient {
       '--target=$target',
       if (target == 'dartdevc')
         '--dartdevc-module-format=$dartdevcModuleFormat',
-      for (var root in fileSystemRoots) '--filesystem-root=$root',
+      for (final root in fileSystemRoots) '--filesystem-root=$root',
       '--filesystem-scheme',
       fileSystemScheme,
       '--output-dill',
@@ -87,9 +87,9 @@ class FrontendServerClient {
       if (verbose) '--verbose',
       if (!printIncrementalDependencies) '--no-print-incremental-dependencies',
       if (enabledExperiments != null)
-        for (var experiment in enabledExperiments)
+        for (final experiment in enabledExperiments)
           '--enable-experiment=$experiment',
-      for (var source in additionalSources) ...[
+      for (final source in additionalSources) ...[
         '--source',
         source,
       ],
@@ -185,7 +185,7 @@ class FrontendServerClient {
         }
         final boundaryKey = generateUuidV4();
         command.writeln(' $boundaryKey');
-        for (var uri in invalidatedUris) {
+        for (final uri in invalidatedUris) {
           command.writeln('$uri');
         }
         command.write(boundaryKey);
@@ -359,7 +359,7 @@ class FrontendServerClient {
   void _sendCommand(String command) {
     if (_verbose) {
       final lines = const LineSplitter().convert(command);
-      for (var line in lines) {
+      for (final line in lines) {
         print('>> $line');
       }
     }

--- a/frontend_server_client/lib/src/shared.dart
+++ b/frontend_server_client/lib/src/shared.dart
@@ -28,7 +28,7 @@ String generateUuidV4() {
       printDigits(generateBits(bitCount), digitCount);
 
   // Generate xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx / 8-4-4-4-12.
-  var special = 8 + random.nextInt(4);
+  final special = 8 + random.nextInt(4);
 
   return '${bitsDigits(16, 4)}${bitsDigits(16, 4)}-'
       '${bitsDigits(16, 4)}-'

--- a/frontend_server_common/lib/src/asset_server.dart
+++ b/frontend_server_common/lib/src/asset_server.dart
@@ -91,10 +91,10 @@ class TestAssetServer implements AssetReader {
       return shelf.Response.notFound('');
     }
 
-    var headers = <String, String>{};
+    final headers = <String, String>{};
 
     if (request.url.path.endsWith('.html')) {
-      var indexFile = _fileSystem.file(index);
+      final indexFile = _fileSystem.file(index);
       if (indexFile.existsSync()) {
         headers[HttpHeaders.contentTypeHeader] = 'text/html';
         headers[HttpHeaders.contentLengthHeader] =
@@ -129,12 +129,12 @@ class TestAssetServer implements AssetReader {
       return shelf.Response.ok(bytes, headers: headers);
     }
 
-    var file = _resolveDartFile(requestPath);
+    final file = _resolveDartFile(requestPath);
     if (!file.existsSync()) {
       return shelf.Response.notFound('');
     }
 
-    var length = file.lengthSync();
+    final length = file.lengthSync();
     // Attempt to determine the file's mime type. if this is not provided some
     // browsers will refuse to render images/show video et cetera. If the tool
     // cannot determine a mime type, fall back to application/octet-stream.
@@ -167,18 +167,19 @@ class TestAssetServer implements AssetReader {
   /// Returns a list of updated modules.
   List<String> write(
       File codeFile, File manifestFile, File sourcemapFile, File metadataFile) {
-    var modules = <String>[];
-    var codeBytes = codeFile.readAsBytesSync();
-    var sourcemapBytes = sourcemapFile.readAsBytesSync();
-    var metadataBytes = metadataFile.readAsBytesSync();
-    var manifest =
+    final modules = <String>[];
+    final codeBytes = codeFile.readAsBytesSync();
+    final sourcemapBytes = sourcemapFile.readAsBytesSync();
+    final metadataBytes = metadataFile.readAsBytesSync();
+    final manifest =
         _castStringKeyedMap(json.decode(manifestFile.readAsStringSync()));
     for (var filePath in manifest.keys) {
-      var offsets = _castStringKeyedMap(manifest[filePath]);
-      var codeOffsets = (offsets['code'] as List<dynamic>).cast<int>();
-      var sourcemapOffsets =
+      final offsets = _castStringKeyedMap(manifest[filePath]);
+      final codeOffsets = (offsets['code'] as List<dynamic>).cast<int>();
+      final sourcemapOffsets =
           (offsets['sourcemap'] as List<dynamic>).cast<int>();
-      var metadataOffsets = (offsets['metadata'] as List<dynamic>).cast<int>();
+      final metadataOffsets =
+          (offsets['metadata'] as List<dynamic>).cast<int>();
       if (codeOffsets.length != 2 ||
           sourcemapOffsets.length != 2 ||
           metadataOffsets.length != 2) {
@@ -186,13 +187,13 @@ class TestAssetServer implements AssetReader {
         continue;
       }
 
-      var codeStart = codeOffsets[0];
-      var codeEnd = codeOffsets[1];
+      final codeStart = codeOffsets[0];
+      final codeEnd = codeOffsets[1];
       if (codeStart < 0 || codeEnd > codeBytes.lengthInBytes) {
         _logger.severe('Invalid byte index: [$codeStart, $codeEnd]');
         continue;
       }
-      var byteView = Uint8List.view(
+      final byteView = Uint8List.view(
         codeBytes.buffer,
         codeStart,
         codeEnd - codeStart,
@@ -202,26 +203,26 @@ class TestAssetServer implements AssetReader {
           filePath.startsWith('/') ? filePath.substring(1) : filePath;
       _files[fileName] = byteView;
 
-      var sourcemapStart = sourcemapOffsets[0];
-      var sourcemapEnd = sourcemapOffsets[1];
+      final sourcemapStart = sourcemapOffsets[0];
+      final sourcemapEnd = sourcemapOffsets[1];
       if (sourcemapStart < 0 || sourcemapEnd > sourcemapBytes.lengthInBytes) {
         _logger.severe('Invalid byte index: [$sourcemapStart, $sourcemapEnd]');
         continue;
       }
-      var sourcemapView = Uint8List.view(
+      final sourcemapView = Uint8List.view(
         sourcemapBytes.buffer,
         sourcemapStart,
         sourcemapEnd - sourcemapStart,
       );
       _sourceMaps['$fileName.map'] = sourcemapView;
 
-      var metadataStart = metadataOffsets[0];
-      var metadataEnd = metadataOffsets[1];
+      final metadataStart = metadataOffsets[0];
+      final metadataEnd = metadataOffsets[1];
       if (metadataStart < 0 || metadataEnd > metadataBytes.lengthInBytes) {
         _logger.severe('Invalid byte index: [$metadataStart, $metadataEnd]');
         continue;
       }
-      var metadataView = Uint8List.view(
+      final metadataView = Uint8List.view(
         metadataBytes.buffer,
         metadataStart,
         metadataEnd - metadataStart,
@@ -263,8 +264,8 @@ class TestAssetServer implements AssetReader {
     }
 
     // Otherwise it must be a Dart SDK source.
-    var dartSdkParent = _fileSystem.directory(_sdkLayout.sdkDirectory).parent;
-    var dartSdkFile = _fileSystem.file(
+    final dartSdkParent = _fileSystem.directory(_sdkLayout.sdkDirectory).parent;
+    final dartSdkFile = _fileSystem.file(
         _fileSystem.path.joinAll(<String>[dartSdkParent.path, ...segments]));
     return dartSdkFile;
   }
@@ -273,7 +274,7 @@ class TestAssetServer implements AssetReader {
   Future<String?> dartSourceContents(String serverPath) async {
     final stripped = _stripBasePath(serverPath, basePath);
     if (stripped != null) {
-      var result = _resolveDartFile(stripped);
+      final result = _resolveDartFile(stripped);
       if (result.existsSync()) {
         return result.readAsString();
       }
@@ -336,6 +337,6 @@ class TestAssetServer implements AssetReader {
 /// Given a data structure which is a Map of String to dynamic values, return
 /// the same structure (`Map<String, dynamic>`) with the correct runtime types.
 Map<String, dynamic> _castStringKeyedMap(dynamic untyped) {
-  var map = untyped as Map<dynamic, dynamic>;
+  final map = untyped as Map<dynamic, dynamic>;
   return map.cast<String, dynamic>();
 }

--- a/frontend_server_common/lib/src/asset_server.dart
+++ b/frontend_server_common/lib/src/asset_server.dart
@@ -173,7 +173,7 @@ class TestAssetServer implements AssetReader {
     final metadataBytes = metadataFile.readAsBytesSync();
     final manifest =
         _castStringKeyedMap(json.decode(manifestFile.readAsStringSync()));
-    for (var filePath in manifest.keys) {
+    for (final filePath in manifest.keys) {
       final offsets = _castStringKeyedMap(manifest[filePath]);
       final codeOffsets = (offsets['code'] as List<dynamic>).cast<int>();
       final sourcemapOffsets =

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -142,14 +142,14 @@ class WebDevFS {
 
     assetServer.writeFile('main_module.digests', '{}');
 
-    var sdk = soundNullSafety ? dartSdk : dartSdkWeak;
-    var sdkSourceMap =
+    final sdk = soundNullSafety ? dartSdk : dartSdkWeak;
+    final sdkSourceMap =
         soundNullSafety ? dartSdkSourcemap : dartSdkSourcemapWeak;
     assetServer.writeFile('dart_sdk.js', sdk.readAsStringSync());
     assetServer.writeFile('dart_sdk.js.map', sdkSourceMap.readAsStringSync());
 
     generator.reset();
-    var compilerOutput = await generator.recompile(
+    final compilerOutput = await generator.recompile(
       Uri.parse('org-dartlang-app:///$mainUri'),
       invalidatedFiles,
       outputPath: p.join(dillOutputPath, 'app.dill'),
@@ -165,7 +165,7 @@ class WebDevFS {
     File metadataFile;
     List<String> modules;
     try {
-      var parentDirectory = fileSystem.directory(outputDirectoryPath);
+      final parentDirectory = fileSystem.directory(outputDirectoryPath);
       codeFile =
           parentDirectory.childFile('${compilerOutput.outputFilename}.sources');
       manifestFile =

--- a/frontend_server_common/lib/src/frontend_server_client.dart
+++ b/frontend_server_common/lib/src/frontend_server_client.dart
@@ -322,7 +322,7 @@ class ResidentCompiler {
     final inputKey = generateV4UUID();
     server.stdin.writeln('recompile $mainUri$inputKey');
     _logger.info('<- recompile $mainUri$inputKey');
-    for (var fileUri in request.invalidatedFiles) {
+    for (final fileUri in request.invalidatedFiles) {
       String message;
       if (fileUri.scheme == 'package') {
         message = fileUri.toString();

--- a/frontend_server_common/lib/src/frontend_server_client.dart
+++ b/frontend_server_common/lib/src/frontend_server_client.dart
@@ -66,7 +66,7 @@ class StdoutHandler {
     if (_badState) {
       return;
     }
-    var kResultPrefix = 'result ';
+    final kResultPrefix = 'result ';
     if (_boundaryKey == null && message.startsWith(kResultPrefix)) {
       _boundaryKey = message.substring(kResultPrefix.length);
       return;
@@ -111,7 +111,7 @@ class StdoutHandler {
         compilerOutput.complete(null);
         return;
       }
-      var spaceDelimiter = message.lastIndexOf(' ');
+      final spaceDelimiter = message.lastIndexOf(' ');
       compilerOutput.complete(CompilerOutput(
           message.substring(boundaryKey.length + 1, spaceDelimiter),
           int.parse(message.substring(spaceDelimiter + 1).trim()),
@@ -298,7 +298,7 @@ class ResidentCompiler {
       _controller.stream.listen(_handleCompilationRequest);
     }
 
-    var completer = Completer<CompilerOutput?>();
+    final completer = Completer<CompilerOutput?>();
     _controller.add(_RecompileRequest(
         completer, mainUri, invalidatedFiles, outputPath, packageConfig));
     return completer.future;
@@ -317,9 +317,9 @@ class ResidentCompiler {
     if (_server == null) {
       return _compile(mainUri, request.outputPath);
     }
-    var server = _server!;
+    final server = _server!;
 
-    var inputKey = generateV4UUID();
+    final inputKey = generateV4UUID();
     server.stdin.writeln('recompile $mainUri$inputKey');
     _logger.info('<- recompile $mainUri$inputKey');
     for (var fileUri in request.invalidatedFiles) {
@@ -342,14 +342,14 @@ class ResidentCompiler {
   final List<_CompilationRequest> _compilationQueue = <_CompilationRequest>[];
 
   Future<void> _handleCompilationRequest(_CompilationRequest request) async {
-    var isEmpty = _compilationQueue.isEmpty;
+    final isEmpty = _compilationQueue.isEmpty;
     _compilationQueue.add(request);
     // Only trigger processing if queue was empty - i.e. no other requests
     // are currently being processed. This effectively enforces "one
     // compilation request at a time".
     if (isEmpty) {
       while (_compilationQueue.isNotEmpty) {
-        var request = _compilationQueue.first;
+        final request = _compilationQueue.first;
         await request.run(this);
         _compilationQueue.removeAt(0);
       }
@@ -358,8 +358,8 @@ class ResidentCompiler {
 
   Future<CompilerOutput?> _compile(
       String scriptUri, String outputFilePath) async {
-    var frontendServer = sdkLayout.frontendServerSnapshotPath;
-    var args = <String>[
+    final frontendServer = sdkLayout.frontendServerSnapshotPath;
+    final args = <String>[
       frontendServer,
       '--sdk-root',
       sdkRoot,
@@ -402,7 +402,7 @@ class ResidentCompiler {
     _server = await Process.start(sdkLayout.dartAotRuntimePath, args,
         workingDirectory: workingDirectory);
 
-    var server = _server!;
+    final server = _server!;
     server.stdout
         .transform<String>(utf8.decoder)
         .transform<String>(const LineSplitter())
@@ -445,7 +445,7 @@ class ResidentCompiler {
       _controller.stream.listen(_handleCompilationRequest);
     }
 
-    var completer = Completer<CompilerOutput?>();
+    final completer = Completer<CompilerOutput?>();
     _controller.add(_CompileExpressionRequest(completer, expression,
         definitions, typeDefinitions, libraryUri, klass, isStatic));
     return completer.future;
@@ -460,9 +460,9 @@ class ResidentCompiler {
     if (_server == null) {
       return null;
     }
-    var server = _server!;
+    final server = _server!;
 
-    var inputKey = generateV4UUID();
+    final inputKey = generateV4UUID();
     server.stdin.writeln('compile-expression $inputKey');
     server.stdin.writeln(request.expression);
     request.definitions.forEach(server.stdin.writeln);
@@ -489,7 +489,7 @@ class ResidentCompiler {
       _controller.stream.listen(_handleCompilationRequest);
     }
 
-    var completer = Completer<CompilerOutput?>();
+    final completer = Completer<CompilerOutput?>();
     _controller.add(_CompileExpressionToJsRequest(completer, libraryUri, line,
         column, jsModules, jsFrameValues, moduleName, expression));
     return completer.future;
@@ -505,9 +505,9 @@ class ResidentCompiler {
     if (_server == null) {
       return null;
     }
-    var server = _server!;
+    final server = _server!;
 
-    var inputKey = generateV4UUID();
+    final inputKey = generateV4UUID();
     server.stdin.writeln('compile-expression-to-js $inputKey');
     server.stdin.writeln(request.libraryUri);
     server.stdin.writeln(request.line);
@@ -545,7 +545,7 @@ class ResidentCompiler {
       _controller.stream.listen(_handleCompilationRequest);
     }
 
-    var completer = Completer<CompilerOutput?>();
+    final completer = Completer<CompilerOutput?>();
     _controller.add(_RejectRequest(completer));
     return completer.future;
   }
@@ -597,7 +597,7 @@ class ResidentCompiler {
       return 0;
     }
 
-    var server = _server!;
+    final server = _server!;
     _logger.info('killing pid ${server.pid}');
     server.kill();
     return server.exitCode;
@@ -618,11 +618,11 @@ class TestExpressionCompiler implements ExpressionCompiler {
       Map<String, String> jsFrameValues,
       String moduleName,
       String expression) async {
-    var compilerOutput = await _generator.compileExpressionToJs(libraryUri,
+    final compilerOutput = await _generator.compileExpressionToJs(libraryUri,
         line, column, jsModules, jsFrameValues, moduleName, expression);
 
     if (compilerOutput != null) {
-      var content = utf8.decode(localFileSystem
+      final content = utf8.decode(localFileSystem
           .file(compilerOutput.outputFilename)
           .readAsBytesSync());
       return ExpressionCompilationResult(

--- a/frontend_server_common/lib/src/resident_runner.dart
+++ b/frontend_server_common/lib/src/resident_runner.dart
@@ -85,7 +85,7 @@ class ResidentWebRunner {
     );
     uri = await devFS.create();
 
-    var report = await _updateDevFS();
+    final report = await _updateDevFS();
     if (!report.success) {
       _logger.severe('Failed to compile application.');
       return 1;
@@ -98,7 +98,7 @@ class ResidentWebRunner {
   }
 
   Future<UpdateFSReport> _updateDevFS() async {
-    var report = await devFS.update(
+    final report = await devFS.update(
         mainUri: mainUri,
         dillOutputPath: outputPath,
         generator: generator,

--- a/test_common/test/proper_release_test.dart
+++ b/test_common/test/proper_release_test.dart
@@ -15,7 +15,7 @@ import 'package:test/test.dart';
 import 'package:test_common/utilities.dart';
 
 void main() {
-  for (var package in ['dwds', 'webdev']) {
+  for (final package in ['dwds', 'webdev']) {
     test('$package is following proper release procedure', () async {
       final pubspecPath =
           absolutePath(pathFromWebdev: p.join(package, 'pubspec.yaml'));

--- a/webdev/bin/webdev.dart
+++ b/webdev/bin/webdev.dart
@@ -32,7 +32,7 @@ Future main(List<String> args) async {
         e.unsupportedArgument != null ? ' with --${e.unsupportedArgument}' : '';
     print(red
         .wrap('$_boldApp could not run$withUnsupportedArg for this project.'));
-    for (var detail in e.details) {
+    for (final detail in e.details) {
       print(yellow.wrap(detail.error));
       if (detail.description != null) {
         print(detail.description);

--- a/webdev/bin/webdev.dart
+++ b/webdev/bin/webdev.dart
@@ -28,7 +28,7 @@ Future main(List<String> args) async {
     }
     exitCode = ExitCode.config.code;
   } on PackageException catch (e) {
-    var withUnsupportedArg =
+    final withUnsupportedArg =
         e.unsupportedArgument != null ? ' with --${e.unsupportedArgument}' : '';
     print(red
         .wrap('$_boldApp could not run$withUnsupportedArg for this project.'));

--- a/webdev/lib/src/command/build_command.dart
+++ b/webdev/lib/src/command/build_command.dart
@@ -37,17 +37,18 @@ class BuildCommand extends Command<int> {
 
   @override
   Future<int> run() async {
-    var extraArgs = argResults?.rest ?? [];
-    var unsupported = extraArgs.where((arg) => !arg.startsWith('-')).toList();
+    final extraArgs = argResults?.rest ?? [];
+    final unsupported = extraArgs.where((arg) => !arg.startsWith('-')).toList();
     if (unsupported.isNotEmpty) {
       throw UsageException(
           'Arguments were provided that are not supported: '
           '"${unsupported.join(' ')}".',
           argParser.usage);
     }
-    var validExtraArgs = extraArgs.where((arg) => arg.startsWith('-')).toList();
+    final validExtraArgs =
+        extraArgs.where((arg) => arg.startsWith('-')).toList();
 
-    var configuration = Configuration.fromArgs(argResults);
+    final configuration = Configuration.fromArgs(argResults);
     configureLogWriter(configuration.verbose);
 
     List<String> arguments;
@@ -62,7 +63,7 @@ class BuildCommand extends Command<int> {
 
     try {
       logWriter(logging.Level.INFO, 'Connecting to the build daemon...');
-      var client = await connectClient(
+      final client = await connectClient(
         Directory.current.path,
         arguments,
         (serverLog) {
@@ -73,7 +74,7 @@ class BuildCommand extends Command<int> {
         },
       );
       OutputLocation? outputLocation;
-      var outputInput = configuration.outputInput;
+      final outputInput = configuration.outputInput;
       if (configuration.outputPath != null) {
         outputLocation = OutputLocation((b) => b
           ..output = configuration.outputPath
@@ -87,7 +88,7 @@ class BuildCommand extends Command<int> {
       var exitCode = 0;
       var gotBuildStart = false;
       await for (final result in client.buildResults) {
-        var targetResult = result.results.firstWhereOrNull(
+        final targetResult = result.results.firstWhereOrNull(
             (buildResult) => buildResult.target == configuration.outputInput);
         if (targetResult == null) continue;
         // We ignore any builds that happen before we get a `started` event,
@@ -103,7 +104,7 @@ class BuildCommand extends Command<int> {
           exitCode = 1;
         }
 
-        var error = targetResult.error ?? '';
+        final error = targetResult.error ?? '';
         if (error.isNotEmpty) {
           logWriter(logging.Level.SEVERE, error);
         }

--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -290,7 +290,7 @@ class Configuration {
     defaultConfiguration ??= Configuration();
     if (argResults == null) return defaultConfiguration;
 
-    var enableInjectedClient =
+    final enableInjectedClient =
         argResults.options.contains(enableInjectedClientFlag)
             ? (argResults[enableInjectedClientFlag] as bool)
             : defaultConfiguration.enableInjectedClient;
@@ -304,36 +304,36 @@ class Configuration {
           ._override(Configuration.noInjectedClientDefaults());
     }
 
-    var chromeDebugPort = argResults.options.contains(chromeDebugPortFlag)
+    final chromeDebugPort = argResults.options.contains(chromeDebugPortFlag)
         ? int.parse(argResults[chromeDebugPortFlag] as String)
         : defaultConfiguration.chromeDebugPort;
 
-    var debugExtension = argResults.options.contains(debugExtensionFlag)
+    final debugExtension = argResults.options.contains(debugExtensionFlag)
         ? argResults[debugExtensionFlag] as bool?
         : defaultConfiguration.debugExtension;
 
-    var debug = argResults.options.contains(debugFlag)
+    final debug = argResults.options.contains(debugFlag)
         ? argResults[debugFlag] as bool?
         : defaultConfiguration.debug;
 
-    var hostname = argResults.options.contains(hostnameFlag)
+    final hostname = argResults.options.contains(hostnameFlag)
         ? argResults[hostnameFlag] as String?
         : defaultConfiguration.hostname;
 
-    var tlsCertChain = argResults.options.contains(tlsCertChainFlag)
+    final tlsCertChain = argResults.options.contains(tlsCertChainFlag)
         ? argResults[tlsCertChainFlag] as String?
         : defaultConfiguration.tlsCertChain;
 
-    var tlsCertKey = argResults.options.contains(tlsCertKeyFlag)
+    final tlsCertKey = argResults.options.contains(tlsCertKeyFlag)
         ? argResults[tlsCertKeyFlag] as String?
         : defaultConfiguration.tlsCertKey;
 
-    var launchApps = argResults.options.contains(launchAppOption) &&
+    final launchApps = argResults.options.contains(launchAppOption) &&
             argResults.wasParsed(launchAppOption)
         ? argResults[launchAppOption] as List<String>?
         : defaultConfiguration.launchApps;
 
-    var launchInChrome = argResults.options.contains(launchInChromeFlag) &&
+    final launchInChrome = argResults.options.contains(launchInChromeFlag) &&
             argResults.wasParsed(launchInChromeFlag)
         ? argResults[launchInChromeFlag] as bool?
         // We want to default to launch chrome if the user provides just --debug
@@ -344,15 +344,15 @@ class Configuration {
             ? true
             : defaultConfiguration.launchInChrome;
 
-    var userDataDir = argResults.options.contains(userDataDirFlag)
+    final userDataDir = argResults.options.contains(userDataDirFlag)
         ? argResults[userDataDirFlag] as String?
         : defaultConfiguration.userDataDir;
 
-    var logRequests = argResults.options.contains(logRequestsFlag)
+    final logRequests = argResults.options.contains(logRequestsFlag)
         ? argResults[logRequestsFlag] as bool?
         : defaultConfiguration.logRequests;
 
-    var output = argResults.options.contains(outputFlag)
+    final output = argResults.options.contains(outputFlag)
         ? argResults[outputFlag] as String?
         : defaultConfiguration.output;
 
@@ -362,7 +362,7 @@ class Configuration {
       // The empty string means build everything.
       outputInput = '';
     } else {
-      var splitOutput = output.split(':');
+      final splitOutput = output.split(':');
       if (splitOutput.length == 1) {
         // The empty string means build everything.
         outputInput = '';
@@ -373,38 +373,38 @@ class Configuration {
       }
     }
 
-    var release = argResults.options.contains(releaseFlag)
+    final release = argResults.options.contains(releaseFlag)
         ? argResults[releaseFlag] as bool?
         : defaultConfiguration.release;
 
-    var requireBuildWebCompilers =
+    final requireBuildWebCompilers =
         argResults.options.contains(requireBuildWebCompilersFlag)
             ? argResults[requireBuildWebCompilersFlag] as bool?
             : defaultConfiguration.requireBuildWebCompilers;
 
-    var enableExpressionEvaluation =
+    final enableExpressionEvaluation =
         argResults.options.contains(enableExpressionEvaluationFlag)
             ? argResults[enableExpressionEvaluationFlag] as bool?
             : defaultConfiguration.enableExpressionEvaluation;
 
-    var verbose = argResults.options.contains(verboseFlag)
+    final verbose = argResults.options.contains(verboseFlag)
         ? argResults[verboseFlag] as bool?
         : defaultConfiguration.verbose;
 
-    var nullSafety = argResults.options.contains(nullSafetyFlag)
+    final nullSafety = argResults.options.contains(nullSafetyFlag)
         ? argResults[nullSafetyFlag] as String?
         : defaultConfiguration.nullSafety;
 
-    var disableDds = argResults.options.contains(disableDdsFlag)
+    final disableDds = argResults.options.contains(disableDdsFlag)
         ? argResults[disableDdsFlag] as bool?
         : defaultConfiguration.disableDds;
 
-    var experiments = argResults.options.contains(enableExperimentOption) &&
+    final experiments = argResults.options.contains(enableExperimentOption) &&
             argResults.wasParsed(enableExperimentOption)
         ? argResults[enableExperimentOption] as List<String>?
         : defaultConfiguration.experiments;
 
-    var canaryFeatures = argResults.options.contains(canaryFeaturesFlag)
+    final canaryFeatures = argResults.options.contains(canaryFeaturesFlag)
         ? argResults[canaryFeaturesFlag] as bool?
         : defaultConfiguration.canaryFeatures;
 

--- a/webdev/lib/src/command/daemon_command.dart
+++ b/webdev/lib/src/command/daemon_command.dart
@@ -61,7 +61,7 @@ class DaemonCommand extends Command<int> {
 
   @override
   Future<int> run() async {
-    var configuration = Configuration.fromArgs(argResults,
+    final configuration = Configuration.fromArgs(argResults,
         defaultConfiguration: Configuration(
             launchInChrome: true, debug: true, autoRun: false, release: false));
     configureLogWriter(configuration.verbose);
@@ -76,7 +76,7 @@ class DaemonCommand extends Command<int> {
     Daemon? daemon;
     DevWorkflow? workflow;
     var cancelCount = 0;
-    var cancelSub = StreamGroup.merge([
+    final cancelSub = StreamGroup.merge([
       ProcessSignal.sigint.watch(),
       // SIGTERM is not supported on Windows.
       Platform.isWindows ? const Stream.empty() : ProcessSignal.sigterm.watch()
@@ -87,7 +87,7 @@ class DaemonCommand extends Command<int> {
     });
     try {
       daemon = Daemon(_stdinCommandStream, _stdoutCommandResponse);
-      var daemonDomain = DaemonDomain(daemon);
+      final daemonDomain = DaemonDomain(daemon);
       configureLogWriter(configuration.verbose, customLogWriter:
           (level, message, {loggerName, error, stackTrace, verbose}) {
         if (configuration.verbose || level >= Level.INFO) {
@@ -103,11 +103,11 @@ class DaemonCommand extends Command<int> {
         }
       });
       daemon.registerDomain(daemonDomain);
-      var buildOptions = buildRunnerArgs(configuration);
-      var extraArgs = argResults?.rest ?? [];
-      var directoryArgs =
+      final buildOptions = buildRunnerArgs(configuration);
+      final extraArgs = argResults?.rest ?? [];
+      final directoryArgs =
           extraArgs.where((arg) => !arg.startsWith('-')).toList();
-      var targetPorts =
+      final targetPorts =
           parseDirectoryArgs(directoryArgs, basePort: await findUnusedPort());
       validateLaunchApps(configuration.launchApps, targetPorts.keys);
 

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -103,14 +103,15 @@ refresh: Performs a full page refresh.
     }
     // Forward remaining arguments as Build Options to the Daemon.
     // This isn't documented. Should it be advertised?
-    var buildOptions = buildRunnerArgs(configuration)
+    final buildOptions = buildRunnerArgs(configuration)
       ..addAll(argResults!.rest.where((arg) => arg.startsWith('-')).toList());
-    var extraArgs = argResults?.rest ?? [];
-    var directoryArgs = extraArgs.where((arg) => !arg.startsWith('-')).toList();
-    var targetPorts = parseDirectoryArgs(directoryArgs);
+    final extraArgs = argResults?.rest ?? [];
+    final directoryArgs =
+        extraArgs.where((arg) => !arg.startsWith('-')).toList();
+    final targetPorts = parseDirectoryArgs(directoryArgs);
     validateLaunchApps(configuration.launchApps, targetPorts.keys);
 
-    var workflow =
+    final workflow =
         await DevWorkflow.start(configuration, buildOptions, targetPorts);
     await workflow.done;
     return 0;

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -136,13 +136,13 @@ Map<String, int> parseDirectoryArgs(List<String> args, {int? basePort}) {
   final result = <String, int>{};
   var port = basePort ?? 8080;
   if (args.isEmpty) {
-    for (var dir in _defaultWebDirs) {
+    for (final dir in _defaultWebDirs) {
       if (Directory(dir).existsSync()) {
         result[dir] = port++;
       }
     }
   } else {
-    for (var arg in args) {
+    for (final arg in args) {
       final splitOption = arg.split(':');
       ensureIsTopLevelDir(splitOption.first);
       if (splitOption.length == 2) {
@@ -165,7 +165,7 @@ in the `<directory>:<port>` format, such as `webdev serve test:8080`.
 }
 
 void validateLaunchApps(List<String> launchApps, Iterable<String> serveDirs) {
-  for (var app in launchApps) {
+  for (final app in launchApps) {
     final dir = p.url.split(app).first;
     if (!serveDirs.contains(dir)) {
       throw InvalidConfiguration(

--- a/webdev/lib/src/command/shared.dart
+++ b/webdev/lib/src/command/shared.dart
@@ -80,7 +80,7 @@ void addSharedArgs(ArgParser argParser,
 /// Parses the provided [Configuration] to return a list of
 /// `package:build_runner` appropriate arguments.
 List<String> buildRunnerArgs(Configuration configuration) {
-  var arguments = <String>[];
+  final arguments = <String>[];
   if (configuration.release) {
     arguments.add('--$releaseFlag');
   }
@@ -103,7 +103,7 @@ List<String> buildRunnerArgs(Configuration configuration) {
 }
 
 Future<void> validatePubspecLock(Configuration configuration) async {
-  var pubspecLock = await PubspecLock.read();
+  final pubspecLock = await PubspecLock.read();
   await checkPubspecLock(pubspecLock,
       requireBuildWebCompilers: configuration.requireBuildWebCompilers);
 }
@@ -133,7 +133,7 @@ final _defaultWebDirs = const ['web'];
 /// Throws an [InvalidConfiguration] exception if it can't find at
 /// least one directory.
 Map<String, int> parseDirectoryArgs(List<String> args, {int? basePort}) {
-  var result = <String, int>{};
+  final result = <String, int>{};
   var port = basePort ?? 8080;
   if (args.isEmpty) {
     for (var dir in _defaultWebDirs) {
@@ -143,7 +143,7 @@ Map<String, int> parseDirectoryArgs(List<String> args, {int? basePort}) {
     }
   } else {
     for (var arg in args) {
-      var splitOption = arg.split(':');
+      final splitOption = arg.split(':');
       ensureIsTopLevelDir(splitOption.first);
       if (splitOption.length == 2) {
         result[splitOption.first] = int.parse(splitOption.last);
@@ -166,7 +166,7 @@ in the `<directory>:<port>` format, such as `webdev serve test:8080`.
 
 void validateLaunchApps(List<String> launchApps, Iterable<String> serveDirs) {
   for (var app in launchApps) {
-    var dir = p.url.split(app).first;
+    final dir = p.url.split(app).first;
     if (!serveDirs.contains(dir)) {
       throw InvalidConfiguration(
           'Unable to launch app `$app` since its top level dir (`$dir`) '

--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -62,13 +62,13 @@ class AppDomain extends Domain {
   }
 
   Future<void> _handleAppConnections(WebDevServer server) async {
-    var dwds = server.dwds!;
+    final dwds = server.dwds!;
     // The connection is established right before `main()` is called.
     await for (var appConnection in dwds.connectedApps) {
-      var debugConnection = await dwds.debugConnection(appConnection);
+      final debugConnection = await dwds.debugConnection(appConnection);
       final debugUri = debugConnection.ddsUri ?? debugConnection.uri;
       final vmService = await vmServiceConnectUri(debugUri);
-      var appId = appConnection.request.appId;
+      final appId = appConnection.request.appId;
       unawaited(debugConnection.onDone.then((_) {
         sendEvent('app.log', {
           'appId': appId,
@@ -97,7 +97,7 @@ class AppDomain extends Domain {
         await vmService.streamListen('Service');
       } catch (_) {}
       // ignore: cancel_subscriptions
-      var stdOutSub = vmService.onStdoutEvent.listen((log) {
+      final stdOutSub = vmService.onStdoutEvent.listen((log) {
         sendEvent('app.log', {
           'appId': appId,
           'log': utf8.decode(base64.decode(log.bytes!)),
@@ -109,10 +109,10 @@ class AppDomain extends Domain {
         'wsUri': debugConnection.uri,
       });
       // ignore: cancel_subscriptions
-      var resultSub =
+      final resultSub =
           server.buildResults.listen((r) => _handleBuildResult(r, appId));
 
-      var appState = _AppState(debugConnection, resultSub, stdOutSub);
+      final appState = _AppState(debugConnection, resultSub, stdOutSub);
       _appStates[appId] = appState;
       sendEvent('app.started', {
         'appId': appId,
@@ -152,27 +152,27 @@ class AppDomain extends Domain {
 
   Future<Map<String, dynamic>?> _callServiceExtension(
       Map<String, dynamic> args) async {
-    var appId = getStringArg(args, 'appId', required: true);
-    var appState = _appStates[appId];
+    final appId = getStringArg(args, 'appId', required: true);
+    final appState = _appStates[appId];
     if (appState == null) {
       throw ArgumentError.value(appId, 'appId', 'Not found');
     }
-    var methodName = getStringArg(args, 'methodName', required: true)!;
-    var params = args['params'] != null
+    final methodName = getStringArg(args, 'methodName', required: true)!;
+    final params = args['params'] != null
         ? (args['params'] as Map<String, dynamic>)
         : <String, dynamic>{};
-    var response = await appState.vmService!
+    final response = await appState.vmService!
         .callServiceExtension(methodName, args: params);
     return response.json;
   }
 
   Future<Map<String, dynamic>> _restart(Map<String, dynamic> args) async {
-    var appId = getStringArg(args, 'appId', required: true);
-    var appState = _appStates[appId];
+    final appId = getStringArg(args, 'appId', required: true);
+    final appState = _appStates[appId];
     if (appState == null) {
       throw ArgumentError.value(appId, 'appId', 'Not found');
     }
-    var fullRestart = getBoolArg(args, 'fullRestart') ?? false;
+    final fullRestart = getBoolArg(args, 'fullRestart') ?? false;
     if (!fullRestart) {
       return {
         'code': 1,
@@ -181,7 +181,7 @@ class AppDomain extends Domain {
     }
     // TODO(grouma) - Support pauseAfterRestart.
     // var pauseAfterRestart = getBoolArg(args, 'pause') ?? false;
-    var stopwatch = Stopwatch()..start();
+    final stopwatch = Stopwatch()..start();
     _progressEventId++;
     sendEvent('app.progress', {
       'appId': appId,
@@ -189,9 +189,9 @@ class AppDomain extends Domain {
       'message': 'Performing hot restart...',
       'progressId': 'hot.restart',
     });
-    var restartMethod =
+    final restartMethod =
         _registeredMethodsForService['hotRestart'] ?? 'hotRestart';
-    var response =
+    final response =
         await appState.vmService!.callServiceExtension(restartMethod);
     sendEvent('app.progress', {
       'appId': appId,
@@ -210,8 +210,8 @@ class AppDomain extends Domain {
   }
 
   Future<bool> _stop(Map<String, dynamic> args) async {
-    var appId = getStringArg(args, 'appId', required: true);
-    var appState = _appStates[appId];
+    final appId = getStringArg(args, 'appId', required: true);
+    final appState = _appStates[appId];
     if (appState == null) {
       throw ArgumentError.value(appId, 'appId', 'Not found');
     }

--- a/webdev/lib/src/daemon/app_domain.dart
+++ b/webdev/lib/src/daemon/app_domain.dart
@@ -64,7 +64,7 @@ class AppDomain extends Domain {
   Future<void> _handleAppConnections(WebDevServer server) async {
     final dwds = server.dwds!;
     // The connection is established right before `main()` is called.
-    await for (var appConnection in dwds.connectedApps) {
+    await for (final appConnection in dwds.connectedApps) {
       final debugConnection = await dwds.debugConnection(appConnection);
       final debugUri = debugConnection.ddsUri ?? debugConnection.uri;
       final vmService = await vmServiceConnectUri(debugUri);
@@ -226,7 +226,7 @@ class AppDomain extends Domain {
   @override
   void dispose() {
     _isShutdown = true;
-    for (var state in _appStates.values) {
+    for (final state in _appStates.values) {
       state.dispose();
     }
     _appStates.clear();

--- a/webdev/lib/src/daemon/daemon.dart
+++ b/webdev/lib/src/daemon/daemon.dart
@@ -45,7 +45,7 @@ class Daemon {
     // {id, method, params}
 
     // [id] is an opaque type to us.
-    var id = request['id'];
+    final id = request['id'];
 
     if (id == null) {
       stderr.writeln('no id for request: $request');
@@ -53,14 +53,14 @@ class Daemon {
     }
 
     try {
-      var method = request['method'] as String? ?? '';
+      final method = request['method'] as String? ?? '';
       if (!method.contains('.')) {
         throw ArgumentError('method not understood: $method');
       }
 
-      var domain = method.substring(0, method.indexOf('.'));
-      var name = method.substring(method.indexOf('.') + 1);
-      var domainValue = _domainMap[domain];
+      final domain = method.substring(0, method.indexOf('.'));
+      final name = method.substring(method.indexOf('.') + 1);
+      final domainValue = _domainMap[domain];
       if (domainValue == null) {
         throw ArgumentError('no domain for method: $method');
       }

--- a/webdev/lib/src/daemon/daemon.dart
+++ b/webdev/lib/src/daemon/daemon.dart
@@ -80,7 +80,7 @@ class Daemon {
 
   void shutdown({Object? error}) {
     _commandSubscription.cancel();
-    for (var domain in _domainMap.values) {
+    for (final domain in _domainMap.values) {
       domain.dispose();
     }
     if (!_onExitCompleter.isCompleted) {

--- a/webdev/lib/src/daemon/domain.dart
+++ b/webdev/lib/src/daemon/domain.dart
@@ -42,7 +42,7 @@ abstract class Domain {
   }
 
   void sendEvent(String name, [dynamic args]) {
-    var map = <String, dynamic>{'event': name};
+    final map = <String, dynamic>{'event': name};
     if (args != null) map['params'] = toJsonable(args);
     _send(map);
   }

--- a/webdev/lib/src/daemon/utilites.dart
+++ b/webdev/lib/src/daemon/utilites.dart
@@ -19,7 +19,7 @@ String? getStringArg(Map<String, dynamic> args, String name,
   if (required && !args.containsKey(name)) {
     throw ArgumentError('$name is required');
   }
-  var val = args[name];
+  final val = args[name];
   if (val != null && val is! String) {
     throw ArgumentError('$name is not a String');
   }
@@ -31,7 +31,7 @@ bool? getBoolArg(Map<String, dynamic> args, String name,
   if (required && !args.containsKey(name)) {
     throw ArgumentError('$name is required');
   }
-  var val = args[name];
+  final val = args[name];
   if (val != null && val is! bool) throw ArgumentError('$name is not a bool');
   return val as bool?;
 }
@@ -41,7 +41,7 @@ int? getIntArg(Map<String, dynamic> args, String name,
   if (required && !args.containsKey(name)) {
     throw ArgumentError('$name is required');
   }
-  var val = args[name];
+  final val = args[name];
   if (val != null && val is! int) throw ArgumentError('$name is not an int');
   return val as int?;
 }

--- a/webdev/lib/src/daemon_client.dart
+++ b/webdev/lib/src/daemon_client.dart
@@ -20,7 +20,7 @@ Future<BuildDaemonClient> connectClient(String workingDirectory,
 
 /// Returns the port of the daemon asset server.
 int daemonPort(String workingDirectory) {
-  var portFile = File(_assetServerPortFilePath(workingDirectory));
+  final portFile = File(_assetServerPortFilePath(workingDirectory));
   if (!portFile.existsSync()) {
     throw Exception('Unable to read daemon asset port file.');
   }

--- a/webdev/lib/src/logging.dart
+++ b/webdev/lib/src/logging.dart
@@ -31,7 +31,7 @@ LogWriter _logWriter =
     (level, message, {String? error, String? loggerName, String? stackTrace}) {
   // Erases the previous line
   if (!_verbose) stdout.write('\x1b[2K\r');
-  var log = formatLog(level, message,
+  final log = formatLog(level, message,
       error: error,
       loggerName: loggerName,
       stackTrace: stackTrace,
@@ -54,7 +54,7 @@ LogWriter get logWriter => _logWriter;
 String formatLog(Level level, String message,
     {bool? withColors, String? error, String? loggerName, String? stackTrace}) {
   withColors ??= false;
-  var buffer = StringBuffer(message);
+  final buffer = StringBuffer(message);
   if (error != null) {
     buffer.writeln(error);
   }
@@ -76,7 +76,7 @@ String formatLog(Level level, String message,
     formattedLevel = color.wrap(formattedLevel) ?? formattedLevel;
   }
 
-  var loggerNameOutput =
+  final loggerNameOutput =
       (loggerName != null && (_verbose || loggerName.contains(' ')))
           ? ' $loggerName:'
           : '';

--- a/webdev/lib/src/pubspec.dart
+++ b/webdev/lib/src/pubspec.dart
@@ -47,7 +47,7 @@ dev_dependencies:
 }
 
 Future _runPubDeps() async {
-  var result = Process.runSync(dartPath, ['pub', 'deps']);
+  final result = Process.runSync(dartPath, ['pub', 'deps']);
 
   if (result.exitCode == 65 || result.exitCode == 66) {
     throw PackageException(
@@ -87,36 +87,36 @@ class PubspecLock {
       dir = next;
     }
 
-    var pubspecLock = loadYaml(
+    final pubspecLock = loadYaml(
             await File(p.relative(p.join(dir, 'pubspec.lock'))).readAsString())
         as YamlMap;
 
-    var packages = pubspecLock['packages'] as YamlMap?;
+    final packages = pubspecLock['packages'] as YamlMap?;
     return PubspecLock(packages);
   }
 
   List<PackageExceptionDetails> checkPackage(
       String pkgName, VersionConstraint constraint,
       {String? forArgument}) {
-    var issues = <PackageExceptionDetails>[];
-    var missingDetails =
+    final issues = <PackageExceptionDetails>[];
+    final missingDetails =
         PackageExceptionDetails.missingDep(pkgName, constraint);
 
-    var pkgDataMap =
+    final pkgDataMap =
         (_packages == null) ? null : _packages[pkgName] as YamlMap?;
     if (pkgDataMap == null) {
       issues.add(missingDetails);
     } else {
-      var source = pkgDataMap['source'] as String?;
+      final source = pkgDataMap['source'] as String?;
       if (source == 'hosted') {
         // NOTE: pkgDataMap['description'] should be:
         //           `{url: https://pub.dev, name: [pkgName]}`
         //       If a user is playing around here, they are on their own.
 
-        var version = pkgDataMap['version'] as String;
-        var pkgVersion = Version.parse(version);
+        final version = pkgDataMap['version'] as String;
+        final pkgVersion = Version.parse(version);
         if (!constraint.allows(pkgVersion)) {
-          var error = 'The `$pkgName` version – $pkgVersion – is not '
+          final error = 'The `$pkgName` version – $pkgVersion – is not '
               'within the allowed constraint – $constraint.';
           issues.add(PackageExceptionDetails._(error));
         }
@@ -131,19 +131,19 @@ class PubspecLock {
 
 Future<List<PackageExceptionDetails>> _validateBuildDaemonVersion(
     PubspecLock pubspecLock) async {
-  var buildDaemonConstraint = '^4.0.0';
+  final buildDaemonConstraint = '^4.0.0';
 
-  var issues = <PackageExceptionDetails>[];
+  final issues = <PackageExceptionDetails>[];
 
-  var buildDaemonIssues = pubspecLock.checkPackage(
+  final buildDaemonIssues = pubspecLock.checkPackage(
     'build_daemon',
     VersionConstraint.parse(buildDaemonConstraint),
   );
 
   // Only warn of build_daemon issues if they have a dependency on the package.
   if (buildDaemonIssues.any((issue) => !issue._missingDependency)) {
-    var info = await _latestPackageInfo();
-    var issuePreamble =
+    final info = await _latestPackageInfo();
+    final issuePreamble =
         'This version of webdev does not support the `build_daemon` '
         'protocol used by your version of `build_runner`.';
     // Check if the newer version supports the `build_daemon` transitive version
@@ -171,8 +171,8 @@ final buildWebCompilersConstraint = VersionConstraint.parse('^4.0.4');
 // get them by default.
 Future<void> checkPubspecLock(PubspecLock pubspecLock,
     {required bool requireBuildWebCompilers}) async {
-  var issues = <PackageExceptionDetails>[];
-  var buildRunnerIssues =
+  final issues = <PackageExceptionDetails>[];
+  final buildRunnerIssues =
       pubspecLock.checkPackage('build_runner', buildRunnerConstraint);
 
   issues.addAll(buildRunnerIssues);
@@ -200,20 +200,20 @@ class _PackageInfo {
 
 /// Returns the package info for the latest webdev release.
 Future<_PackageInfo> _latestPackageInfo() async {
-  var response = await get(Uri.parse('https://pub.dev/api/packages/webdev'),
+  final response = await get(Uri.parse('https://pub.dev/api/packages/webdev'),
       headers: {HttpHeaders.userAgentHeader: 'webdev $packageVersion'});
-  var responseObj = json.decode(response.body);
-  var pubspec = Pubspec.fromJson(
+  final responseObj = json.decode(response.body);
+  final pubspec = Pubspec.fromJson(
       responseObj['latest']['pubspec'] as Map<String, dynamic>);
-  var buildDaemonDependency = pubspec.dependencies['build_daemon'];
+  final buildDaemonDependency = pubspec.dependencies['build_daemon'];
   // This should never be satisfied.
   var buildDaemonConstraint = VersionConstraint.parse('0.0.0');
   if (buildDaemonDependency is HostedDependency) {
     buildDaemonConstraint = buildDaemonDependency.version;
   }
-  var currentVersion = Version.parse(packageVersion);
-  var pubspecVersion = pubspec.version;
-  var isNewer = (pubspecVersion == null)
+  final currentVersion = Version.parse(packageVersion);
+  final pubspecVersion = pubspec.version;
+  final isNewer = (pubspecVersion == null)
       ? true
       : currentVersion.compareTo(pubspecVersion) < 0;
   return _PackageInfo(pubspec.version, buildDaemonConstraint, isNewer);

--- a/webdev/lib/src/serve/chrome.dart
+++ b/webdev/lib/src/serve/chrome.dart
@@ -53,15 +53,15 @@ class Chrome {
     // pass null to have it create a directory.
     // Issue: https://github.com/dart-lang/webdev/issues/1545
     if (!Platform.isWindows) {
-      var userDataTemp = path.join(Directory.current.absolute.path,
+      final userDataTemp = path.join(Directory.current.absolute.path,
           '.dart_tool', 'webdev', 'chrome_user_data');
-      var userDataCopy = path.join(Directory.current.absolute.path,
+      final userDataCopy = path.join(Directory.current.absolute.path,
           '.dart_tool', 'webdev', 'chrome_user_data_copy');
 
       if (userDataDir != null) {
         signIn = true;
         dir = userDataCopy;
-        var stopwatch = Stopwatch()..start();
+        final stopwatch = Stopwatch()..start();
         try {
           _logger.info('Copying user data directory...');
           _logger.warning(
@@ -94,7 +94,7 @@ class Chrome {
     }
 
     _logger.info('Starting chrome with user data directory: $dir');
-    var chrome = await browser_launcher.Chrome.startWithDebugPort(urls,
+    final chrome = await browser_launcher.Chrome.startWithDebugPort(urls,
         debugPort: port, userDataDir: dir, signIn: signIn);
     return _connect(Chrome._(chrome.debugPort, chrome));
   }
@@ -129,7 +129,7 @@ class ChromeError extends Error {
 
 String? autoDetectChromeUserDataDirectory() {
   Directory directory;
-  var home = Platform.environment['HOME'] ?? '';
+  final home = Platform.environment['HOME'] ?? '';
   if (Platform.isMacOS) {
     directory = Directory(
         path.join(home, 'Library', 'Application Support', 'Google', 'Chrome'));

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -43,9 +43,9 @@ Future<BuildDaemonClient> _startBuildDaemon(
 }
 
 String _uriForLaunchApp(String launchApp, ServerManager serverManager) {
-  var parts = p.url.split(launchApp);
-  var dir = parts.first;
-  var server =
+  final parts = p.url.split(launchApp);
+  final dir = parts.first;
+  final server =
       serverManager.servers.firstWhere((server) => server.target == dir);
   return Uri(
           scheme: 'http',
@@ -60,7 +60,7 @@ Future<Chrome?> _startChrome(
   ServerManager serverManager,
   BuildDaemonClient client,
 ) async {
-  var uris = [
+  final uris = [
     if (configuration.launchApps.isEmpty)
       for (var s in serverManager.servers)
         Uri(scheme: 'http', host: s.host, port: s.port).toString()
@@ -70,7 +70,7 @@ Future<Chrome?> _startChrome(
   ];
   try {
     if (configuration.launchInChrome) {
-      var userDataDir = configuration.userDataDir == autoOption
+      final userDataDir = configuration.userDataDir == autoOption
           ? autoDetectChromeUserDataDirectory()
           : configuration.userDataDir;
       return await Chrome.start(uris,
@@ -92,8 +92,8 @@ Future<ServerManager> _startServerManager(
   String workingDirectory,
   BuildDaemonClient client,
 ) async {
-  var assetPort = daemonPort(workingDirectory);
-  var serverOptions = <ServerOptions>{};
+  final assetPort = daemonPort(workingDirectory);
+  final serverOptions = <ServerOptions>{};
   for (var target in targetPorts.keys) {
     serverOptions.add(ServerOptions(
       configuration,
@@ -103,7 +103,7 @@ Future<ServerManager> _startServerManager(
     ));
   }
   logWriter(logging.Level.INFO, 'Starting resource servers...');
-  var serverManager =
+  final serverManager =
       await ServerManager.start(serverOptions, client.buildResults);
 
   for (var server in serverManager.servers) {
@@ -139,7 +139,7 @@ void _registerBuildTargets(
   // Empty string indicates we should build everything, register a corresponding
   // target.
   if (configuration.outputInput == '' && configuration.outputPath != null) {
-    var outputLocation = OutputLocation((b) => b
+    final outputLocation = OutputLocation((b) => b
       ..output = configuration.outputPath
       ..useSymlinks = true
       ..hoist = false);
@@ -191,15 +191,15 @@ class DevWorkflow {
     List<String> buildOptions,
     Map<String, int> targetPorts,
   ) async {
-    var workingDirectory = Directory.current.path;
-    var client = await _startBuildDaemon(workingDirectory, buildOptions);
+    final workingDirectory = Directory.current.path;
+    final client = await _startBuildDaemon(workingDirectory, buildOptions);
     logWriter(logging.Level.INFO, 'Registering build targets...');
     _registerBuildTargets(client, configuration, targetPorts);
     logWriter(logging.Level.INFO, 'Starting initial build...');
     client.startBuild();
-    var serverManager = await _startServerManager(
+    final serverManager = await _startServerManager(
         configuration, targetPorts, workingDirectory, client);
-    var chrome = await _startChrome(configuration, serverManager, client);
+    final chrome = await _startChrome(configuration, serverManager, client);
     return DevWorkflow._(client, chrome, serverManager);
   }
 

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -62,10 +62,10 @@ Future<Chrome?> _startChrome(
 ) async {
   final uris = [
     if (configuration.launchApps.isEmpty)
-      for (var s in serverManager.servers)
+      for (final s in serverManager.servers)
         Uri(scheme: 'http', host: s.host, port: s.port).toString()
     else
-      for (var app in configuration.launchApps)
+      for (final app in configuration.launchApps)
         _uriForLaunchApp(app, serverManager)
   ];
   try {
@@ -94,7 +94,7 @@ Future<ServerManager> _startServerManager(
 ) async {
   final assetPort = daemonPort(workingDirectory);
   final serverOptions = <ServerOptions>{};
-  for (var target in targetPorts.keys) {
+  for (final target in targetPorts.keys) {
     serverOptions.add(ServerOptions(
       configuration,
       targetPorts[target]!,
@@ -106,7 +106,7 @@ Future<ServerManager> _startServerManager(
   final serverManager =
       await ServerManager.start(serverOptions, client.buildResults);
 
-  for (var server in serverManager.servers) {
+  for (final server in serverManager.servers) {
     logWriter(
         logging.Level.INFO,
         'Serving `${server.target}` on '
@@ -122,7 +122,7 @@ void _registerBuildTargets(
   Map<String, int> targetPorts,
 ) {
   // Register a target for each serve target.
-  for (var target in targetPorts.keys) {
+  for (final target in targetPorts.keys) {
     OutputLocation? outputLocation;
     if (configuration.outputPath != null &&
         (configuration.outputInput == null ||

--- a/webdev/lib/src/serve/handlers/favicon_handler.dart
+++ b/webdev/lib/src/serve/handlers/favicon_handler.dart
@@ -10,7 +10,7 @@ import 'package:shelf/shelf.dart';
 
 Handler interceptFavicon(Handler handler) {
   return (request) async {
-    var response = await handler(request);
+    final response = await handler(request);
     if (response.statusCode == 404 &&
         request.url.pathSegments.isNotEmpty &&
         request.url.pathSegments.last == 'favicon.ico') {

--- a/webdev/lib/src/serve/server_manager.dart
+++ b/webdev/lib/src/serve/server_manager.dart
@@ -19,14 +19,14 @@ class ServerManager {
     Stream<BuildResults> buildResults,
   ) async {
     final servers = <WebDevServer>{};
-    for (var options in serverOptions) {
+    for (final options in serverOptions) {
       servers.add(await WebDevServer.start(options, buildResults));
     }
     return ServerManager._(servers);
   }
 
   Future<void> stop() async {
-    for (var server in servers) {
+    for (final server in servers) {
       await server.stop();
     }
   }

--- a/webdev/lib/src/serve/server_manager.dart
+++ b/webdev/lib/src/serve/server_manager.dart
@@ -18,7 +18,7 @@ class ServerManager {
     Set<ServerOptions> serverOptions,
     Stream<BuildResults> buildResults,
   ) async {
-    var servers = <WebDevServer>{};
+    final servers = <WebDevServer>{};
     for (var options in serverOptions) {
       servers.add(await WebDevServer.start(options, buildResults));
     }

--- a/webdev/lib/src/serve/utils.dart
+++ b/webdev/lib/src/serve/utils.dart
@@ -42,7 +42,7 @@ Future<void> _copyUpdated(String from, String to) async {
     if (file is Directory) {
       await _copyUpdated(file.path, copyTo);
     } else if (file is File) {
-      var copyToFile = File(copyTo);
+      final copyToFile = File(copyTo);
       if (!copyToFile.existsSync() ||
           copyToFile.statSync().modified.compareTo(file.statSync().modified) <
               0) {
@@ -67,15 +67,15 @@ Future<void> _removeDeleted(String from, String to) async {
   await for (final file in Directory(to).list()) {
     final copyFrom = p.join(from, p.relative(file.path, from: to));
     if (file is File) {
-      var copyFromFile = File(copyFrom);
+      final copyFromFile = File(copyFrom);
       if (!copyFromFile.existsSync()) {
         await File(file.path).delete();
       }
     } else if (file is Directory) {
-      var copyFromDir = Directory(copyFrom);
+      final copyFromDir = Directory(copyFrom);
       await _removeDeleted(copyFromDir.path, file.path);
     } else if (file is Link) {
-      var copyFromDir = Link(copyFrom);
+      final copyFromDir = Link(copyFrom);
       if (!copyFromDir.existsSync()) {
         await Link(file.path).delete();
       }

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -198,7 +198,7 @@ class WebDevServer {
     final tlsCertKey = options.configuration.tlsCertKey ?? '';
 
     HttpServer server;
-    var protocol =
+    final protocol =
         (tlsCertChain.isNotEmpty && tlsCertKey.isNotEmpty) ? 'https' : 'http';
     if (protocol == 'https') {
       final serverContext = SecurityContext()

--- a/webdev/lib/src/util.dart
+++ b/webdev/lib/src/util.dart
@@ -27,7 +27,7 @@ void serveHttpRequests(Stream<HttpRequest> requests, Handler handler,
 final String _sdkDir = (() {
   // The Dart executable is in "/path/to/sdk/bin/dart", so two levels up is
   // "/path/to/sdk".
-  var aboveExecutable = p.dirname(p.dirname(Platform.resolvedExecutable));
+  final aboveExecutable = p.dirname(p.dirname(Platform.resolvedExecutable));
   assert(FileSystemEntity.isFileSync(p.join(aboveExecutable, 'version')));
   return aboveExecutable;
 })();

--- a/webdev/test/build/min_sdk_test.dart
+++ b/webdev/test/build/min_sdk_test.dart
@@ -14,12 +14,12 @@ import 'package:test/test.dart';
 
 void main() {
   test('webdev pubspec has the stable as min SDK constraint', () {
-    var pubspec = Pubspec.parse(File('pubspec.yaml').readAsStringSync());
+    final pubspec = Pubspec.parse(File('pubspec.yaml').readAsStringSync());
     var sdkVersion = Version.parse(Platform.version.split(' ')[0]);
     sdkVersion = Version(sdkVersion.major, sdkVersion.minor, 0);
 
-    var sdkConstraint = VersionConstraint.compatibleWith(sdkVersion);
-    var pubspecSdkConstraint = pubspec.environment!['sdk']!;
+    final sdkConstraint = VersionConstraint.compatibleWith(sdkVersion);
+    final pubspecSdkConstraint = pubspec.environment!['sdk']!;
     expect(sdkConstraint.allowsAll(pubspecSdkConstraint), true,
         reason:
             'Min sdk constraint is outdated. Please update SDK constraint in '

--- a/webdev/test/chrome_test.dart
+++ b/webdev/test/chrome_test.dart
@@ -29,7 +29,8 @@ void main() {
       chrome!.chromeConnection.getUrl(_closeTabUrl(tab.id));
 
   Future<WipConnection> connectToTab(String url) async {
-    var tab = await chrome!.chromeConnection.getTab((t) => t.url.contains(url),
+    final tab = await chrome!.chromeConnection.getTab(
+        (t) => t.url.contains(url),
         retryFor: const Duration(milliseconds: 60));
     expect(tab, isNotNull);
     return tab!.connect();
@@ -37,7 +38,7 @@ void main() {
 
   group('chrome with temp data dir', () {
     tearDown(() async {
-      var tabs = await chrome?.chromeConnection.getTabs();
+      final tabs = await chrome?.chromeConnection.getTabs();
       if (tabs != null) {
         for (var tab in tabs) {
           await closeTab(tab);
@@ -54,7 +55,7 @@ void main() {
 
     test('has a working debugger', () async {
       await launchChrome();
-      var tabs = await chrome!.chromeConnection.getTabs();
+      final tabs = await chrome!.chromeConnection.getTabs();
       expect(
           tabs,
           contains(const TypeMatcher<ChromeTab>()
@@ -70,8 +71,8 @@ void main() {
       await launchChrome();
       await openTab(_chromeVersionUrl);
 
-      var wipConnection = await connectToTab(_chromeVersionUrl);
-      var result = await _evaluateExpression(wipConnection.page,
+      final wipConnection = await connectToTab(_chromeVersionUrl);
+      final result = await _evaluateExpression(wipConnection.page,
           "document.getElementById('profile_path').textContent");
 
       if (Platform.isWindows) {
@@ -105,7 +106,7 @@ void main() {
     });
 
     tearDown(() async {
-      var tabs = await chrome?.chromeConnection.getTabs();
+      final tabs = await chrome?.chromeConnection.getTabs();
       if (tabs != null) {
         for (var tab in tabs) {
           await closeTab(tab);
@@ -133,7 +134,7 @@ void main() {
     test('has a working debugger', () async {
       await launchChrome(userDataDir: dataDir.path);
 
-      var tabs = await chrome!.chromeConnection.getTabs();
+      final tabs = await chrome!.chromeConnection.getTabs();
       expect(
           tabs,
           contains(const TypeMatcher<ChromeTab>()
@@ -144,8 +145,8 @@ void main() {
       await launchChrome(userDataDir: dataDir.path);
       await openTab(_chromeVersionUrl);
 
-      var wipConnection = await connectToTab(_chromeVersionUrl);
-      var result = await _evaluateExpression(wipConnection.page,
+      final wipConnection = await connectToTab(_chromeVersionUrl);
+      final result = await _evaluateExpression(wipConnection.page,
           "document.getElementById('profile_path').textContent");
 
       if (Platform.isWindows) {
@@ -158,7 +159,7 @@ void main() {
     }, skip: 'https://github.com/dart-lang/webdev/issues/2030');
 
     test('can auto detect default chrome directory', () async {
-      var userDataDir = autoDetectChromeUserDataDirectory();
+      final userDataDir = autoDetectChromeUserDataDirectory();
       expect(userDataDir, isNotNull);
 
       expect(Directory(userDataDir!).existsSync(), isTrue);
@@ -166,8 +167,8 @@ void main() {
       await launchChrome(userDataDir: userDataDir);
       await openTab(_chromeVersionUrl);
 
-      var wipConnection = await connectToTab(_chromeVersionUrl);
-      var result = await _evaluateExpression(wipConnection.page,
+      final wipConnection = await connectToTab(_chromeVersionUrl);
+      final result = await _evaluateExpression(wipConnection.page,
           "document.getElementById('profile_path').textContent");
 
       expect(result, contains('chrome_user_data_copy'));
@@ -176,7 +177,7 @@ void main() {
     }, skip: 'https://github.com/dart-lang/webdev/issues/2030');
 
     test('cannot auto detect default chrome directory on windows', () async {
-      var userDataDir = autoDetectChromeUserDataDirectory();
+      final userDataDir = autoDetectChromeUserDataDirectory();
       expect(userDataDir, isNull);
     }, onPlatform: {
       'linux': const Skip('https://github.com/dart-lang/webdev/issues/1545'),
@@ -192,7 +193,7 @@ Future<String> _evaluateExpression(WipPage page, String expression) async {
   String? result = '';
   while (result == null || result.isEmpty) {
     await Future.delayed(const Duration(milliseconds: 100));
-    var wipResponse = await page.sendCommand(
+    final wipResponse = await page.sendCommand(
       'Runtime.evaluate',
       params: {'expression': expression},
     );

--- a/webdev/test/chrome_test.dart
+++ b/webdev/test/chrome_test.dart
@@ -40,7 +40,7 @@ void main() {
     tearDown(() async {
       final tabs = await chrome?.chromeConnection.getTabs();
       if (tabs != null) {
-        for (var tab in tabs) {
+        for (final tab in tabs) {
           await closeTab(tab);
         }
       }
@@ -108,7 +108,7 @@ void main() {
     tearDown(() async {
       final tabs = await chrome?.chromeConnection.getTabs();
       if (tabs != null) {
-        for (var tab in tabs) {
+        for (final tab in tabs) {
           await closeTab(tab);
         }
       }

--- a/webdev/test/configuration_test.dart
+++ b/webdev/test/configuration_test.dart
@@ -17,15 +17,15 @@ void main() {
   });
 
   test('default configuration is correctly applied', () {
-    var configuration = Configuration.fromArgs(null);
+    final configuration = Configuration.fromArgs(null);
     expect(configuration.hostname, equals('localhost'));
   });
 
   test('arg configuration takes precedence to default configuration', () {
-    var defaultConfiguration = Configuration.fromArgs(null);
+    final defaultConfiguration = Configuration.fromArgs(null);
     expect(defaultConfiguration.release, isFalse);
-    var argResults = argParser.parse(['--release']);
-    var argConfiguration = Configuration.fromArgs(argResults);
+    final argResults = argParser.parse(['--release']);
+    final argConfiguration = Configuration.fromArgs(argResults);
     expect(argConfiguration.release, isTrue);
   });
 
@@ -42,26 +42,26 @@ void main() {
   });
 
   test('user data directory defaults to null ', () {
-    var argResults = argParser.parse(['']);
-    var defaultConfiguration = Configuration.fromArgs(argResults);
+    final argResults = argParser.parse(['']);
+    final defaultConfiguration = Configuration.fromArgs(argResults);
     expect(defaultConfiguration.userDataDir, isNull);
   });
 
   test('can read user data dir from args ', () {
-    var argResults =
+    final argResults =
         argParser.parse(['--launch-in-chrome', '--user-data-dir=tempdir']);
-    var configuration = Configuration.fromArgs(argResults);
+    final configuration = Configuration.fromArgs(argResults);
     expect(configuration.userDataDir, equals('tempdir'));
   });
 
   test('can set user data directory with launchInChrome ', () {
-    var configuration =
+    final configuration =
         Configuration(launchInChrome: true, userDataDir: 'temp');
     expect(configuration.userDataDir, equals('temp'));
   });
 
   test('can set user data directory to auto with launchInChrome ', () {
-    var configuration =
+    final configuration =
         Configuration(launchInChrome: true, userDataDir: 'auto');
     expect(configuration.userDataDir, equals('auto'));
   });
@@ -72,8 +72,8 @@ void main() {
   });
 
   test('nullSafety defaults to auto', () {
-    var argResults = argParser.parse(['']);
-    var defaultConfiguration = Configuration.fromArgs(argResults);
+    final argResults = argParser.parse(['']);
+    final defaultConfiguration = Configuration.fromArgs(argResults);
     expect(defaultConfiguration.nullSafety, equals(nullSafetyAuto));
   });
 

--- a/webdev/test/daemon/app_domain_test.dart
+++ b/webdev/test/daemon/app_domain_test.dart
@@ -27,7 +27,7 @@ void main() {
   group('AppDomain', () {
     group('Events', () {
       test('.start', () async {
-        var webdev = await testRunner
+        final webdev = await testRunner
             .runWebDev(['daemon'], workingDirectory: exampleDirectory);
         await expectLater(
             webdev.stdout, emitsThrough(startsWith('[{"event":"app.start"')));
@@ -35,7 +35,7 @@ void main() {
       });
 
       test('.started', () async {
-        var webdev = await testRunner
+        final webdev = await testRunner
             .runWebDev(['daemon'], workingDirectory: exampleDirectory);
         await expectLater(
             webdev.stdout, emitsThrough(startsWith('[{"event":"app.started"')));
@@ -43,7 +43,7 @@ void main() {
       });
 
       test('.debugPort', () async {
-        var webdev = await testRunner
+        final webdev = await testRunner
             .runWebDev(['daemon'], workingDirectory: exampleDirectory);
         await expectLater(webdev.stdout,
             emitsThrough(startsWith('[{"event":"app.debugPort"')));
@@ -51,9 +51,9 @@ void main() {
       });
 
       test('.log', () async {
-        var webdev = await testRunner
+        final webdev = await testRunner
             .runWebDev(['daemon'], workingDirectory: exampleDirectory);
-        var appId = await waitForAppId(webdev);
+        final appId = await waitForAppId(webdev);
         // The example app does an initial print.
         await expectLater(
             webdev.stdout,
@@ -68,15 +68,15 @@ void main() {
       test(
         '.callServiceExtension',
         () async {
-          var webdev = await testRunner
+          final webdev = await testRunner
               .runWebDev(['daemon'], workingDirectory: exampleDirectory);
-          var appId = await waitForAppId(webdev);
+          final appId = await waitForAppId(webdev);
           if (Platform.isWindows) {
             // Windows takes a bit longer to run the application and register
             // the service extension.
             await Future.delayed(const Duration(seconds: 5));
           }
-          var extensionCall = '[{"method":"app.callServiceExtension","id":0,'
+          final extensionCall = '[{"method":"app.callServiceExtension","id":0,'
               '"params" : { "appId" : "$appId", "methodName" : "ext.print"}}]';
           webdev.stdin.add(utf8.encode('$extensionCall\n'));
           // The example app sets up a service extension for printing.
@@ -95,10 +95,10 @@ void main() {
       test(
         '.reload',
         () async {
-          var webdev = await testRunner
+          final webdev = await testRunner
               .runWebDev(['daemon'], workingDirectory: exampleDirectory);
-          var appId = await waitForAppId(webdev);
-          var extensionCall = '[{"method":"app.restart","id":0,'
+          final appId = await waitForAppId(webdev);
+          final extensionCall = '[{"method":"app.restart","id":0,'
               '"params" : { "appId" : "$appId", "fullRestart" : false}}]';
           webdev.stdin.add(utf8.encode('$extensionCall\n'));
           await expectLater(
@@ -117,10 +117,10 @@ void main() {
       test(
         '.restart',
         () async {
-          var webdev = await testRunner
+          final webdev = await testRunner
               .runWebDev(['daemon'], workingDirectory: exampleDirectory);
-          var appId = await waitForAppId(webdev);
-          var extensionCall = '[{"method":"app.restart","id":0,'
+          final appId = await waitForAppId(webdev);
+          final extensionCall = '[{"method":"app.restart","id":0,'
               '"params" : { "appId" : "$appId", "fullRestart" : true}}]';
           webdev.stdin.add(utf8.encode('$extensionCall\n'));
           await expectLater(
@@ -143,10 +143,10 @@ void main() {
       test(
         '.stop',
         () async {
-          var webdev = await testRunner
+          final webdev = await testRunner
               .runWebDev(['daemon'], workingDirectory: exampleDirectory);
-          var appId = await waitForAppId(webdev);
-          var stopCall = '[{"method":"app.stop","id":0,'
+          final appId = await waitForAppId(webdev);
+          final stopCall = '[{"method":"app.stop","id":0,'
               '"params" : { "appId" : "$appId"}}]';
           webdev.stdin.add(utf8.encode('$stopCall\n'));
           await expectLater(

--- a/webdev/test/daemon/daemon_domain_test.dart
+++ b/webdev/test/daemon/daemon_domain_test.dart
@@ -26,7 +26,7 @@ void main() {
   group('Daemon', () {
     group('Events', () {
       test('.connected', () async {
-        var webdev = await testRunner
+        final webdev = await testRunner
             .runWebDev(['daemon'], workingDirectory: exampleDirectory);
         await expectLater(
             webdev.stdout, emits(startsWith('[{"event":"daemon.connected"')));
@@ -36,7 +36,7 @@ void main() {
 
     group('Methods', () {
       test('.version', () async {
-        var webdev = await testRunner
+        final webdev = await testRunner
             .runWebDev(['daemon'], workingDirectory: exampleDirectory);
         webdev.stdin.add(utf8.encode('[{"method":"daemon.version","id":0}]\n'));
         await expectLater(
@@ -45,7 +45,7 @@ void main() {
       });
 
       test('.shutdown', () async {
-        var webdev = await testRunner
+        final webdev = await testRunner
             .runWebDev(['daemon'], workingDirectory: exampleDirectory);
         webdev.stdin
             .add(utf8.encode('[{"method":"daemon.shutdown","id":0}]\n'));

--- a/webdev/test/daemon/launch_app_test.dart
+++ b/webdev/test/daemon/launch_app_test.dart
@@ -22,10 +22,10 @@ void main() {
   tearDownAll(testRunner.tearDownAll);
 
   test('--launch-app launches the specified app', () async {
-    var webdev = await testRunner.runWebDev(
+    final webdev = await testRunner.runWebDev(
         ['daemon', '--launch-app=web/scopes.html'],
         workingDirectory: exampleDirectory);
-    var appId = await waitForAppId(webdev);
+    final appId = await waitForAppId(webdev);
 
     // The example app does an initial print.
     await expectLater(

--- a/webdev/test/daemon/utils.dart
+++ b/webdev/test/daemon/utils.dart
@@ -24,7 +24,7 @@ Future<String> waitForAppId(TestProcess webdev) async {
     var line = await webdev.stdout.next;
     if (line.startsWith('[{"event":"app.started"')) {
       line = line.substring(1, line.length - 1);
-      var message = json.decode(line) as Map<String, dynamic>;
+      final message = json.decode(line) as Map<String, dynamic>;
       appId = message['params']['appId'] as String;
       break;
     }
@@ -34,10 +34,10 @@ Future<String> waitForAppId(TestProcess webdev) async {
 }
 
 String? getDebugServiceUri(String line) {
-  var regex = RegExp(r'Debug service listening on (?<wsUri>[^\s^\\]*)');
-  var match = regex.firstMatch(line);
+  final regex = RegExp(r'Debug service listening on (?<wsUri>[^\s^\\]*)');
+  final match = regex.firstMatch(line);
   if (match != null) {
-    var wsUri = match.namedGroup('wsUri');
+    final wsUri = match.namedGroup('wsUri');
     return wsUri;
   }
   return null;
@@ -45,9 +45,9 @@ String? getDebugServiceUri(String line) {
 
 Future<int> findBreakpointLine(VmService vmService, String breakpointId,
     String isolateId, ScriptRef scriptRef) async {
-  var script = await vmService.getObject(isolateId, scriptRef.id!) as Script;
-  var lines = LineSplitter.split(script.source!).toList();
-  var lineNumber =
+  final script = await vmService.getObject(isolateId, scriptRef.id!) as Script;
+  final lines = LineSplitter.split(script.source!).toList();
+  final lineNumber =
       lines.indexWhere((l) => l.endsWith('// Breakpoint: $breakpointId'));
   if (lineNumber == -1) {
     throw StateError('Unable to find breakpoint in ${scriptRef.uri} with id '

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -121,7 +121,7 @@ void main() {
   );
 
   group('should build with valid configuration', () {
-    for (var withDDC in [true, false]) {
+    for (final withDDC in [true, false]) {
       test(
         withDDC ? 'DDC' : 'dart2js',
         () async {
@@ -138,7 +138,7 @@ void main() {
           await checkProcessStdout(process, expectedItems);
           await process.shouldExit(0);
 
-          for (var entry in _testItems.entries) {
+          for (final entry in _testItems.entries) {
             final shouldExist = (entry.value ?? withDDC) == withDDC;
 
             if (shouldExist) {
@@ -179,7 +179,7 @@ void main() {
   });
 
   group('should build with --output=NONE', () {
-    for (var withDDC in [true, false]) {
+    for (final withDDC in [true, false]) {
       test(withDDC ? 'DDC' : 'dart2js', () async {
         final args = ['build', '--output=NONE'];
         if (withDDC) {
@@ -200,7 +200,7 @@ void main() {
   });
 
   group('should serve with valid configuration', () {
-    for (var withDDC in [true, false]) {
+    for (final withDDC in [true, false]) {
       final type = withDDC ? 'DDC' : 'dart2js';
       test('using $type', () async {
         final openPort = await findUnusedPort();
@@ -220,7 +220,7 @@ void main() {
         final client = HttpClient();
 
         try {
-          for (var entry in _testItems.entries) {
+          for (final entry in _testItems.entries) {
             final url = Uri.parse('$hostUrl/${entry.key}');
 
             final request = await client.getUrl(url);
@@ -243,8 +243,8 @@ void main() {
 
   group('Should fail with invalid build directories', () {
     final invalidServeDirs = ['.', '../', '../foo', 'foo/bar', 'foo/../'];
-    for (var dir in invalidServeDirs) {
-      for (var command in ['build', 'serve']) {
+    for (final dir in invalidServeDirs) {
+      for (final command in ['build', 'serve']) {
         test('cannot $command directory: `$dir`', () async {
           final args = [
             command,

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -47,7 +47,7 @@ void main() {
     soundExampleDirectory =
         p.absolute(p.join(p.current, '..', 'fixtures', '_webdevSoundSmoke'));
 
-    var process = await TestProcess.start(dartPath, ['pub', 'upgrade'],
+    final process = await TestProcess.start(dartPath, ['pub', 'upgrade'],
         workingDirectory: soundExampleDirectory,
         environment: getPubEnvironment());
 
@@ -62,10 +62,10 @@ void main() {
   tearDownAll(testRunner.tearDownAll);
 
   test('smoke test is configured properly', () async {
-    var smokeYaml = loadYaml(
+    final smokeYaml = loadYaml(
             await File('$soundExampleDirectory/pubspec.yaml').readAsString())
         as YamlMap;
-    var webdevYaml =
+    final webdevYaml =
         loadYaml(await File('pubspec.yaml').readAsString()) as YamlMap;
     expect(smokeYaml['environment']['sdk'],
         equals(webdevYaml['environment']['sdk']));
@@ -78,9 +78,9 @@ void main() {
   test('build should fail if targeting an existing directory', () async {
     await d.file('simple thing', 'throw-away').create();
 
-    var args = ['build', '-o', 'web:${d.sandbox}'];
+    final args = ['build', '-o', 'web:${d.sandbox}'];
 
-    var process = await testRunner.runWebDev(args,
+    final process = await testRunner.runWebDev(args,
         workingDirectory: soundExampleDirectory);
 
     // NOTE: We'd like this to be more useful
@@ -102,7 +102,7 @@ void main() {
   test(
     'build should allow passing extra arguments to build_runner',
     () async {
-      var args = [
+      final args = [
         'build',
         '-o',
         'web:${d.sandbox}',
@@ -110,7 +110,7 @@ void main() {
         '--delete-conflicting-outputs'
       ];
 
-      var process = await testRunner.runWebDev(args,
+      final process = await testRunner.runWebDev(args,
           workingDirectory: soundExampleDirectory);
 
       await checkProcessStdout(process, ['Succeeded']);
@@ -125,21 +125,21 @@ void main() {
       test(
         withDDC ? 'DDC' : 'dart2js',
         () async {
-          var args = ['build', '-o', 'web:${d.sandbox}'];
+          final args = ['build', '-o', 'web:${d.sandbox}'];
           if (withDDC) {
             args.add('--no-release');
           }
 
-          var process = await testRunner.runWebDev(args,
+          final process = await testRunner.runWebDev(args,
               workingDirectory: soundExampleDirectory);
 
-          var expectedItems = <Object>['Succeeded'];
+          final expectedItems = <Object>['Succeeded'];
 
           await checkProcessStdout(process, expectedItems);
           await process.shouldExit(0);
 
           for (var entry in _testItems.entries) {
-            var shouldExist = (entry.value ?? withDDC) == withDDC;
+            final shouldExist = (entry.value ?? withDDC) == withDDC;
 
             if (shouldExist) {
               await d.file(entry.key, isNotEmpty).validate();
@@ -155,7 +155,7 @@ void main() {
     test(
       'and --null-safety=sound',
       () async {
-        var args = [
+        final args = [
           'build',
           '-o',
           'web:${d.sandbox}',
@@ -163,10 +163,10 @@ void main() {
           '--null-safety=sound'
         ];
 
-        var process = await testRunner.runWebDev(args,
+        final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
 
-        var expectedItems = <Object>['Succeeded'];
+        final expectedItems = <Object>['Succeeded'];
 
         await checkProcessStdout(process, expectedItems);
         await process.shouldExit(0);
@@ -181,15 +181,15 @@ void main() {
   group('should build with --output=NONE', () {
     for (var withDDC in [true, false]) {
       test(withDDC ? 'DDC' : 'dart2js', () async {
-        var args = ['build', '--output=NONE'];
+        final args = ['build', '--output=NONE'];
         if (withDDC) {
           args.add('--no-release');
         }
 
-        var process = await testRunner.runWebDev(args,
+        final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
 
-        var expectedItems = <Object>['Succeeded'];
+        final expectedItems = <Object>['Succeeded'];
 
         await checkProcessStdout(process, expectedItems);
         await process.shouldExit(0);
@@ -201,32 +201,32 @@ void main() {
 
   group('should serve with valid configuration', () {
     for (var withDDC in [true, false]) {
-      var type = withDDC ? 'DDC' : 'dart2js';
+      final type = withDDC ? 'DDC' : 'dart2js';
       test('using $type', () async {
-        var openPort = await findUnusedPort();
-        var args = ['serve', 'web:$openPort'];
+        final openPort = await findUnusedPort();
+        final args = ['serve', 'web:$openPort'];
         if (!withDDC) {
           args.add('--release');
         }
 
-        var process = await testRunner.runWebDev(args,
+        final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
 
-        var hostUrl = 'http://localhost:$openPort';
+        final hostUrl = 'http://localhost:$openPort';
 
         // Wait for the initial build to finish.
         await expectLater(process.stdout, emitsThrough(contains('Succeeded')));
 
-        var client = HttpClient();
+        final client = HttpClient();
 
         try {
           for (var entry in _testItems.entries) {
-            var url = Uri.parse('$hostUrl/${entry.key}');
+            final url = Uri.parse('$hostUrl/${entry.key}');
 
-            var request = await client.getUrl(url);
-            var response = await request.close();
+            final request = await client.getUrl(url);
+            final response = await request.close();
 
-            var shouldExist = (entry.value ?? withDDC) == withDDC;
+            final shouldExist = (entry.value ?? withDDC) == withDDC;
 
             expect(response.statusCode, shouldExist ? 200 : 404,
                 reason: 'Expecting "$url"? $shouldExist');
@@ -242,16 +242,16 @@ void main() {
   });
 
   group('Should fail with invalid build directories', () {
-    var invalidServeDirs = ['.', '../', '../foo', 'foo/bar', 'foo/../'];
+    final invalidServeDirs = ['.', '../', '../foo', 'foo/bar', 'foo/../'];
     for (var dir in invalidServeDirs) {
       for (var command in ['build', 'serve']) {
         test('cannot $command directory: `$dir`', () async {
-          var args = [
+          final args = [
             command,
             if (command == 'build') '--output=$dir:foo' else dir
           ];
 
-          var process = await testRunner.runWebDev(args,
+          final process = await testRunner.runWebDev(args,
               workingDirectory: soundExampleDirectory);
           await expectLater(
               process.stdout,
@@ -273,16 +273,16 @@ void main() {
         configureLogWriter(debug);
       });
       test('evaluateInFrame', () async {
-        var openPort = await findUnusedPort();
+        final openPort = await findUnusedPort();
         // running daemon command that starts dwds without keyboard input
-        var args = [
+        final args = [
           'daemon',
           'web:$openPort',
           '--enable-expression-evaluation',
           '--null-safety=sound',
           '--verbose',
         ];
-        var process = await testRunner.runWebDev(args,
+        final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
         VmService? vmService;
 
@@ -300,20 +300,20 @@ void main() {
           expect(wsUri, isNotNull);
 
           vmService = await vmServiceConnectUri(wsUri!);
-          var vm = await vmService.getVM();
-          var isolateId = vm.isolates!.first.id!;
-          var scripts = await vmService.getScripts(isolateId);
+          final vm = await vmService.getVM();
+          final isolateId = vm.isolates!.first.id!;
+          final scripts = await vmService.getScripts(isolateId);
 
           await vmService.streamListen('Debug');
-          var stream = vmService.onEvent('Debug');
+          final stream = vmService.onEvent('Debug');
 
-          var mainScript = scripts.scripts!
+          final mainScript = scripts.scripts!
               .firstWhere((each) => each.uri!.contains('main.dart'));
 
-          var bpLine = await findBreakpointLine(
+          final bpLine = await findBreakpointLine(
               vmService, 'printCounter', isolateId, mainScript);
 
-          var bp = await vmService.addBreakpointWithScriptUri(
+          final bp = await vmService.addBreakpointWithScriptUri(
               isolateId, mainScript.uri!, bpLine);
           expect(bp, isNotNull);
 
@@ -339,15 +339,15 @@ void main() {
       }, timeout: const Timeout.factor(2));
 
       test('evaluate', () async {
-        var openPort = await findUnusedPort();
+        final openPort = await findUnusedPort();
         // running daemon command that starts dwds without keyboard input
-        var args = [
+        final args = [
           'daemon',
           'web:$openPort',
           '--enable-expression-evaluation',
           '--verbose',
         ];
-        var process = await testRunner.runWebDev(args,
+        final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
 
         process.stdoutStream().listen(Logger.root.fine);
@@ -365,10 +365,10 @@ void main() {
           expect(wsUri, isNotNull);
 
           vmService = await vmServiceConnectUri(wsUri!);
-          var vm = await vmService.getVM();
-          var isolateId = vm.isolates!.first.id!;
-          var isolate = await vmService.getIsolate(isolateId);
-          var libraryId = isolate.rootLib!.id!;
+          final vm = await vmService.getVM();
+          final isolateId = vm.isolates!.first.id!;
+          final isolate = await vmService.getIsolate(isolateId);
+          final libraryId = isolate.rootLib!.id!;
 
           await vmService.streamListen('Debug');
 
@@ -399,15 +399,15 @@ void main() {
       }, timeout: const Timeout.factor(2));
 
       test('evaluate and get objects', () async {
-        var openPort = await findUnusedPort();
+        final openPort = await findUnusedPort();
         // running daemon command that starts dwds without keyboard input
-        var args = [
+        final args = [
           'daemon',
           'web:$openPort',
           '--enable-expression-evaluation',
           '--verbose',
         ];
-        var process = await testRunner.runWebDev(args,
+        final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
 
         process.stdoutStream().listen(Logger.root.fine);
@@ -425,10 +425,10 @@ void main() {
           expect(wsUri, isNotNull);
 
           vmService = await vmServiceConnectUri(wsUri!);
-          var vm = await vmService.getVM();
-          var isolateId = vm.isolates!.first.id!;
-          var isolate = await vmService.getIsolate(isolateId);
-          var libraryId = isolate.rootLib!.id!;
+          final vm = await vmService.getVM();
+          final isolateId = vm.isolates!.first.id!;
+          final isolate = await vmService.getIsolate(isolateId);
+          final libraryId = isolate.rootLib!.id!;
 
           await vmService.streamListen('Debug');
 
@@ -471,14 +471,14 @@ void main() {
 
     group('and --no-enable-expression-evaluation:', () {
       test('evaluateInFrame', () async {
-        var openPort = await findUnusedPort();
-        var args = [
+        final openPort = await findUnusedPort();
+        final args = [
           'daemon',
           'web:$openPort',
           '--no-enable-expression-evaluation',
           '--verbose',
         ];
-        var process = await testRunner.runWebDev(args,
+        final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
         VmService? vmService;
 
@@ -492,24 +492,24 @@ void main() {
           expect(wsUri, isNotNull);
 
           vmService = await vmServiceConnectUri(wsUri!);
-          var vm = await vmService.getVM();
-          var isolateId = vm.isolates!.first.id!;
-          var scripts = await vmService.getScripts(isolateId);
+          final vm = await vmService.getVM();
+          final isolateId = vm.isolates!.first.id!;
+          final scripts = await vmService.getScripts(isolateId);
 
           await vmService.streamListen('Debug');
-          var stream = vmService.onEvent('Debug');
+          final stream = vmService.onEvent('Debug');
 
-          var mainScript = scripts.scripts!
+          final mainScript = scripts.scripts!
               .firstWhere((each) => each.uri!.contains('main.dart'));
 
-          var bpLine = await findBreakpointLine(
+          final bpLine = await findBreakpointLine(
               vmService, 'printCounter', isolateId, mainScript);
 
-          var bp = await vmService.addBreakpointWithScriptUri(
+          final bp = await vmService.addBreakpointWithScriptUri(
               isolateId, mainScript.uri!, bpLine);
           expect(bp, isNotNull);
 
-          var event = await stream.firstWhere(
+          final event = await stream.firstWhere(
               (Event event) => event.kind == EventKind.kPauseBreakpoint);
 
           expect(
@@ -524,15 +524,15 @@ void main() {
       });
 
       test('evaluate', () async {
-        var openPort = await findUnusedPort();
+        final openPort = await findUnusedPort();
         // running daemon command that starts dwds without keyboard input
-        var args = [
+        final args = [
           'daemon',
           'web:$openPort',
           '--no-enable-expression-evaluation',
           '--verbose',
         ];
-        var process = await testRunner.runWebDev(args,
+        final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
         VmService? vmService;
 
@@ -546,10 +546,10 @@ void main() {
           expect(wsUri, isNotNull);
 
           vmService = await vmServiceConnectUri(wsUri!);
-          var vm = await vmService.getVM();
-          var isolateId = vm.isolates!.first.id!;
-          var isolate = await vmService.getIsolate(isolateId);
-          var libraryId = isolate.rootLib!.id!;
+          final vm = await vmService.getVM();
+          final isolateId = vm.isolates!.first.id!;
+          final isolate = await vmService.getIsolate(isolateId);
+          final libraryId = isolate.rootLib!.id!;
 
           await vmService.streamListen('Debug');
 

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -15,7 +15,7 @@ void main() {
   tearDownAll(testRunner.tearDownAll);
 
   test('non-existent commands create errors', () async {
-    var process = await testRunner.runWebDev(['monkey']);
+    final process = await testRunner.runWebDev(['monkey']);
 
     await expectLater(
         process.stdout, emits('Could not find a command named "monkey".'));
@@ -24,7 +24,7 @@ void main() {
   });
 
   test('passing extra args to build fails with bad usage', () async {
-    var process = await testRunner.runWebDev(['build', 'extra', 'args']);
+    final process = await testRunner.runWebDev(['build', 'extra', 'args']);
 
     await expectLater(process.stdout,
         emits('Arguments were provided that are not supported: "extra args".'));
@@ -48,17 +48,17 @@ void main() {
     await d.dir('.dart_tool', [d.file('package_config.json', '')]).create();
     await d.file('.dart_tool/package_config.json', '').create();
 
-    var process =
+    final process =
         await testRunner.runWebDev(['serve'], workingDirectory: d.sandbox);
 
-    var output = await process.stdout.rest.toList();
+    final output = await process.stdout.rest.toList();
 
     expect(output, isNot(contains(contains('`build_daemon`'))));
 
     await process.shouldExit(78);
   });
 
-  var invalidRanges = <String, List<String>>{
+  final invalidRanges = <String, List<String>>{
     'build_runner': ['0.8.9', '3.0.0'],
     'build_web_compilers': ['0.3.5', '5.0.0'],
     'build_daemon': ['0.3.0', '5.0.0'],
@@ -78,7 +78,7 @@ void main() {
               .dir('.dart_tool', [d.file('package_config.json', '')]).create();
           await d.file('.dart_tool/package_config.json', '').create();
 
-          var process = await testRunner
+          final process = await testRunner
               .runWebDev([command], workingDirectory: d.sandbox);
 
           await checkProcessStdout(process, ['webdev could not run']);
@@ -96,7 +96,7 @@ void main() {
               .dir('.dart_tool', [d.file('package_config.json', '')]).create();
           await d.file('.dart_tool/package_config.json', '').create();
 
-          var process = await testRunner
+          final process = await testRunner
               .runWebDev(['serve'], workingDirectory: d.sandbox);
 
           await checkProcessStdout(process, ['webdev could not run']);
@@ -119,7 +119,7 @@ void main() {
           // Required for webdev to not complain about nothing to serve.
           await d.dir('web').create();
 
-          var process = await testRunner.runWebDev(
+          final process = await testRunner.runWebDev(
               ['serve', '--no-build-web-compilers'],
               workingDirectory: d.sandbox);
 
@@ -161,7 +161,7 @@ void main() {
                   '.dart_tool', [d.file('package_config.json', '')]).create();
               await d.file('.dart_tool/package_config.json', '').create();
 
-              var process = await testRunner
+              final process = await testRunner
                   .runWebDev(['serve'], workingDirectory: d.sandbox);
 
               await checkProcessStdout(process, ['webdev could not run']);
@@ -173,7 +173,7 @@ void main() {
       }
 
       test('no pubspec.yaml', () async {
-        var process =
+        final process =
             await testRunner.runWebDev(['serve'], workingDirectory: d.sandbox);
 
         await checkProcessStdout(process, ['webdev could not run']);
@@ -185,7 +185,7 @@ void main() {
         () async {
           await d.file('pubspec.yaml', _pubspecYaml).create();
 
-          var process = await testRunner
+          final process = await testRunner
               .runWebDev(['serve'], workingDirectory: d.sandbox);
 
           await checkProcessStdout(process, ['webdev could not run']);
@@ -208,7 +208,7 @@ dependencies:
   args: ^1.0.0
 ''').create();
 
-        var process =
+        final process =
             await testRunner.runWebDev(['serve'], workingDirectory: d.sandbox);
 
         await checkProcessStdout(process, ['webdev could not run']);
@@ -231,7 +231,7 @@ String _pubspecLock(
     String? webCompilersVersion = _supportedWebCompilersVersion,
     String? daemonVersion = _supportedBuildDaemonVersion,
     List<String> extraPkgs = const []}) {
-  var buffer = StringBuffer('''
+  final buffer = StringBuffer('''
 # Copy-pasted from a valid run
 packages:
 ''');

--- a/webdev/test/integration_test.dart
+++ b/webdev/test/integration_test.dart
@@ -64,7 +64,7 @@ void main() {
     'build_daemon': ['0.3.0', '5.0.0'],
   };
 
-  for (var command in ['build', 'serve', 'daemon']) {
+  for (final command in ['build', 'serve', 'daemon']) {
     group('`$command` command', () {
       group('missing dependency on', () {
         test('`build_runner` should fail', () async {
@@ -127,9 +127,9 @@ void main() {
         });
       });
 
-      for (var entry in invalidRanges.entries) {
+      for (final entry in invalidRanges.entries) {
         group('with package `${entry.key}`', () {
-          for (var version in entry.value) {
+          for (final version in entry.value) {
             test('at invalid version `$version` should fail', () async {
               var buildRunnerVersion = _supportedBuildRunnerVersion;
               var webCompilersVersion = _supportedWebCompilersVersion;
@@ -272,7 +272,7 @@ packages:
 ''');
   }
 
-  for (var pkg in extraPkgs) {
+  for (final pkg in extraPkgs) {
     buffer.writeln('''
   $pkg:
     dependency: "direct"

--- a/webdev/test/readme_test.dart
+++ b/webdev/test/readme_test.dart
@@ -28,8 +28,8 @@ void main() {
 final _readmeContents = File('README.md').readAsStringSync();
 
 Future _readmeCheck(TestRunner testRunner, List<String> args) async {
-  var process = await testRunner.runWebDev(args);
-  var output =
+  final process = await testRunner.runWebDev(args);
+  final output =
       (await process.stdoutStream().map((line) => line.trimRight()).join('\n'))
           .trim();
   await process.shouldExit(0);

--- a/webdev/test/test_utils.dart
+++ b/webdev/test/test_utils.dart
@@ -38,17 +38,17 @@ class TestRunner {
 
   Future<TestProcess> runWebDev(List<String> args,
       {String? workingDirectory}) async {
-    var fullArgs = [_webdevBin, ...args];
+    final fullArgs = [_webdevBin, ...args];
 
     return TestProcess.start(sdkLayout.dartPath, fullArgs,
         workingDirectory: workingDirectory);
   }
 
   Future<String> prepareWorkspace() async {
-    var exampleDirectory =
+    final exampleDirectory =
         p.absolute(p.join(p.current, '..', 'fixtures', '_webdevSoundSmoke'));
 
-    var process = await TestProcess.start(
+    final process = await TestProcess.start(
         sdkLayout.dartPath, ['pub', 'upgrade'],
         workingDirectory: exampleDirectory, environment: getPubEnvironment());
 
@@ -72,14 +72,14 @@ Future checkProcessStdout(TestProcess process, List items) async {
 /// Maintains any existing values for this environment var.
 /// Adds a new value that flags this is a bot/test and not human usage.
 Map<String, String> getPubEnvironment() {
-  var pubEnvironmentKey = 'PUB_ENVIRONMENT';
+  final pubEnvironmentKey = 'PUB_ENVIRONMENT';
   var pubEnvironment = Platform.environment[pubEnvironmentKey] ?? '';
   if (pubEnvironment.isNotEmpty) {
     pubEnvironment = '$pubEnvironment;';
   }
   pubEnvironment = '${pubEnvironment}bot.pkg.webdev.test';
 
-  var environment = {'PUB_ENVIRONMENT': pubEnvironment};
+  final environment = {'PUB_ENVIRONMENT': pubEnvironment};
 
   return environment;
 }

--- a/webdev/test/utils_test.dart
+++ b/webdev/test/utils_test.dart
@@ -27,8 +27,8 @@ void main() {
   });
 
   test('updatePath does nothing for non-existing directories', () async {
-    var subDirFrom = Directory(p.join(from.path, '1'));
-    var subDirTo = Directory(p.join(to.path, '2'));
+    final subDirFrom = Directory(p.join(from.path, '1'));
+    final subDirTo = Directory(p.join(to.path, '2'));
 
     expect(subDirFrom.existsSync(), isFalse);
     expect(subDirTo.existsSync(), isFalse);
@@ -40,8 +40,8 @@ void main() {
   });
 
   test('updatePath creates non-existing directories', () async {
-    var subDirFrom = Directory(p.join(from.path, '1'));
-    var subDirTo = Directory(p.join(to.path, '2'));
+    final subDirFrom = Directory(p.join(from.path, '1'));
+    final subDirTo = Directory(p.join(to.path, '2'));
 
     subDirFrom.createSync();
 
@@ -55,8 +55,8 @@ void main() {
   });
 
   test('updatePath removes stale directories', () async {
-    var subDirFrom = Directory(p.join(from.path, '1'));
-    var subDirTo = Directory(p.join(to.path, '2'));
+    final subDirFrom = Directory(p.join(from.path, '1'));
+    final subDirTo = Directory(p.join(to.path, '2'));
 
     subDirTo.createSync();
 
@@ -70,72 +70,72 @@ void main() {
   });
 
   test('updatePath updates directories', () async {
-    var subDirFrom = Directory(p.join(from.path, '1'));
-    var subDirTo = Directory(p.join(to.path, '2'));
+    final subDirFrom = Directory(p.join(from.path, '1'));
+    final subDirTo = Directory(p.join(to.path, '2'));
 
     subDirFrom.createSync();
     subDirTo.createSync();
 
-    var listFrom =
+    final listFrom =
         from.listSync().map((e) => p.relative(e.path, from: from.path));
     await updatePath(from.path, to.path);
 
-    var listTo = to.listSync().map((e) => p.relative(e.path, from: to.path));
+    final listTo = to.listSync().map((e) => p.relative(e.path, from: to.path));
     expect(listFrom, listTo);
   });
 
   test('updatePath updates files', () async {
-    var fileFrom = File(p.join(from.path, '1'));
-    var fileTo = File(p.join(to.path, '2'));
+    final fileFrom = File(p.join(from.path, '1'));
+    final fileTo = File(p.join(to.path, '2'));
 
     fileFrom.createSync();
     fileTo.createSync();
 
-    var listFrom =
+    final listFrom =
         from.listSync().map((e) => p.relative(e.path, from: from.path));
     await updatePath(from.path, to.path);
 
-    var listTo = to.listSync().map((e) => p.relative(e.path, from: to.path));
+    final listTo = to.listSync().map((e) => p.relative(e.path, from: to.path));
     expect(listFrom, listTo);
   });
 
   test('updatePath updates files and directories', () async {
-    var subDirFrom = Directory(p.join(from.path, '1'));
-    var subDirTo1 = Directory(p.join(to.path, '1'));
-    var subDirTo2 = Directory(p.join(to.path, '2'));
+    final subDirFrom = Directory(p.join(from.path, '1'));
+    final subDirTo1 = Directory(p.join(to.path, '1'));
+    final subDirTo2 = Directory(p.join(to.path, '2'));
 
     subDirFrom.createSync();
     subDirTo1.createSync();
     subDirTo2.createSync();
 
-    var fileFrom = File(p.join(subDirFrom.path, 'a'));
-    var fileTo1 = File(p.join(subDirTo1.path, 'b'));
-    var fileTo2 = File(p.join(subDirTo2.path, 'b'));
+    final fileFrom = File(p.join(subDirFrom.path, 'a'));
+    final fileTo1 = File(p.join(subDirTo1.path, 'b'));
+    final fileTo2 = File(p.join(subDirTo2.path, 'b'));
 
     fileFrom.createSync();
     fileTo1.createSync();
     fileTo2.createSync();
 
-    var listFrom = from
+    final listFrom = from
         .listSync(recursive: true)
         .map((e) => p.relative(e.path, from: from.path));
     await updatePath(from.path, to.path);
 
-    var listTo = to
+    final listTo = to
         .listSync(recursive: true)
         .map((e) => p.relative(e.path, from: to.path));
     expect(listFrom, listTo);
   });
 
   test('updatePath updates stale files', () async {
-    var fileFrom = File(p.join(from.path, '1'));
-    var fileTo = File(p.join(to.path, '1'));
+    final fileFrom = File(p.join(from.path, '1'));
+    final fileTo = File(p.join(to.path, '1'));
 
     fileTo.writeAsStringSync('contentsTo');
     await Future.delayed(const Duration(seconds: 1));
     fileFrom.writeAsStringSync('contentsFrom');
 
-    var stats = fileFrom.statSync();
+    final stats = fileFrom.statSync();
     expect(fileTo.statSync().modified, isNot(equals(stats.modified)));
 
     expect(fileTo.readAsStringSync(), equals('contentsTo'));
@@ -144,14 +144,14 @@ void main() {
   });
 
   test('updatePath does not update newer files', () async {
-    var fileFrom = File(p.join(from.path, '1'));
-    var fileTo = File(p.join(to.path, '1'));
+    final fileFrom = File(p.join(from.path, '1'));
+    final fileTo = File(p.join(to.path, '1'));
 
     fileFrom.writeAsStringSync('contentsFrom');
     await Future.delayed(const Duration(seconds: 1));
     fileTo.writeAsStringSync('contentsTo');
 
-    var stats = fileFrom.statSync();
+    final stats = fileFrom.statSync();
     expect(fileTo.statSync().modified, isNot(equals(stats.modified)));
 
     await updatePath(from.path, to.path);
@@ -160,17 +160,17 @@ void main() {
   });
 
   test('updatePath updates stale files and directories', () async {
-    var subDirFrom = Directory(p.join(from.path, '1'));
-    var subDirTo1 = Directory(p.join(to.path, '1'));
-    var subDirTo2 = Directory(p.join(to.path, '2'));
+    final subDirFrom = Directory(p.join(from.path, '1'));
+    final subDirTo1 = Directory(p.join(to.path, '1'));
+    final subDirTo2 = Directory(p.join(to.path, '2'));
 
     subDirFrom.createSync();
     subDirTo1.createSync();
     subDirTo2.createSync();
 
-    var fileFrom = File(p.join(subDirFrom.path, 'a'));
-    var fileTo1 = File(p.join(subDirTo1.path, 'a'));
-    var fileTo2 = File(p.join(subDirTo2.path, 'b'));
+    final fileFrom = File(p.join(subDirFrom.path, 'a'));
+    final fileTo1 = File(p.join(subDirTo1.path, 'a'));
+    final fileTo2 = File(p.join(subDirTo2.path, 'b'));
 
     fileTo1.writeAsStringSync('contentsTo1');
     fileTo2.writeAsStringSync('contentsTo2');
@@ -184,17 +184,17 @@ void main() {
   });
 
   test('updatePath does not update newer files and directories', () async {
-    var subDirFrom = Directory(p.join(from.path, '1'));
-    var subDirTo1 = Directory(p.join(to.path, '1'));
-    var subDirTo2 = Directory(p.join(to.path, '2'));
+    final subDirFrom = Directory(p.join(from.path, '1'));
+    final subDirTo1 = Directory(p.join(to.path, '1'));
+    final subDirTo2 = Directory(p.join(to.path, '2'));
 
     subDirFrom.createSync();
     subDirTo1.createSync();
     subDirTo2.createSync();
 
-    var fileFrom = File(p.join(subDirFrom.path, 'a'));
-    var fileTo1 = File(p.join(subDirTo1.path, 'a'));
-    var fileTo2 = File(p.join(subDirTo2.path, 'b'));
+    final fileFrom = File(p.join(subDirFrom.path, 'a'));
+    final fileTo1 = File(p.join(subDirTo1.path, 'a'));
+    final fileTo2 = File(p.join(subDirTo2.path, 'b'));
 
     fileFrom.writeAsStringSync('contentsFrom');
     await Future.delayed(const Duration(seconds: 1));


### PR DESCRIPTION
Before this change, only `dwds` was set up to prefer `final`, while the other projects used an inconsistent mix of `var` and `final`. This PR pulls the declaration of `prefer_final_locals` out to the shared `analysis_options.yaml`, adds `prefer_final_in_for_each` as well, and applies the fixes across the repository.

This will help reduce the question of which keyword to use when working in this repository.