### PR TITLE
Updated DWDS to include a boolean flag that enables debugging support when set to true

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 24.3.8
+
+- Updated DWDS to include a boolean flag that enables debugging support only when set to true. [#60289](https://github.com/dart-lang/sdk/issues/60289)
+
 ## 24.3.7
 
 - The registered extension `reassemble` is now no longer called when calling

--- a/dwds/lib/dart_web_debug_service.dart
+++ b/dwds/lib/dart_web_debug_service.dart
@@ -66,6 +66,7 @@ class Dwds {
     required Stream<BuildResult> buildResults,
     required ConnectionProvider chromeConnection,
     required ToolConfiguration toolConfiguration,
+    bool enableDebuggingSupport = true,
   }) async {
     globalToolConfiguration = toolConfiguration;
     final debugSettings = toolConfiguration.debugSettings;
@@ -117,7 +118,10 @@ class Dwds {
       _logger.info('Serving DevTools at $uri\n');
     }
 
-    final injected = DwdsInjector(extensionUri: extensionUri);
+    final injected = DwdsInjector(
+      extensionUri: extensionUri,
+      enableDebuggingSupport: enableDebuggingSupport,
+    );
 
     final devHandler = DevHandler(
       chromeConnection,

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -37,8 +37,7 @@ class DwdsInjector {
   DwdsInjector({
     Future<String>? extensionUri,
     bool enableDebuggingSupport = true,
-  })
-    : _extensionUri = extensionUri,
+  }) : _extensionUri = extensionUri,
        _enableDebuggingSupport = enableDebuggingSupport;
 
   /// Returns the embedded dev handler paths.

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -26,8 +26,6 @@ const mainExtensionMarker = '/* MAIN_EXTENSION_MARKER */';
 
 const _clientScript = 'dwds/src/injected/client';
 
-/// Handles injecting the DWDS client and embedding debugging-related information.
-///
 /// This class is responsible for modifying the served JavaScript files
 /// to include the injected DWDS client, enabling debugging capabilities
 /// and source mapping when running in a browser environment.

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -32,8 +32,14 @@ class DwdsInjector {
   final Future<String>? _extensionUri;
   final _devHandlerPaths = StreamController<String>();
   final _logger = Logger('DwdsInjector');
+  final bool _enableDebuggingSupport;
 
-  DwdsInjector({Future<String>? extensionUri}) : _extensionUri = extensionUri;
+  DwdsInjector({
+    Future<String>? extensionUri,
+    bool enableDebuggingSupport = true,
+  })
+    : _extensionUri = extensionUri,
+       _enableDebuggingSupport = enableDebuggingSupport;
 
   /// Returns the embedded dev handler paths.
   ///
@@ -95,13 +101,17 @@ class DwdsInjector {
           await globalToolConfiguration.loadStrategy.trackEntrypoint(
             entrypoint,
           );
-          body = await _injectClientAndHoistMain(
-            body,
-            appId,
-            devHandlerPath,
-            entrypoint,
-            await _extensionUri,
-          );
+          // If true, inject the debugging client and hoist the main function
+          // to enable debugging support.
+          if (_enableDebuggingSupport) {
+            body = await _injectClientAndHoistMain(
+              body,
+              appId,
+              devHandlerPath,
+              entrypoint,
+              await _extensionUri,
+            );
+          }
           body += await globalToolConfiguration.loadStrategy.bootstrapFor(
             entrypoint,
           );

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -37,6 +37,9 @@ const _clientScript = 'dwds/src/injected/client';
 /// - When `true`, the DWDS client is injected, enabling debugging features.
 /// - When `false`, debugging support is disabled, meaning the application will
 ///   run without debugging.
+///
+/// This separation allows for scenarios where debugging is not needed or
+/// should be explicitly avoided.
 class DwdsInjector {
   final Future<String>? _extensionUri;
   final _devHandlerPaths = StreamController<String>();

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -26,8 +26,17 @@ const mainExtensionMarker = '/* MAIN_EXTENSION_MARKER */';
 
 const _clientScript = 'dwds/src/injected/client';
 
-/// Handles injecting the DWDS client and embedding debugging related
-/// information.
+/// Handles injecting the DWDS client and embedding debugging-related information.
+///
+/// This class is responsible for modifying the served JavaScript files
+/// to include the injected DWDS client, enabling debugging capabilities
+/// and source mapping when running in a browser environment.
+///
+/// The `_enableDebuggingSupport` flag determines whether debugging-related
+/// functionality should be included:
+/// - When `true`, the DWDS client is injected, enabling debugging features.
+/// - When `false`, debugging support is disabled, meaning the application will
+///   run without debugging.
 class DwdsInjector {
   final Future<String>? _extensionUri;
   final _devHandlerPaths = StreamController<String>();

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '24.3.7';
+const packageVersion = '24.3.8';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 24.3.7
+version: 24.3.8
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM
   service protocol.


### PR DESCRIPTION
Updated DWDS to include a boolean flag that enables debugging support when set to true (default behavior). This flag will enable us to support running a Flutter app on a `web-server` with the new DDC library bundle format. However, it will not support debugging, as debugging features are not compatible with this configuration.

- Related to https://github.com/dart-lang/sdk/issues/60289