### PR TITLE
Rename copied SDK directory prefix from 'sdk copy' to 'sdk_copy'

### DIFF
--- a/test_common/lib/test_sdk_configuration.dart
+++ b/test_common/lib/test_sdk_configuration.dart
@@ -35,7 +35,7 @@ class TestSdkConfigurationProvider extends SdkConfigurationProvider {
     bool verbose = false,
     this.ddcModuleFormat = ModuleFormat.amd,
   }) : _verbose = verbose {
-    _sdkDirectory = Directory.systemTemp.createTempSync('sdk copy');
+    _sdkDirectory = Directory.systemTemp.createTempSync('sdk_copy');
     sdkLayout = TestSdkLayout.createDefault(_sdkDirectory.path);
   }
 


### PR DESCRIPTION
webdev/test/e2e_test.dart was failing due to paths with spaces not being handled correctly.

Related issue: https://github.com/dart-lang/webdev/issues/2556
Fixes https://github.com/dart-lang/sdk/issues/59784