### PR TITLE
Renamed boolean flag in DWDS Injector

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 24.3.9-wip
+## 24.3.9
+
+- Renamed DWDS Injector parameter `enableDebuggingSupport` to `injectDebuggingSupportCode` for clearer intent.
 
 ## 24.3.8
 

--- a/dwds/lib/dart_web_debug_service.dart
+++ b/dwds/lib/dart_web_debug_service.dart
@@ -66,7 +66,7 @@ class Dwds {
     required Stream<BuildResult> buildResults,
     required ConnectionProvider chromeConnection,
     required ToolConfiguration toolConfiguration,
-    bool enableDebuggingSupport = true,
+    bool injectDebuggingSupportCode = true,
   }) async {
     globalToolConfiguration = toolConfiguration;
     final debugSettings = toolConfiguration.debugSettings;
@@ -120,7 +120,7 @@ class Dwds {
 
     final injected = DwdsInjector(
       extensionUri: extensionUri,
-      enableDebuggingSupport: enableDebuggingSupport,
+      injectDebuggingSupportCode: injectDebuggingSupportCode,
     );
 
     final devHandler = DevHandler(

--- a/dwds/lib/src/handlers/injector.dart
+++ b/dwds/lib/src/handlers/injector.dart
@@ -30,7 +30,7 @@ const _clientScript = 'dwds/src/injected/client';
 /// to include the injected DWDS client, enabling debugging capabilities
 /// and source mapping when running in a browser environment.
 ///
-/// The `_enableDebuggingSupport` flag determines whether debugging-related
+/// The `_injectDebuggingSupportCode` flag determines whether debugging-related
 /// functionality should be included:
 /// - When `true`, the DWDS client is injected, enabling debugging features.
 /// - When `false`, debugging support is disabled, meaning the application will
@@ -42,13 +42,13 @@ class DwdsInjector {
   final Future<String>? _extensionUri;
   final _devHandlerPaths = StreamController<String>();
   final _logger = Logger('DwdsInjector');
-  final bool _enableDebuggingSupport;
+  final bool _injectDebuggingSupportCode;
 
   DwdsInjector({
     Future<String>? extensionUri,
-    bool enableDebuggingSupport = true,
+    bool injectDebuggingSupportCode = true,
   }) : _extensionUri = extensionUri,
-       _enableDebuggingSupport = enableDebuggingSupport;
+       _injectDebuggingSupportCode = injectDebuggingSupportCode;
 
   /// Returns the embedded dev handler paths.
   ///
@@ -112,7 +112,7 @@ class DwdsInjector {
           );
           // If true, inject the debugging client and hoist the main function
           // to enable debugging support.
-          if (_enableDebuggingSupport) {
+          if (_injectDebuggingSupportCode) {
             body = await _injectClientAndHoistMain(
               body,
               appId,

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '24.3.9-wip';
+const packageVersion = '24.3.9';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 24.3.9-wip
+version: 24.3.9
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM
   service protocol.


### PR DESCRIPTION
Renamed boolean flag in DWDS Injector from `enableDebuggingSupport` to `injectDebuggingSupportCode `. 

- Follows this PR: https://github.com/dart-lang/webdev/pull/2601
- Required for this PR: https://github.com/flutter/flutter/pull/165700
- Related to https://github.com/dart-lang/sdk/issues/60289