### PR TITLE
Update pattern test to account for new DDC JS variable naming

### DIFF
--- a/dwds/test/instances/common/patterns_inspection_common.dart
+++ b/dwds/test/instances/common/patterns_inspection_common.dart
@@ -98,8 +98,9 @@ void runTests({
 
         expect(await getFrameVariables(frame), {
           'obj': matchListInstance(type: 'Object'),
-          'a': matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
-          'n': matchPrimitiveInstance(kind: InstanceKind.kDouble, value: 3.14),
+          // Renamed to avoid shadowing variables from previous case.
+          'a\$': matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
+          'n\$': matchPrimitiveInstance(kind: InstanceKind.kDouble, value: 3.14),
         });
       });
     });

--- a/dwds/test/instances/common/patterns_inspection_common.dart
+++ b/dwds/test/instances/common/patterns_inspection_common.dart
@@ -5,6 +5,7 @@
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
+import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../fixtures/context.dart';
@@ -96,13 +97,25 @@ void runTests({
       await onBreakPoint('testPatternCase2', (event) async {
         final frame = event.topFrame!;
 
-        expect(await getFrameVariables(frame), {
-          'obj': matchListInstance(type: 'Object'),
-          // Renamed to avoid shadowing variables from previous case.
-          'a\$': matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
-          'n\$':
-              matchPrimitiveInstance(kind: InstanceKind.kDouble, value: 3.14),
-        });
+        if (dartSdkIsAtLeast('3.7.0-246.0.dev')) {
+          expect(await getFrameVariables(frame), {
+            'obj': matchListInstance(type: 'Object'),
+            // Renamed to avoid shadowing variables from previous case.
+            'a\$':
+                matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
+            'n\$':
+                matchPrimitiveInstance(kind: InstanceKind.kDouble, value: 3.14),
+          });
+        } else {
+          expect(await getFrameVariables(frame), {
+            'obj': matchListInstance(type: 'Object'),
+            // Renamed to avoid shadowing variables from previous case.
+            'a':
+                matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
+            'n':
+                matchPrimitiveInstance(kind: InstanceKind.kDouble, value: 3.14),
+          });
+        }
       });
     });
 

--- a/dwds/test/instances/common/patterns_inspection_common.dart
+++ b/dwds/test/instances/common/patterns_inspection_common.dart
@@ -100,7 +100,8 @@ void runTests({
           'obj': matchListInstance(type: 'Object'),
           // Renamed to avoid shadowing variables from previous case.
           'a\$': matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
-          'n\$': matchPrimitiveInstance(kind: InstanceKind.kDouble, value: 3.14),
+          'n\$': 
+              matchPrimitiveInstance(kind: InstanceKind.kDouble, value: 3.14),
         });
       });
     });

--- a/dwds/test/instances/common/patterns_inspection_common.dart
+++ b/dwds/test/instances/common/patterns_inspection_common.dart
@@ -110,8 +110,7 @@ void runTests({
           expect(await getFrameVariables(frame), {
             'obj': matchListInstance(type: 'Object'),
             // Renamed to avoid shadowing variables from previous case.
-            'a':
-                matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
+            'a': matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
             'n':
                 matchPrimitiveInstance(kind: InstanceKind.kDouble, value: 3.14),
           });

--- a/dwds/test/instances/common/patterns_inspection_common.dart
+++ b/dwds/test/instances/common/patterns_inspection_common.dart
@@ -100,7 +100,7 @@ void runTests({
           'obj': matchListInstance(type: 'Object'),
           // Renamed to avoid shadowing variables from previous case.
           'a\$': matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
-          'n\$': 
+          'n\$':
               matchPrimitiveInstance(kind: InstanceKind.kDouble, value: 3.14),
         });
       });


### PR DESCRIPTION
A bug recently uncovered in DDC required renaming some variables (primarily around patterns) to avoid declarations from shadowing each other incorrectly. 'a' is now 'a$' as it is the second case that declares a Dart variable named 'a'.
