### PR TITLE
Move dwds to v24.4.0-wip to make proper_release_test pass

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 24.4.0-wip
+
 ## 24.3.0
 
 - Update to be forward compatible with changes to `package:shelf_web_socket`.

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '24.3.0';
+const packageVersion = '24.4.0-wip';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 24.3.0
+version: 24.4.0-wip
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM
   service protocol.


### PR DESCRIPTION
There's a check in there to make sure there's a WIP release.

This is needed so https://github.com/dart-lang/webdev/pull/2559 is unblocked, which in turn unblocks https://github.com/dart-lang/webdev/pull/2558.