### PR TITLE
Add ignores for deprecated web libraries with a TODO and move dwds to 24.4.0-wip

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 24.4.0-wip
+
 ## 24.3.0
 
 - Update to be forward compatible with changes to `package:shelf_web_socket`.

--- a/dwds/debug_extension/web/chrome_api.dart
+++ b/dwds/debug_extension/web/chrome_api.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 import 'package:js/js.dart';

--- a/dwds/debug_extension/web/cider_connection.dart
+++ b/dwds/debug_extension/web/cider_connection.dart
@@ -6,6 +6,8 @@
 library;
 
 import 'dart:convert';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:js_util';
 
 import 'package:js/js.dart';

--- a/dwds/debug_extension/web/copier.dart
+++ b/dwds/debug_extension/web/copier.dart
@@ -5,6 +5,8 @@
 @JS()
 library;
 
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 import 'package:js/js.dart';

--- a/dwds/debug_extension/web/debug_info.dart
+++ b/dwds/debug_extension/web/debug_info.dart
@@ -6,7 +6,11 @@
 library;
 
 import 'dart:convert';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:js';
 
 import 'package:dwds/data/debug_info.dart';

--- a/dwds/debug_extension/web/detector.dart
+++ b/dwds/debug_extension/web/detector.dart
@@ -6,7 +6,11 @@
 library;
 
 import 'dart:convert';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:js_util';
 
 import 'package:dwds/data/debug_info.dart';

--- a/dwds/debug_extension/web/devtools.dart
+++ b/dwds/debug_extension/web/devtools.dart
@@ -5,6 +5,8 @@
 @JS()
 library;
 
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 import 'package:dwds/data/debug_info.dart';

--- a/dwds/debug_extension/web/messaging.dart
+++ b/dwds/debug_extension/web/messaging.dart
@@ -7,6 +7,8 @@ library;
 
 import 'dart:async';
 import 'dart:convert';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:js_util';
 
 import 'package:js/js.dart';

--- a/dwds/debug_extension/web/panel.dart
+++ b/dwds/debug_extension/web/panel.dart
@@ -7,6 +7,8 @@ library;
 
 import 'dart:async';
 import 'dart:convert';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 import 'package:dwds/data/debug_info.dart';

--- a/dwds/debug_extension/web/popup.dart
+++ b/dwds/debug_extension/web/popup.dart
@@ -7,6 +7,8 @@ library;
 
 import 'dart:async';
 import 'dart:convert';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 import 'package:dwds/data/debug_info.dart';

--- a/dwds/debug_extension/web/storage.dart
+++ b/dwds/debug_extension/web/storage.dart
@@ -7,6 +7,8 @@ library;
 
 import 'dart:async';
 import 'dart:convert';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:js_util';
 
 import 'package:js/js.dart';

--- a/dwds/debug_extension/web/utils.dart
+++ b/dwds/debug_extension/web/utils.dart
@@ -6,6 +6,8 @@
 library;
 
 import 'dart:async';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:js_util';
 
 import 'package:js/js.dart';

--- a/dwds/debug_extension/web/web_api.dart
+++ b/dwds/debug_extension/web/web_api.dart
@@ -1,7 +1,12 @@
 // Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:js_util' as js_util;
 
 import 'package:js/js.dart';

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '24.3.0';
+const packageVersion = '24.4.0-wip';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 24.3.0
+version: 24.4.0-wip
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM
   service protocol.

--- a/example/web/main.dart
+++ b/example/web/main.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 void main() {

--- a/fixtures/_experimentSound/web/main.dart
+++ b/fixtures/_experimentSound/web/main.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 import 'dart:core';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 void main() {

--- a/fixtures/_testCircular2Sound/web/main.dart
+++ b/fixtures/_testCircular2Sound/web/main.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 import 'dart:core';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 import 'package:_test_circular1_sound/library1.dart';

--- a/fixtures/_testHotRestart2Sound/web/main.dart
+++ b/fixtures/_testHotRestart2Sound/web/main.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:core';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 import 'package:_test_hot_restart1/library1.dart';

--- a/fixtures/_testPackageSound/web/main.dart
+++ b/fixtures/_testPackageSound/web/main.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:core';
 import 'dart:developer';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 import 'package:_test_package_sound/test_library.dart';

--- a/fixtures/_testSound/example/append_body/main.dart
+++ b/fixtures/_testSound/example/append_body/main.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 import 'dart:developer';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 void main() {

--- a/fixtures/_testSound/example/hello_world/main.dart
+++ b/fixtures/_testSound/example/hello_world/main.dart
@@ -6,7 +6,11 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:developer';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:js';
 
 import 'package:intl/intl.dart';

--- a/fixtures/_webdevSoundSmoke/web/main.dart
+++ b/fixtures/_webdevSoundSmoke/web/main.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
+// TODO: https://github.com/dart-lang/webdev/issues/2508
+// ignore: deprecated_member_use
 import 'dart:html';
 
 void main() {


### PR DESCRIPTION
Dart web libraries are now deprecated. This triggers a lint which we fail on. We should migrate these to dart:js_interop and package:web, but for now, ignore to make CI happy.

This also moves the CHANGELOG, pubspec, and version.dart files to 24.4.0-wip, which is needed for proper_release_test to pass.