### PR TITLE
Add option to not use module name in MetadataProvider

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -5,7 +5,11 @@
 - Replace deprecated JS code `this.__proto__` with `Object.getPrototypeOf(this)`. - [#2500](https://github.com/dart-lang/webdev/pull/2500)
 - Migrate injected client code to `package:web`. - [#2491](https://github.com/dart-lang/webdev/pull/2491)
 - Deprecated MetadataProvider's, CompilerOptions', SdkConfiguration's & SdkLayout's soundNullSafety. - [#2427](https://github.com/dart-lang/webdev/issues/2427)
-- Add load strategy and an unimplemented hot restart strategy for DDC library bundle format.
+- Add load strategy and an unimplemented hot restart strategy for DDC library
+  bundle format.
+- Added `useModuleName` option to `MetadataProvider` to determine whether or not
+  to use the provided `name` in a `ModuleMetadata`. Metadata provided by DDC
+  when using the library bundle format does not provide a useful bundle name.
 
 ## 24.1.0
 

--- a/dwds/lib/src/debugging/metadata/module_metadata.dart
+++ b/dwds/lib/src/debugging/metadata/module_metadata.dart
@@ -101,6 +101,8 @@ class ModuleMetadata {
   ///
   /// Used as a name of the js module created by the compiler and
   /// as key to store and load modules in the debugger and the browser
+  // TODO(srujzs): Remove once https://github.com/dart-lang/sdk/issues/59618 is
+  // resolved.
   final String name;
 
   /// Name of the function enclosing the module

--- a/dwds/lib/src/loaders/ddc.dart
+++ b/dwds/lib/src/loaders/ddc.dart
@@ -164,6 +164,9 @@ class DdcStrategy extends LoadStrategy {
   String get loadModuleSnippet => 'dart_library.import';
 
   @override
+  BuildSettings get buildSettings => _buildSettings;
+
+  @override
   Future<String> bootstrapFor(String entrypoint) async =>
       await _ddcLoaderSetup(entrypoint);
 
@@ -207,9 +210,6 @@ window.\$dartLoader.loader.nextAttempt();
 
   @override
   String? serverPathForAppUri(String appUri) => _serverPathForAppUri(appUri);
-
-  @override
-  BuildSettings get buildSettings => _buildSettings;
 
   @override
   String? g3RelativePath(String absolutePath) => _g3RelativePath(absolutePath);

--- a/dwds/lib/src/loaders/ddc_library_bundle.dart
+++ b/dwds/lib/src/loaders/ddc_library_bundle.dart
@@ -141,6 +141,9 @@ class DdcLibraryBundleStrategy extends LoadStrategy {
       "This is currently unsupported in the DDC library bundle format.'); }";
 
   @override
+  BuildSettings get buildSettings => _buildSettings;
+
+  @override
   Future<String> bootstrapFor(String entrypoint) async =>
       await _ddcLoaderSetup(entrypoint);
 
@@ -186,8 +189,11 @@ window.\$dartLoader.loader.nextAttempt();
   String? serverPathForAppUri(String appUri) => _serverPathForAppUri(appUri);
 
   @override
-  BuildSettings get buildSettings => _buildSettings;
+  String? g3RelativePath(String absolutePath) => _g3RelativePath(absolutePath);
 
   @override
-  String? g3RelativePath(String absolutePath) => _g3RelativePath(absolutePath);
+  MetadataProvider createProvider(String entrypoint, AssetReader reader) =>
+      // DDC library bundle format does not provide module names in the module
+      // metadata.
+      MetadataProvider(entrypoint, reader, useModuleName: false);
 }

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -363,10 +363,10 @@ class FakeStrategy extends LoadStrategy {
   String get loadModuleSnippet => '';
 
   @override
-  String? g3RelativePath(String absolutePath) => null;
+  ReloadConfiguration get reloadConfiguration => ReloadConfiguration.none;
 
   @override
-  ReloadConfiguration get reloadConfiguration => ReloadConfiguration.none;
+  String? g3RelativePath(String absolutePath) => null;
 
   @override
   String loadClientSnippet(String clientScript) => 'dummy-load-client-snippet';
@@ -394,7 +394,7 @@ class FakeStrategy extends LoadStrategy {
 
   @override
   MetadataProvider metadataProviderFor(String entrypoint) =>
-      MetadataProvider(entrypoint, FakeAssetReader());
+      createProvider(entrypoint, FakeAssetReader());
 
   @override
   Future<Map<String, ModuleInfo>> moduleInfoForEntrypoint(String entrypoint) =>


### PR DESCRIPTION
DDC library bundle format does not provide module names as part of the ModuleMetadata.

- To support this discrepancy, a flag is added to MetadataProvider to either use the module name or the module path to identify the module.
- createProvider is added so LoadStrategys can create MetadataProviders based on whether the module format uses the module name.
- Cleans up some getters and methods in LoadStrategy implementations so that getters are grouped together.
