### PR TITLE
Add tests covering the ability to debug dot shorthands

### DIFF
--- a/dwds/test/instances/common/class_inspection_common.dart
+++ b/dwds/test/instances/common/class_inspection_common.dart
@@ -49,6 +49,7 @@ void runTests({
           compilationMode: compilationMode,
           enableExpressionEvaluation: true,
           verboseCompiler: debug,
+          experiments: ['dot-shorthands'],
           canaryFeatures: canaryFeatures,
           moduleFormat: provider.ddcModuleFormat,
         ),

--- a/dwds/test/instances/common/dot_shorthands_common.dart
+++ b/dwds/test/instances/common/dot_shorthands_common.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dwds/src/services/expression_compiler.dart' show ModuleFormat;
+import 'package:path/path.dart' show basename;
+import 'package:test/test.dart';
+import 'package:test_common/logging.dart';
+import 'package:test_common/test_sdk_configuration.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../fixtures/context.dart';
+import '../../fixtures/project.dart';
+import '../../fixtures/utilities.dart';
+import 'test_inspector.dart';
+
+void runTests({
+  required TestSdkConfigurationProvider provider,
+  required CompilationMode compilationMode,
+  required bool canaryFeatures,
+  required bool debug,
+}) {
+  final context = TestContext(TestProject.testExperiment, provider);
+  final testInspector = TestInspector(context);
+
+  late VmService service;
+  late Stream<Event> stream;
+  late String isolateId;
+  late ScriptRef mainScript;
+
+  Future<void> onBreakPoint(breakPointId, body) => testInspector.onBreakPoint(
+    stream,
+    isolateId,
+    mainScript,
+    breakPointId,
+    body,
+  );
+
+  Future<InstanceRef> getInstanceRef(frame, expression) =>
+      testInspector.getInstanceRef(isolateId, frame, expression);
+
+  group('$compilationMode |', () {
+    setUpAll(() async {
+      setCurrentLogWriter(debug: debug);
+      await context.setUp(
+        testSettings: TestSettings(
+          compilationMode: compilationMode,
+          enableExpressionEvaluation: true,
+          verboseCompiler: debug,
+          experiments: ['dot-shorthands'],
+          canaryFeatures: canaryFeatures,
+          moduleFormat: provider.ddcModuleFormat,
+        ),
+      );
+      service = context.debugConnection.vmService;
+
+      final vm = await service.getVM();
+      isolateId = vm.isolates!.first.id!;
+      final scripts = await service.getScripts(isolateId);
+
+      await service.streamListen('Debug');
+      stream = service.onEvent('Debug');
+
+      mainScript = scripts.scripts!.firstWhere(
+        (each) => each.uri!.contains('main.dart'),
+      );
+    });
+
+    tearDownAll(() async {
+      await context.tearDown();
+    });
+
+    setUp(() => setCurrentLogWriter(debug: debug));
+    tearDown(() => service.resume(isolateId));
+
+    test('dot shorthands: expression evaluation', () async {
+      await onBreakPoint('testDotShorthands', (event) async {
+        final frame = event.topFrame!.index!;
+
+        var instanceRef = await getInstanceRef(frame, '(c = .two).value');
+        expect(instanceRef.valueAsString, '2');
+
+        instanceRef = await getInstanceRef(frame, '(c = .three).value');
+        expect(instanceRef.valueAsString, '3');
+
+        instanceRef = await getInstanceRef(frame, '(c = .four()).value');
+        expect(instanceRef.valueAsString, '4');
+      });
+    });
+
+    test('dot shorthands: single-stepping', () async {
+      await onBreakPoint('testDotShorthands', (event) async {
+        final scriptBasename = basename(mainScript.uri!);
+
+        const lineA = 116;
+        const lineB = 118;
+        const lineC = 119;
+        const lineD = 120;
+        const lineE = 127;
+        const lineF = 129;
+        const lineG = 131;
+        const lineH = 132;
+
+        final expected = [
+          '$scriptBasename:$lineE:3', // on 'c'
+          // TODO(2638): Investigate why this conditional exclusion is needed.
+          if (provider.ddcModuleFormat == ModuleFormat.ddc)
+            '$scriptBasename:$lineB:20', // on '2'
+          '$scriptBasename:$lineF:3', // on 'c'
+          '$scriptBasename:$lineC:25', // on 'C'
+          '$scriptBasename:$lineA:10', // on 'v' of 'value'
+          '$scriptBasename:$lineA:16', // on ';'
+          '$scriptBasename:$lineC:27', // on '3'
+          '$scriptBasename:$lineG:3', // on 'c'
+          '$scriptBasename:$lineD:22', // on 'C'
+          '$scriptBasename:$lineA:10', // on 'v' of 'value'
+          '$scriptBasename:$lineA:16', // on ';'
+          '$scriptBasename:$lineD:24', // on '4'
+          '$scriptBasename:$lineH:3', // on 'p' of 'print'
+        ];
+
+        final stops = <String>[];
+        await testInspector.runStepIntoThroughProgramRecordingStops(
+          stream,
+          isolateId,
+          stops,
+          provider.ddcModuleFormat == ModuleFormat.ddc ? 13 : 12,
+        );
+
+        expect(stops, expected);
+      });
+    });
+  });
+}

--- a/dwds/test/instances/common/patterns_inspection_common.dart
+++ b/dwds/test/instances/common/patterns_inspection_common.dart
@@ -57,7 +57,7 @@ void runTests({
           compilationMode: compilationMode,
           enableExpressionEvaluation: true,
           verboseCompiler: debug,
-          experiments: ['records', 'patterns'],
+          experiments: ['dot-shorthands'],
           canaryFeatures: canaryFeatures,
         ),
       );

--- a/dwds/test/instances/common/record_inspection_common.dart
+++ b/dwds/test/instances/common/record_inspection_common.dart
@@ -63,7 +63,7 @@ void runTests({
           compilationMode: compilationMode,
           enableExpressionEvaluation: true,
           verboseCompiler: debug,
-          experiments: ['records', 'patterns'],
+          experiments: ['dot-shorthands'],
           canaryFeatures: canaryFeatures,
           moduleFormat: provider.ddcModuleFormat,
         ),

--- a/dwds/test/instances/common/record_type_inspection_common.dart
+++ b/dwds/test/instances/common/record_type_inspection_common.dart
@@ -62,7 +62,7 @@ void runTests({
           compilationMode: compilationMode,
           enableExpressionEvaluation: true,
           verboseCompiler: debug,
-          experiments: ['records', 'patterns'],
+          experiments: ['dot-shorthands'],
           canaryFeatures: canaryFeatures,
           moduleFormat: provider.ddcModuleFormat,
         ),

--- a/dwds/test/instances/common/test_inspector.dart
+++ b/dwds/test/instances/common/test_inspector.dart
@@ -233,7 +233,6 @@ class TestInspector {
   }
 
   Future<void> runStepIntoThroughProgramRecordingStops(
-    Stream<Event> debugStream,
     String isolateId,
 
     /// A list to which the pause location is added after each single-step.
@@ -248,7 +247,7 @@ class TestInspector {
     final completer = Completer<void>();
 
     late StreamSubscription subscription;
-    subscription = debugStream.listen((event) async {
+    subscription = service.onDebugEvent.listen((event) async {
       if (event.kind == EventKind.kPauseInterrupted) {
         final isolate = await service.getIsolate(isolateId);
         final frame = isolate.pauseEvent!.topFrame!;

--- a/dwds/test/instances/common/test_inspector.dart
+++ b/dwds/test/instances/common/test_inspector.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async' show Completer, StreamSubscription;
+
+import 'package:path/path.dart' show basename;
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -213,6 +216,57 @@ class TestInspector {
                 as Instance,
       ),
     );
+  }
+
+  Future<String> _locationToString(
+    VmService service,
+    String isolateId,
+    SourceLocation location,
+  ) async {
+    final script =
+        await service.getObject(isolateId, location.script!.id!) as Script;
+    final scriptName = basename(script.uri!);
+    final tokenPos = location.tokenPos!;
+    final line = script.getLineNumberFromTokenPos(tokenPos);
+    final column = script.getColumnNumberFromTokenPos(tokenPos);
+    return '$scriptName:$line:$column';
+  }
+
+  Future<void> runStepIntoThroughProgramRecordingStops(
+    Stream<Event> debugStream,
+    String isolateId,
+
+    /// A list to which the pause location is added after each single-step.
+    List<String> recordedStops,
+
+    /// A limit on the number of stops to record.
+    ///
+    /// The program will not be resumed after the length of [recordedStops]
+    /// becomes [numStops].
+    int numStops,
+  ) async {
+    final completer = Completer<void>();
+
+    late StreamSubscription subscription;
+    subscription = debugStream.listen((event) async {
+      if (event.kind == EventKind.kPauseInterrupted) {
+        final isolate = await service.getIsolate(isolateId);
+        final frame = isolate.pauseEvent!.topFrame!;
+        recordedStops.add(
+          await _locationToString(service, isolateId, frame.location!),
+        );
+        if (recordedStops.length == numStops) {
+          await subscription.cancel();
+          completer.complete();
+        }
+        await service.resume(isolateId, step: StepOption.kInto);
+      } else if (event.kind == EventKind.kPauseExit) {
+        await subscription.cancel();
+        completer.complete();
+      }
+    });
+    await service.resume(isolateId, step: StepOption.kInto);
+    await completer.future;
   }
 }
 

--- a/dwds/test/instances/common/type_inspection_common.dart
+++ b/dwds/test/instances/common/type_inspection_common.dart
@@ -80,7 +80,7 @@ void runTests({
           compilationMode: compilationMode,
           enableExpressionEvaluation: true,
           verboseCompiler: debug,
-          experiments: ['records', 'patterns'],
+          experiments: ['dot-shorthands'],
           canaryFeatures: canaryFeatures,
         ),
       );

--- a/dwds/test/instances/dot_shorthands_amd_canary_test.dart
+++ b/dwds/test/instances/dot_shorthands_amd_canary_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['daily'])
+@TestOn('vm')
+@Timeout(Duration(minutes: 2))
+library;
+
+import 'package:dwds/expression_compiler.dart';
+import 'package:test/test.dart';
+import 'package:test_common/test_sdk_configuration.dart';
+
+import '../fixtures/context.dart';
+import 'common/dot_shorthands_common.dart';
+
+void main() {
+  // Enable verbose logging for debugging.
+  final debug = false;
+  final canaryFeatures = true;
+
+  group('canary: $canaryFeatures |', () {
+    final provider = TestSdkConfigurationProvider(
+      verbose: debug,
+      canaryFeatures: canaryFeatures,
+      ddcModuleFormat: ModuleFormat.amd,
+    );
+    tearDownAll(provider.dispose);
+
+    for (final compilationMode in CompilationMode.values) {
+      runTests(
+        provider: provider,
+        compilationMode: compilationMode,
+        canaryFeatures: canaryFeatures,
+        debug: debug,
+      );
+    }
+  });
+}

--- a/dwds/test/instances/dot_shorthands_amd_canary_test.dart
+++ b/dwds/test/instances/dot_shorthands_amd_canary_test.dart
@@ -16,8 +16,8 @@ import 'common/dot_shorthands_common.dart';
 
 void main() {
   // Enable verbose logging for debugging.
-  final debug = false;
-  final canaryFeatures = true;
+  const debug = false;
+  const canaryFeatures = true;
 
   group('canary: $canaryFeatures |', () {
     final provider = TestSdkConfigurationProvider(

--- a/dwds/test/instances/dot_shorthands_amd_test.dart
+++ b/dwds/test/instances/dot_shorthands_amd_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['daily'])
+@TestOn('vm')
+@Timeout(Duration(minutes: 2))
+library;
+
+import 'package:dwds/src/services/expression_compiler.dart';
+import 'package:test/test.dart';
+import 'package:test_common/test_sdk_configuration.dart';
+
+import '../fixtures/context.dart';
+import 'common/dot_shorthands_common.dart';
+
+void main() {
+  // Enable verbose logging for debugging.
+  final debug = false;
+  final canaryFeatures = false;
+
+  group('canary: $canaryFeatures |', () {
+    final provider = TestSdkConfigurationProvider(
+      verbose: debug,
+      canaryFeatures: canaryFeatures,
+      ddcModuleFormat: ModuleFormat.amd,
+    );
+    tearDownAll(provider.dispose);
+
+    for (final compilationMode in CompilationMode.values) {
+      runTests(
+        provider: provider,
+        compilationMode: compilationMode,
+        canaryFeatures: canaryFeatures,
+        debug: debug,
+      );
+    }
+  });
+}

--- a/dwds/test/instances/dot_shorthands_amd_test.dart
+++ b/dwds/test/instances/dot_shorthands_amd_test.dart
@@ -16,8 +16,8 @@ import 'common/dot_shorthands_common.dart';
 
 void main() {
   // Enable verbose logging for debugging.
-  final debug = false;
-  final canaryFeatures = false;
+  const debug = false;
+  const canaryFeatures = false;
 
   group('canary: $canaryFeatures |', () {
     final provider = TestSdkConfigurationProvider(

--- a/dwds/test/instances/dot_shorthands_ddc_library_bundle_test.dart
+++ b/dwds/test/instances/dot_shorthands_ddc_library_bundle_test.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['daily'])
+@TestOn('vm')
+@Timeout(Duration(minutes: 2))
+library;
+
+import 'package:dwds/expression_compiler.dart';
+import 'package:test/test.dart';
+import 'package:test_common/test_sdk_configuration.dart';
+
+import '../fixtures/context.dart';
+import 'common/dot_shorthands_common.dart';
+
+void main() {
+  // Enable verbose logging for debugging.
+  final debug = false;
+  final canaryFeatures = true;
+  final compilationMode = CompilationMode.frontendServer;
+
+  group('canary: $canaryFeatures |', () {
+    final provider = TestSdkConfigurationProvider(
+      verbose: debug,
+      canaryFeatures: canaryFeatures,
+      ddcModuleFormat: ModuleFormat.ddc,
+    );
+    tearDownAll(provider.dispose);
+    runTests(
+      provider: provider,
+      compilationMode: compilationMode,
+      canaryFeatures: canaryFeatures,
+      debug: debug,
+    );
+  });
+}

--- a/dwds/test/instances/dot_shorthands_ddc_library_bundle_test.dart
+++ b/dwds/test/instances/dot_shorthands_ddc_library_bundle_test.dart
@@ -16,9 +16,9 @@ import 'common/dot_shorthands_common.dart';
 
 void main() {
   // Enable verbose logging for debugging.
-  final debug = false;
-  final canaryFeatures = true;
-  final compilationMode = CompilationMode.frontendServer;
+  const debug = false;
+  const canaryFeatures = true;
+  const compilationMode = CompilationMode.frontendServer;
 
   group('canary: $canaryFeatures |', () {
     final provider = TestSdkConfigurationProvider(

--- a/fixtures/_experimentSound/web/main.dart
+++ b/fixtures/_experimentSound/web/main.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart = 3.9
+
 import 'dart:async';
 import 'dart:core';
 // TODO: https://github.com/dart-lang/webdev/issues/2508
@@ -24,6 +26,8 @@ void main() {
     testPattern2();
     print('Classes');
     testClass();
+    print('Dot shorthands');
+    testDotShorthands();
   });
 
   document.body!.appendText('Program is running!');
@@ -105,4 +109,25 @@ class GreeterClass {
   void greetInFrench() {
     print('Bonjour $greeteeName');
   }
+}
+
+class C {
+  int value;
+  C(this.value); // lineA
+
+  static C two = C(2); // lineB
+  static C get three => C(3); // lineC
+  static C four() => C(4); // lineD
+}
+
+void testDotShorthands() {
+  C c = C(1);
+  print('breakpoint'); // Breakpoint: testDotShorthands
+  // ignore: experiment_not_enabled
+  c = .two; // lineE
+  // ignore: experiment_not_enabled
+  c = .three; // lineF
+  // ignore: experiment_not_enabled
+  c = .four(); // lineG
+  print(c.value); // lineH
 }

--- a/webdev/test/tls_test.dart
+++ b/webdev/test/tls_test.dart
@@ -53,6 +53,7 @@ void main() {
         '--hostname=0.0.0.0',
         '--tls-cert-chain=localhost+2.pem',
         '--tls-cert-key=localhost+2-key.pem',
+        '--enable-experiment=dot-shorthands',
       ];
 
       final process =
@@ -83,6 +84,7 @@ void main() {
         '--hostname=0.0.0.0',
         '--tls-cert-chain=localhost+2.pem',
         '--tls-cert-key=localhost+2-key.pem',
+        '--enable-experiment=dot-shorthands',
       ];
 
       final process =


### PR DESCRIPTION
This PR adds tests that ensure that expression evaluation and single-stepping interact with dot shorthands as expected.

Fixes: https://github.com/dart-lang/sdk/issues/59874