### PR TITLE
[dwds] Add unbatching retry mechanism for failing batched expression evals

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update to be forward compatible with changes to `package:shelf_web_socket`.
 - Added support for some debugging APIs with the DDC library bundle format. - [#2537](https://github.com/dart-lang/webdev/issues/2537),[#2544](https://github.com/dart-lang/webdev/issues/2544)
+- Fix issue where batched expression evals were failing if any subexpression failed. - [#2551](https://github.com/dart-lang/webdev/issues/2551)
 
 ## 24.2.0
 

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -48,6 +48,7 @@ Isolate get simpleIsolate => Isolate(
 
 class FakeInspector implements AppInspector {
   final WebkitDebugger _remoteDebugger;
+  final List<String> functionsCalled = [];
   FakeInspector(this._remoteDebugger, {required this.fakeIsolate});
 
   Isolate fakeIsolate;
@@ -61,8 +62,10 @@ class FakeInspector implements AppInspector {
   Future<RemoteObject> callFunction(
     String function,
     Iterable<String> argumentIds,
-  ) async =>
-      RemoteObject({'type': 'string', 'value': 'true'});
+  ) async {
+    functionsCalled.add(function);
+    return RemoteObject({'type': 'string', 'value': 'true'});
+  }
 
   @override
   Future<void> initialize() async => {};
@@ -472,4 +475,8 @@ class FakeExpressionCompiler implements ExpressionCompiler {
 final fakeWipResponse = WipResponse({
   'id': 1,
   'result': {'fake': ''},
+});
+
+final fakeFailingWipResponse = WipResponse({
+  'result': 'Error: Bad request',
 });


### PR DESCRIPTION
If a single subexpression throws in a batched request, the whole batch fails. DevTools is using this API to evaluate all the fields/getters on an Object. If any of those getters throw, all the queried members fail to show information.

Instead if the initial batched request fails we can retry each request as individual expression evals. This will correctly surface errors for the subexpression that throws and the proper values for all the other subexpressions.

See #2551 

