### PR TITLE
Handle unnecessary_non_null_assertion and invalid_null_aware_operator

### DIFF
--- a/dwds/test/build/min_sdk_test.dart
+++ b/dwds/test/build/min_sdk_test.dart
@@ -19,7 +19,7 @@ void main() {
     sdkVersion = Version(sdkVersion.major, sdkVersion.minor, 0);
 
     final sdkConstraint = VersionConstraint.compatibleWith(sdkVersion);
-    final pubspecSdkConstraint = pubspec.environment?['sdk'];
+    final pubspecSdkConstraint = pubspec.environment['sdk'];
     expect(pubspecSdkConstraint, isNotNull);
     expect(
       sdkConstraint.allowsAll(pubspecSdkConstraint!),

--- a/webdev/test/build/min_sdk_test.dart
+++ b/webdev/test/build/min_sdk_test.dart
@@ -19,7 +19,7 @@ void main() {
     sdkVersion = Version(sdkVersion.major, sdkVersion.minor, 0);
 
     final sdkConstraint = VersionConstraint.compatibleWith(sdkVersion);
-    final pubspecSdkConstraint = pubspec.environment!['sdk']!;
+    final pubspecSdkConstraint = pubspec.environment['sdk']!;
     expect(sdkConstraint.allowsAll(pubspecSdkConstraint), true,
         reason:
             'Min sdk constraint is outdated. Please update SDK constraint in '


### PR DESCRIPTION
It looks like the environment field is correctly analyzed as never possibly null with a newer version of Dart. This fixes Dart CI.
