### PR TITLE
Fix e2e 'evaluate' test to use new Closure toString format

### DIFF
--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -390,7 +390,7 @@ void main() {
               const TypeMatcher<InstanceRef>().having(
                   (instance) => instance.valueAsString,
                   'valueAsString',
-                  contains('Hello World!!')));
+                  contains('Closure: () => void')));
         } finally {
           await vmService?.dispose();
           await exitWebdev(process);


### PR DESCRIPTION
As of the release of Dart 3.8 on the stable branch, DDC now produces a different String (more in line with the other Dart backends) from the `toString` of closures. Rather than using JS's `toString` on the underlying `Function`, DDC now generates a string using the Function's RTI object.

This has caused the updated test to start failing in CI:
https://github.com/dart-lang/webdev/actions/runs/15255960533

Fix the test by updating the expectation string to match the new string format.