### PR TITLE
Update e2e_test expectation to look for more consistent message.

### DIFF
--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -113,7 +113,7 @@ void main() {
       final process = await testRunner.runWebDev(args,
           workingDirectory: soundExampleDirectory);
 
-      await checkProcessStdout(process, ['Succeeded']);
+      await checkProcessStdout(process, ['Writing asset manifest completed']);
       await process.shouldExit(0);
     },
     // https://github.com/dart-lang/webdev/issues/2489,
@@ -133,7 +133,7 @@ void main() {
           final process = await testRunner.runWebDev(args,
               workingDirectory: soundExampleDirectory);
 
-          final expectedItems = <Object>['Succeeded'];
+          final expectedItems = <Object>['Writing asset manifest completed'];
 
           await checkProcessStdout(process, expectedItems);
           await process.shouldExit(0);
@@ -166,7 +166,7 @@ void main() {
         final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
 
-        final expectedItems = <Object>['Succeeded'];
+        final expectedItems = <Object>['Writing asset manifest completed'];
 
         await checkProcessStdout(process, expectedItems);
         await process.shouldExit(0);
@@ -189,7 +189,9 @@ void main() {
         final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
 
-        final expectedItems = <Object>['Succeeded'];
+        final expectedItems = <Object>[
+          'Caching finalized dependency graph completed'
+        ];
 
         await checkProcessStdout(process, expectedItems);
         await process.shouldExit(0);
@@ -215,7 +217,10 @@ void main() {
         final hostUrl = 'http://localhost:$openPort';
 
         // Wait for the initial build to finish.
-        await expectLater(process.stdout, emitsThrough(contains('Succeeded')));
+        await expectLater(
+            process.stdout,
+            emitsThrough(
+                contains('Caching finalized dependency graph completed')));
 
         final client = HttpClient();
 


### PR DESCRIPTION
These e2e tests have been extremely flaky requiring many retries (these tests are configured to have 3 retries each) and still sometimes failing.

See failing job here:
https://github.com/dart-lang/webdev/actions/runs/15444512522/job/43470375587

Failures all occur due to the missing "Succeeded" message from the build runner logs. Sometimes the build runner process ends without printing this success message:
https://github.com/dart-lang/build/blob/master/build_runner_core/lib/src/generate/build.dart#L216

The updated messages all appear directly before the "Succeeded" message would and indicate the last expected action was successful.

Associated issue: https://github.com/dart-lang/webdev/issues/2489