### PR TITLE
Invalidate caches after a hot reload

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 24.4.0-wip
+## 24.4.0
 
 - Added support for breakpoint registering on a hot reload with the DDC library bundle format using PausePostRequests.
 - `FrontendServerDdcLibraryBundleStrategy.hotReloadSourceUri` is now expected to also provide the reloaded modules.

--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 24.4.0-wip
 
 - Added support for breakpoint registering on a hot reload with the DDC library bundle format using PausePostRequests.
+- `FrontendServerDdcLibraryBundleStrategy.hotReloadSourceUri` is now expected to also provide the reloaded modules.
 
 ## 24.3.11
 

--- a/dwds/lib/src/debugging/debugger.dart
+++ b/dwds/lib/src/debugging/debugger.dart
@@ -594,6 +594,7 @@ class Debugger extends Domain {
             params: {
               'skipList': _skipLists.compute(
                 scriptId,
+                url,
                 await _locations.locationsForUrl(url),
               ),
             },

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -746,6 +746,7 @@ class AppInspector implements AppInspectorInterface {
         for (final libraryUri in modifiedModuleReport.modifiedLibraries) {
           final libraryRef = await _libraryHelper.libraryRefFor(libraryUri);
           final libraryId = libraryRef?.id;
+          // If this was not a pre-existing library, nothing to invalidate.
           if (libraryId == null) continue;
           final scriptRefs = _libraryIdToScriptRefs.remove(libraryId);
           if (scriptRefs == null) continue;
@@ -768,8 +769,7 @@ class AppInspector implements AppInspectorInterface {
         isolate.libraries ?? <LibraryRef>[],
       );
       for (final uri in userLibraries) {
-        if (modifiedModuleReport != null &&
-            !modifiedModuleReport.modifiedLibraries.contains(uri)) {
+        if (modifiedModuleReport?.modifiedLibraries.contains(uri) == false) {
           continue;
         }
         final parts = scripts[uri];

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -740,7 +740,7 @@ class AppInspector implements AppInspectorInterface {
               .scripts;
       if (modifiedModuleReport != null) {
         // Invalidate any script caches that were computed for the now invalid
-        // libraries. They will get repopulated later.
+        // libraries. They will get repopulated below.
         for (final libraryUri in modifiedModuleReport.modifiedLibraries) {
           final libraryRef = await _libraryHelper.libraryRefFor(libraryUri);
           final libraryId = libraryRef?.id;

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -118,9 +118,9 @@ class AppInspector implements AppInspectorInterface {
 
     if (modifiedModuleReport != null) {
       // Invalidate `_libraryHelper` as we use it populate any script caches.
-      _libraryHelper.invalidate(modifiedModuleReport);
+      _libraryHelper.initialize(modifiedModuleReport);
     } else {
-      _libraryHelper = LibraryHelper(this);
+      _libraryHelper = LibraryHelper(this)..initialize();
       _scriptRefsById.clear();
       _serverPathToScriptRef.clear();
       _scriptIdToLibraryId.clear();

--- a/dwds/lib/src/debugging/inspector.dart
+++ b/dwds/lib/src/debugging/inspector.dart
@@ -13,6 +13,7 @@ import 'package:dwds/src/debugging/execution_context.dart';
 import 'package:dwds/src/debugging/instance.dart';
 import 'package:dwds/src/debugging/libraries.dart';
 import 'package:dwds/src/debugging/location.dart';
+import 'package:dwds/src/debugging/metadata/provider.dart';
 import 'package:dwds/src/debugging/remote_debugger.dart';
 import 'package:dwds/src/loaders/ddc_library_bundle.dart';
 import 'package:dwds/src/readers/asset_reader.dart';
@@ -34,7 +35,9 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 class AppInspector implements AppInspectorInterface {
   var _scriptCacheMemoizer = AsyncMemoizer<List<ScriptRef>>();
 
-  Future<List<ScriptRef>> get scriptRefs => _populateScriptCaches();
+  Future<List<ScriptRef>> getScriptRefs([
+    InvalidatedModuleReport? invalidatedModuleReport,
+  ]) => _populateScriptCaches(invalidatedModuleReport);
 
   final _logger = Logger('AppInspector');
 
@@ -103,24 +106,35 @@ class AppInspector implements AppInspectorInterface {
 
   /// Reset all caches and recompute any mappings.
   ///
-  /// Should be called across hot reloads.
-  Future<void> initialize() async {
+  /// Should be called across hot reloads with a valid [invalidatedModuleReport].
+  Future<void> initialize([
+    InvalidatedModuleReport? invalidatedModuleReport,
+  ]) async {
     _scriptCacheMemoizer = AsyncMemoizer<List<ScriptRef>>();
-    _scriptRefsById.clear();
-    _serverPathToScriptRef.clear();
-    _scriptIdToLibraryId.clear();
-    _libraryIdToScriptRefs.clear();
 
-    _libraryHelper = LibraryHelper(this);
+    // TODO(srujzs): We can invalidate these in a smarter way instead of
+    // reinitializing when doing a hot reload, but these helpers recompute info
+    // on demand and therefore are not in the critical path.
     _classHelper = ClassHelper(this);
     _instanceHelper = InstanceHelper(this);
+
+    if (invalidatedModuleReport != null) {
+      // Invalidate `_libraryHelper` as we use it populate any script caches.
+      _libraryHelper.invalidate(invalidatedModuleReport);
+    } else {
+      _libraryHelper = LibraryHelper(this);
+      _scriptRefsById.clear();
+      _serverPathToScriptRef.clear();
+      _scriptIdToLibraryId.clear();
+      _libraryIdToScriptRefs.clear();
+    }
 
     final libraries = await _libraryHelper.libraryRefs;
     isolate.rootLib = await _libraryHelper.rootLib;
     isolate.libraries?.clear();
     isolate.libraries?.addAll(libraries);
 
-    final scripts = await scriptRefs;
+    final scripts = await getScriptRefs(invalidatedModuleReport);
 
     await DartUri.initialize();
     DartUri.recordAbsoluteUris(libraries.map((lib) => lib.uri).nonNulls);
@@ -583,7 +597,7 @@ class AppInspector implements AppInspectorInterface {
   /// All the scripts in the isolate.
   @override
   Future<ScriptList> getScripts() async {
-    return ScriptList(scripts: await scriptRefs);
+    return ScriptList(scripts: await getScriptRefs());
   }
 
   /// Calls the Chrome Runtime.getProperties API for the object with [objectId].
@@ -714,19 +728,50 @@ class AppInspector implements AppInspectorInterface {
   ///
   /// This will get repopulated on restarts and reloads.
   ///
+  /// If [invalidatedModuleReport] is provided, only invalidates and
+  /// recalculates caches for the invalidated libraries.
+  ///
   /// Returns the list of scripts refs cached.
-  Future<List<ScriptRef>> _populateScriptCaches() {
+  Future<List<ScriptRef>> _populateScriptCaches([
+    InvalidatedModuleReport? invalidatedModuleReport,
+  ]) {
     return _scriptCacheMemoizer.runOnce(() async {
       final scripts =
           await globalToolConfiguration.loadStrategy
               .metadataProviderFor(appConnection.request.entrypointPath)
               .scripts;
+      final invalidatedLibraries = invalidatedModuleReport?.deletedLibraries
+          .union(invalidatedModuleReport.reloadedLibraries);
+      if (invalidatedLibraries != null) {
+        for (final libraryUri in invalidatedLibraries) {
+          final libraryRef = await _libraryHelper.libraryRefFor(libraryUri);
+          final libraryId = libraryRef?.id;
+          if (libraryId == null) continue;
+          final scriptRefs = _libraryIdToScriptRefs.remove(libraryId);
+          if (scriptRefs == null) continue;
+          for (final scriptRef in scriptRefs) {
+            final scriptId = scriptRef.id;
+            final scriptUri = scriptRef.uri;
+            if (scriptId != null && scriptUri != null) {
+              _scriptRefsById.remove(scriptId);
+              _scriptIdToLibraryId.remove(scriptId);
+              _serverPathToScriptRef.remove(
+                DartUri(scriptUri, _root).serverPath,
+              );
+            }
+          }
+        }
+      }
       // For all the non-dart: libraries, find their parts and create scriptRefs
       // for them.
       final userLibraries = _userLibraryUris(
         isolate.libraries ?? <LibraryRef>[],
       );
       for (final uri in userLibraries) {
+        if (invalidatedLibraries != null &&
+            !invalidatedLibraries.contains(uri)) {
+          continue;
+        }
         final parts = scripts[uri];
         final scriptRefs = [
           ScriptRef(uri: uri, id: createId()),

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -52,16 +52,13 @@ class LibraryHelper extends Domain {
     return _rootLib!;
   }
 
-  void invalidate(InvalidatedModuleReport invalidatedModuleReport) {
-    final invalidatedLibraries = invalidatedModuleReport.deletedLibraries.union(
-      invalidatedModuleReport.reloadedLibraries,
-    );
-    for (final library in invalidatedLibraries) {
+  void invalidate(ModifiedModuleReport modifiedModuleReport) {
+    for (final library in modifiedModuleReport.modifiedLibraries) {
       // These will later be initialized by `libraryFor` if needed.
       _librariesById.remove(library);
       _libraryRefsById.remove(library);
     }
-    for (final library in invalidatedModuleReport.reloadedLibraries) {
+    for (final library in modifiedModuleReport.reloadedLibraries) {
       _libraryRefsById[library] = _createLibraryRef(library);
     }
   }

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -17,10 +17,10 @@ class LibraryHelper extends Domain {
   final Logger _logger = Logger('LibraryHelper');
 
   /// Map of library ID to [Library].
-  late final Map<String, Library> _librariesById;
+  final Map<String, Library> _librariesById = {};
 
   /// Map of libraryRef ID to [LibraryRef].
-  late final Map<String, LibraryRef> _libraryRefsById;
+  final Map<String, LibraryRef> _libraryRefsById = {};
 
   LibraryRef? _rootLib;
 
@@ -32,7 +32,7 @@ class LibraryHelper extends Domain {
   ///
   /// If [modifiedModuleReport] is not null, invalidates only modified libraries
   /// from the cache and recomputes values for any eager caches.
-  void initialize([ModifiedModuleReport? modifiedModuleReport]) {
+  void initialize({ModifiedModuleReport? modifiedModuleReport}) {
     _rootLib = null;
     if (modifiedModuleReport != null) {
       for (final library in modifiedModuleReport.modifiedLibraries) {
@@ -45,10 +45,10 @@ class LibraryHelper extends Domain {
         // map is empty before returning.
         _libraryRefsById[library] = _createLibraryRef(library);
       }
-    } else {
-      _librariesById = <String, Library>{};
-      _libraryRefsById = <String, LibraryRef>{};
+      return;
     }
+    _librariesById.clear();
+    _libraryRefsById.clear();
   }
 
   Future<LibraryRef> get rootLib async {

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -5,6 +5,7 @@
 import 'package:collection/collection.dart';
 import 'package:dwds/src/config/tool_configuration.dart';
 import 'package:dwds/src/debugging/metadata/class.dart';
+import 'package:dwds/src/debugging/metadata/provider.dart';
 import 'package:dwds/src/services/chrome_debug_exception.dart';
 import 'package:dwds/src/utilities/domain.dart';
 import 'package:logging/logging.dart';
@@ -51,9 +52,27 @@ class LibraryHelper extends Domain {
     return _rootLib!;
   }
 
+  void invalidate(InvalidatedModuleReport invalidatedModuleReport) {
+    final invalidatedLibraries = invalidatedModuleReport.deletedLibraries.union(
+      invalidatedModuleReport.reloadedLibraries,
+    );
+    for (final library in invalidatedLibraries) {
+      // These will later be initialized by `libraryFor` if needed.
+      _librariesById.remove(library);
+      _libraryRefsById.remove(library);
+    }
+    for (final library in invalidatedModuleReport.reloadedLibraries) {
+      _libraryRefsById[library] = _createLibraryRef(library);
+    }
+  }
+
+  LibraryRef _createLibraryRef(String library) =>
+      LibraryRef(id: library, name: library, uri: library);
+
   /// Returns all libraryRefs in the app.
   ///
-  /// Note this can return a cached result.
+  /// Note this can return a cached result that can be selectively reinitialized
+  /// using [invalidate].
   Future<List<LibraryRef>> get libraryRefs async {
     if (_libraryRefsById.isNotEmpty) return _libraryRefsById.values.toList();
     final libraries =
@@ -61,11 +80,7 @@ class LibraryHelper extends Domain {
             .metadataProviderFor(inspector.appConnection.request.entrypointPath)
             .libraries;
     for (final library in libraries) {
-      _libraryRefsById[library] = LibraryRef(
-        id: library,
-        name: library,
-        uri: library,
-      );
+      _libraryRefsById[library] = _createLibraryRef(library);
     }
     return _libraryRefsById.values.toList();
   }

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -52,6 +52,8 @@ class LibraryHelper extends Domain {
     return _rootLib!;
   }
 
+  /// Removes any modified libraries from the cache and either eagerly or lazily
+  /// computes values for the reloaded libraries in the [modifiedModuleReport].
   void invalidate(ModifiedModuleReport modifiedModuleReport) {
     for (final library in modifiedModuleReport.modifiedLibraries) {
       // These will later be initialized by `libraryFor` if needed.

--- a/dwds/lib/src/debugging/libraries.dart
+++ b/dwds/lib/src/debugging/libraries.dart
@@ -17,10 +17,10 @@ class LibraryHelper extends Domain {
   final Logger _logger = Logger('LibraryHelper');
 
   /// Map of library ID to [Library].
-  final Map<String, Library> _librariesById = {};
+  final _librariesById = <String, Library>{};
 
   /// Map of libraryRef ID to [LibraryRef].
-  final Map<String, LibraryRef> _libraryRefsById = {};
+  final _libraryRefsById = <String, LibraryRef>{};
 
   LibraryRef? _rootLib;
 

--- a/dwds/lib/src/debugging/location.dart
+++ b/dwds/lib/src/debugging/location.dart
@@ -171,10 +171,10 @@ class Locations {
         }
       }
     } else {
-      _sourceToTokenPosTable.clear();
       _locationMemoizer.clear();
-      _sourceToLocation.clear();
       _moduleToLocations.clear();
+      _sourceToTokenPosTable.clear();
+      _sourceToLocation.clear();
       _entrypoint = entrypoint;
     }
   }

--- a/dwds/lib/src/debugging/location.dart
+++ b/dwds/lib/src/debugging/location.dart
@@ -152,10 +152,14 @@ class Locations {
 
   Modules get modules => _modules;
 
+  /// Initialize any caches.
+  ///
+  /// If [modifiedModuleReport] is not null, only invalidates the caches for the
+  /// modified modules instead.
   Future<void> initialize(
-    String entrypoint, [
+    String entrypoint, {
     ModifiedModuleReport? modifiedModuleReport,
-  ]) async {
+  }) async {
     // If we know that only certain modules are deleted or added, we can only
     // invalidate those.
     if (modifiedModuleReport != null) {
@@ -170,13 +174,13 @@ class Locations {
           }
         }
       }
-    } else {
-      _locationMemoizer.clear();
-      _moduleToLocations.clear();
-      _sourceToTokenPosTable.clear();
-      _sourceToLocation.clear();
-      _entrypoint = entrypoint;
+      return;
     }
+    _locationMemoizer.clear();
+    _moduleToLocations.clear();
+    _sourceToTokenPosTable.clear();
+    _sourceToLocation.clear();
+    _entrypoint = entrypoint;
   }
 
   /// Returns all [Location] data for a provided Dart source.

--- a/dwds/lib/src/debugging/location.dart
+++ b/dwds/lib/src/debugging/location.dart
@@ -154,14 +154,12 @@ class Locations {
 
   Future<void> initialize(
     String entrypoint, [
-    InvalidatedModuleReport? invalidatedModuleReport,
+    ModifiedModuleReport? modifiedModuleReport,
   ]) async {
     // If we know that only certain modules are deleted or added, we can only
     // invalidate those.
-    if (invalidatedModuleReport != null) {
-      for (final module in invalidatedModuleReport.deletedModules.union(
-        invalidatedModuleReport.reloadedModules,
-      )) {
+    if (modifiedModuleReport != null) {
+      for (final module in modifiedModuleReport.modifiedModules) {
         _locationMemoizer.remove(module);
         _moduleToLocations.remove(module);
         final sources = await _modules.sourcesForModule(module);

--- a/dwds/lib/src/debugging/metadata/module_metadata.dart
+++ b/dwds/lib/src/debugging/metadata/module_metadata.dart
@@ -103,6 +103,8 @@ class ModuleMetadata {
   ///
   /// Used as a name of the js module created by the compiler and
   /// as key to store and load modules in the debugger and the browser
+  // TODO(srujzs): Remove once https://github.com/dart-lang/sdk/issues/59618 is
+  // resolved.
   final String name;
 
   /// Name of the function enclosing the module

--- a/dwds/lib/src/debugging/metadata/module_metadata.dart
+++ b/dwds/lib/src/debugging/metadata/module_metadata.dart
@@ -103,8 +103,6 @@ class ModuleMetadata {
   ///
   /// Used as a name of the js module created by the compiler and
   /// as key to store and load modules in the debugger and the browser
-  // TODO(srujzs): Remove once https://github.com/dart-lang/sdk/issues/59618 is
-  // resolved.
   final String name;
 
   /// Name of the function enclosing the module

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -344,10 +344,10 @@ class ModifiedModuleReport {
   /// Library uris that were loaded during the hot reload.
   final Set<String> reloadedLibraries;
 
-  /// Module names that were either removed or modified.
+  /// Module names that were either removed or modified, including additions.
   final Set<String> modifiedModules;
 
-  /// Library uris that were either removed or modified.
+  /// Library uris that were either removed or modified, including additions.
   final Set<String> modifiedLibraries;
   ModifiedModuleReport({
     required this.deletedModules,

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -202,7 +202,7 @@ class MetadataProvider {
             );
             final moduleName = metadata.name;
             if (hotReload) {
-              modules?[moduleName] = metadata;
+              modules![moduleName] = metadata;
             } else {
               _addMetadata(metadata);
             }
@@ -226,9 +226,9 @@ class MetadataProvider {
   /// determines deleted and invalidated libraries and modules, invalidates them
   /// in any caches, and recomputes the necessary information.
   ///
-  /// Returns an [InvalidatedModuleReport] that can be used to invalidate other
+  /// Returns an [ModifiedModuleReport] that can be used to invalidate other
   /// caches after a hot reload.
-  Future<InvalidatedModuleReport> reinitializeAfterReload(
+  Future<ModifiedModuleReport> reinitializeAfterReload(
     Map<String, List> reloadedModulesToLibraries,
   ) async {
     final modules = (await _processMetadata(true))!;
@@ -271,7 +271,7 @@ class MetadataProvider {
         invalidatedLibraries
             .where((library) => !_libraries.contains(library))
             .toSet();
-    return InvalidatedModuleReport(
+    return ModifiedModuleReport(
       deletedModules: deletedModules,
       deletedLibraries: deletedLibraries,
       reloadedModules: reloadedModules,
@@ -334,10 +334,10 @@ class AbsoluteImportUriException implements Exception {
 /// Computed after a hot reload using
 /// [MetadataProvider.reinitializeAfterReload], represents the modules and
 /// libraries in the program that were deleted, reloaded, and therefore,
-/// invalidated.
+/// modified.
 ///
 /// Used to recompute caches throughout DWDS.
-class InvalidatedModuleReport {
+class ModifiedModuleReport {
   /// Module names that are no longer in the program.
   final Set<String> deletedModules;
 
@@ -349,10 +349,17 @@ class InvalidatedModuleReport {
 
   /// Library uris that were loaded during the hot reload.
   final Set<String> reloadedLibraries;
-  InvalidatedModuleReport({
+
+  /// Module names that were either removed or modified.
+  final Set<String> modifiedModules;
+
+  /// Library uris that were either removed or modified.
+  final Set<String> modifiedLibraries;
+  ModifiedModuleReport({
     required this.deletedModules,
     required this.deletedLibraries,
     required this.reloadedModules,
     required this.reloadedLibraries,
-  });
+  }) : modifiedModules = deletedModules.union(reloadedModules),
+       modifiedLibraries = deletedLibraries.union(reloadedLibraries);
 }

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -76,19 +76,19 @@ class MetadataProvider {
     return true;
   }
 
-  /// A set of all libraries in the Dart application.
+  /// A list of all libraries in the Dart application.
   ///
   /// Example:
   ///
-  ///  {
+  ///  [
   ///     dart:web_gl,
   ///     dart:math,
   ///     org-dartlang-app:///web/main.dart
-  ///  }
+  ///  ]
   ///
-  Future<Set<String>> get libraries async {
+  Future<List<String>> get libraries async {
     await _initialize();
-    return _libraries;
+    return _libraries.toList();
   }
 
   /// A map of library uri to dart scripts.
@@ -226,9 +226,9 @@ class MetadataProvider {
   /// determines deleted and invalidated libraries and modules, invalidates them
   /// in any caches, and recomputes the necessary information.
   ///
-  /// Returns an [ModifiedModuleReport] that can be used to invalidate other
+  /// Returns a [ModifiedModuleReport] that can be used to invalidate other
   /// caches after a hot reload.
-  Future<ModifiedModuleReport> reinitializeAfterReload(
+  Future<ModifiedModuleReport> reinitializeAfterHotReload(
     Map<String, List> reloadedModulesToLibraries,
   ) async {
     final modules = (await _processMetadata(true))!;
@@ -265,7 +265,7 @@ class MetadataProvider {
       );
       _addMetadata(modules[module]!);
     }
-    // The libraries that were removed from the program or those that we
+    // The libraries that are removed from the program are those that we
     // invalidated but were never added again.
     final deletedLibraries =
         invalidatedLibraries
@@ -332,7 +332,7 @@ class AbsoluteImportUriException implements Exception {
 }
 
 /// Computed after a hot reload using
-/// [MetadataProvider.reinitializeAfterReload], represents the modules and
+/// [MetadataProvider.reinitializeAfterHotReload], represents the modules and
 /// libraries in the program that were deleted, reloaded, and therefore,
 /// modified.
 ///

--- a/dwds/lib/src/debugging/metadata/provider.dart
+++ b/dwds/lib/src/debugging/metadata/provider.dart
@@ -227,7 +227,7 @@ class MetadataProvider {
     }
 
     final deletedModules = <String>{};
-    final invalidatedModules = <String>{};
+    // final invalidatedModules = <String>{};
     for (final module in _moduleToLibraries.keys) {
       final deletedModule = !modules.containsKey(module);
       final invalidatedModule = reloadedModules.contains(module);
@@ -247,9 +247,9 @@ class MetadataProvider {
     }
     // The libraries that were removed from the program or those that we
     // invalidated but were never added again.
-    final deletedLibraries = invalidatedLibraries.where(
-      (library) => !_libraries.contains(library),
-    );
+    // final deletedLibraries = invalidatedLibraries.where(
+    //   (library) => !_libraries.contains(library),
+    // );
   }
 
   void _addMetadata(ModuleMetadata metadata) {

--- a/dwds/lib/src/debugging/modules.dart
+++ b/dwds/lib/src/debugging/modules.dart
@@ -38,9 +38,9 @@ class Modules {
   /// If [modifiedModuleReport] is not null, removes and recalculates caches for
   /// any modified modules and libraries.
   Future<void> initialize(
-    String entrypoint, [
+    String entrypoint, {
     ModifiedModuleReport? modifiedModuleReport,
-  ]) async {
+  }) async {
     if (modifiedModuleReport != null) {
       assert(_entrypoint == entrypoint);
       for (final library in modifiedModuleReport.modifiedLibraries) {
@@ -53,14 +53,14 @@ class Modules {
         _moduleToSources.remove(module);
       }
       await _initializeMapping(modifiedModuleReport);
-    } else {
-      _entrypoint = entrypoint;
-      _sourceToLibrary.clear();
-      _sourceToModule.clear();
-      _libraryToModule.clear();
-      _moduleToSources.clear();
-      _moduleMemoizer = AsyncMemoizer();
+      return;
     }
+    _entrypoint = entrypoint;
+    _sourceToLibrary.clear();
+    _sourceToModule.clear();
+    _libraryToModule.clear();
+    _moduleToSources.clear();
+    _moduleMemoizer = AsyncMemoizer();
   }
 
   /// Returns the containing module for the provided Dart server path.

--- a/dwds/lib/src/debugging/modules.dart
+++ b/dwds/lib/src/debugging/modules.dart
@@ -99,7 +99,8 @@ class Modules {
     final serverPath = await globalToolConfiguration.loadStrategy
         .serverPathForModule(entrypoint, module);
     // TODO(srujzs): We should wait until all scripts are parsed before
-    // accessing.
+    // accessing after a hot reload. See
+    // https://github.com/dart-lang/webdev/issues/2640.
     return chromePathToRuntimeScriptId[serverPath];
   }
 

--- a/dwds/lib/src/debugging/modules.dart
+++ b/dwds/lib/src/debugging/modules.dart
@@ -124,10 +124,10 @@ class Modules {
     final scriptToModule = await provider.scriptToModule;
 
     for (final library in libraryToScripts.keys) {
-      if (modifiedModuleReport != null) {
+      if (modifiedModuleReport?.modifiedLibraries.contains(library) == false) {
         // Note that every module will have at least one library associated with
         // it, so it's okay to only process the modified libraries.
-        if (!modifiedModuleReport.modifiedLibraries.contains(library)) continue;
+        continue;
       }
       final scripts = libraryToScripts[library]!;
       final libraryServerPath = _getLibraryServerPath(library);

--- a/dwds/lib/src/debugging/modules.dart
+++ b/dwds/lib/src/debugging/modules.dart
@@ -54,12 +54,12 @@ class Modules {
       }
       await _initializeMapping(modifiedModuleReport);
     } else {
-      _sourceToModule.clear();
-      _moduleToSources.clear();
-      _sourceToLibrary.clear();
-      _libraryToModule.clear();
-      _moduleMemoizer = AsyncMemoizer();
       _entrypoint = entrypoint;
+      _sourceToLibrary.clear();
+      _sourceToModule.clear();
+      _libraryToModule.clear();
+      _moduleToSources.clear();
+      _moduleMemoizer = AsyncMemoizer();
     }
   }
 

--- a/dwds/lib/src/debugging/skip_list.dart
+++ b/dwds/lib/src/debugging/skip_list.dart
@@ -25,14 +25,13 @@ class SkipLists {
     if (modifiedModuleReport != null) {
       assert(entrypoint != null);
       for (final url in _urlToId.keys) {
-        if (url.isEmpty) continue;
-
         final dartUri = DartUri(url, _root);
         final serverPath = dartUri.serverPath;
         final module = await globalToolConfiguration.loadStrategy
             .moduleForServerPath(entrypoint!, serverPath);
         if (modifiedModuleReport.modifiedModules.contains(module)) {
           _idToList.remove(_urlToId[url]!);
+          _urlToId.remove(url);
         }
       }
     } else {
@@ -51,7 +50,6 @@ class SkipLists {
     String url,
     Set<Location> locations,
   ) {
-    _urlToId[url] = scriptId;
     if (_idToList.containsKey(scriptId)) return _idToList[scriptId]!;
 
     final sortedLocations =
@@ -82,7 +80,10 @@ class SkipLists {
     }
     ranges.add(_rangeFor(scriptId, startLine, startColumn, maxValue, maxValue));
 
-    _idToList[scriptId] = ranges;
+    if (url.isNotEmpty) {
+      _idToList[scriptId] = ranges;
+      _urlToId[url] = scriptId;
+    }
     return ranges;
   }
 

--- a/dwds/lib/src/debugging/skip_list.dart
+++ b/dwds/lib/src/debugging/skip_list.dart
@@ -36,6 +36,7 @@ class SkipLists {
       }
     } else {
       _idToList.clear();
+      _urlToId.clear();
     }
   }
 

--- a/dwds/lib/src/debugging/skip_list.dart
+++ b/dwds/lib/src/debugging/skip_list.dart
@@ -18,26 +18,29 @@ class SkipLists {
 
   SkipLists(this._root);
 
-  Future<void> initialize([
-    String? entrypoint,
+  /// Initialize any caches.
+  ///
+  /// If [modifiedModuleReport] is not null, only invalidates the caches for the
+  /// modified modules instead.
+  Future<void> initialize(
+    String entrypoint, {
     ModifiedModuleReport? modifiedModuleReport,
-  ]) async {
+  }) async {
     if (modifiedModuleReport != null) {
-      assert(entrypoint != null);
       for (final url in _urlToId.keys) {
         final dartUri = DartUri(url, _root);
         final serverPath = dartUri.serverPath;
         final module = await globalToolConfiguration.loadStrategy
-            .moduleForServerPath(entrypoint!, serverPath);
+            .moduleForServerPath(entrypoint, serverPath);
         if (modifiedModuleReport.modifiedModules.contains(module)) {
           _idToList.remove(_urlToId[url]!);
           _urlToId.remove(url);
         }
       }
-    } else {
-      _idToList.clear();
-      _urlToId.clear();
+      return;
     }
+    _idToList.clear();
+    _urlToId.clear();
   }
 
   /// Returns a skipList as defined by the Chrome DevTools Protocol.

--- a/dwds/lib/src/debugging/skip_list.dart
+++ b/dwds/lib/src/debugging/skip_list.dart
@@ -20,13 +20,10 @@ class SkipLists {
 
   Future<void> initialize([
     String? entrypoint,
-    InvalidatedModuleReport? invalidatedModuleReport,
+    ModifiedModuleReport? modifiedModuleReport,
   ]) async {
-    if (invalidatedModuleReport != null) {
+    if (modifiedModuleReport != null) {
       assert(entrypoint != null);
-      final invalidatedModules = invalidatedModuleReport.deletedModules.union(
-        invalidatedModuleReport.reloadedModules,
-      );
       for (final url in _urlToId.keys) {
         if (url.isEmpty) continue;
 
@@ -34,7 +31,7 @@ class SkipLists {
         final serverPath = dartUri.serverPath;
         final module = await globalToolConfiguration.loadStrategy
             .moduleForServerPath(entrypoint!, serverPath);
-        if (invalidatedModules.contains(module)) {
+        if (modifiedModuleReport.modifiedModules.contains(module)) {
           _idToList.remove(_urlToId[url]!);
         }
       }

--- a/dwds/lib/src/injected/client.js
+++ b/dwds/lib/src/injected/client.js
@@ -21651,6 +21651,7 @@
     },
     deserialize$3$specifiedType(serializers, serialized, specifiedType) {
       var t1, t2, value, $$v, _$result,
+        _s11_ = "BuildResult",
         result = new A.BuildResultBuilder(),
         iterator = J.get$iterator$ax(type$.Iterable_nullable_Object._as(serialized));
       for (t1 = type$.BuildStatus; iterator.moveNext$0();) {
@@ -21674,7 +21675,13 @@
         }
       }
       _$result = result._build_result$_$v;
-      return result._build_result$_$v = _$result == null ? new A._$BuildResult(A.BuiltValueNullFieldError_checkNotNull(result.get$_build_result$_$this()._status, "BuildResult", "status", t1)) : _$result;
+      if (_$result == null) {
+        t2 = A.BuiltValueNullFieldError_checkNotNull(result.get$_build_result$_$this()._status, _s11_, "status", t1);
+        _$result = new A._$BuildResult(t2);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s11_, "status", t1);
+      }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.BuildResult);
+      return result._build_result$_$v = _$result;
     },
     deserialize$2(serializers, serialized) {
       return this.deserialize$3$specifiedType(serializers, serialized, B.FullType_null_List_empty_false);
@@ -21805,13 +21812,22 @@
       return _this;
     },
     _connect_request$_build$0() {
-      var t1, _this = this,
+      var t1, t2, t3, t4, _this = this,
         _s14_ = "ConnectRequest",
+        _s10_ = "instanceId",
+        _s14_0 = "entrypointPath",
         _$result = _this._connect_request$_$v;
       if (_$result == null) {
         t1 = type$.String;
-        _$result = new A._$ConnectRequest(A.BuiltValueNullFieldError_checkNotNull(_this.get$_connect_request$_$this()._connect_request$_appId, _s14_, "appId", t1), A.BuiltValueNullFieldError_checkNotNull(_this.get$_connect_request$_$this()._instanceId, _s14_, "instanceId", t1), A.BuiltValueNullFieldError_checkNotNull(_this.get$_connect_request$_$this()._entrypointPath, _s14_, "entrypointPath", t1));
+        t2 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_connect_request$_$this()._connect_request$_appId, _s14_, "appId", t1);
+        t3 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_connect_request$_$this()._instanceId, _s14_, _s10_, t1);
+        t4 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_connect_request$_$this()._entrypointPath, _s14_, _s14_0, t1);
+        _$result = new A._$ConnectRequest(t2, t3, t4);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s14_, "appId", t1);
+        A.BuiltValueNullFieldError_checkNotNull(t3, _s14_, _s10_, t1);
+        A.BuiltValueNullFieldError_checkNotNull(t4, _s14_, _s14_0, t1);
       }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.ConnectRequest);
       return _this._connect_request$_$v = _$result;
     }
   };
@@ -21976,13 +21992,23 @@
       return _this;
     },
     _debug_event$_build$0() {
-      var t1, _this = this,
+      var t1, t2, t3, t4, t5, _this = this,
         _s10_ = "DebugEvent",
+        _s9_ = "eventData",
+        _s9_0 = "timestamp",
         _$result = _this._debug_event$_$v;
       if (_$result == null) {
         t1 = type$.String;
-        _$result = new A._$DebugEvent(A.BuiltValueNullFieldError_checkNotNull(_this.get$_debug_event$_$this()._debug_event$_kind, _s10_, "kind", t1), A.BuiltValueNullFieldError_checkNotNull(_this.get$_debug_event$_$this()._eventData, _s10_, "eventData", t1), A.BuiltValueNullFieldError_checkNotNull(_this.get$_debug_event$_$this()._timestamp, _s10_, "timestamp", type$.int));
+        t2 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_debug_event$_$this()._debug_event$_kind, _s10_, "kind", t1);
+        t3 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_debug_event$_$this()._eventData, _s10_, _s9_, t1);
+        t4 = type$.int;
+        t5 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_debug_event$_$this()._timestamp, _s10_, _s9_0, t4);
+        _$result = new A._$DebugEvent(t2, t3, t5);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s10_, "kind", t1);
+        A.BuiltValueNullFieldError_checkNotNull(t3, _s10_, _s9_, t1);
+        A.BuiltValueNullFieldError_checkNotNull(t5, _s10_, _s9_0, t4);
       }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.DebugEvent);
       return _this._debug_event$_$v = _$result;
     }
   };
@@ -22027,10 +22053,17 @@
       return _this;
     },
     _debug_event$_build$0() {
-      var _$failedField, e, _$result0, exception, t1, _this = this, _$result = null;
+      var _$failedField, e, _$result0, t1, exception, t2, _this = this,
+        _s18_ = "BatchedDebugEvents",
+        _$result = null;
       try {
         _$result0 = _this._debug_event$_$v;
-        _$result = _$result0 == null ? new A._$BatchedDebugEvents(_this.get$events().build$0()) : _$result0;
+        if (_$result0 == null) {
+          t1 = _this.get$events().build$0();
+          _$result0 = new A._$BatchedDebugEvents(t1);
+          A.BuiltValueNullFieldError_checkNotNull(t1, _s18_, "events", type$.BuiltList_DebugEvent);
+        }
+        _$result = _$result0;
       } catch (exception) {
         _$failedField = A._Cell$named("_$failedField");
         try {
@@ -22038,12 +22071,15 @@
           _this.get$events().build$0();
         } catch (exception) {
           e = A.unwrapException(exception);
-          t1 = A.BuiltValueNestedFieldError$("BatchedDebugEvents", _$failedField.readLocal$0(), J.toString$0$(e));
+          t1 = A.BuiltValueNestedFieldError$(_s18_, _$failedField.readLocal$0(), J.toString$0$(e));
           throw A.wrapException(t1);
         }
         throw exception;
       }
-      _this._debug_event$_$v = type$.BatchedDebugEvents._as(_$result);
+      t1 = type$.BatchedDebugEvents;
+      t2 = t1._as(_$result);
+      A.ArgumentError_checkNotNull(t2, "other", t1);
+      _this._debug_event$_$v = t2;
       return _$result;
     },
     set$_events(_events) {
@@ -22263,7 +22299,10 @@
     _build$0() {
       var _this = this,
         _$result = _this._$v;
-      return _this._$v = _$result == null ? new A._$DebugInfo(_this.get$_$this()._appEntrypointPath, _this.get$_$this()._appId, _this.get$_$this()._appInstanceId, _this.get$_$this()._appOrigin, _this.get$_$this()._appUrl, _this.get$_$this()._authUrl, _this.get$_$this()._dwdsVersion, _this.get$_$this()._extensionUrl, _this.get$_$this()._isInternalBuild, _this.get$_$this()._isFlutterApp, _this.get$_$this()._workspaceName, _this.get$_$this()._tabUrl, _this.get$_$this()._tabId) : _$result;
+      if (_$result == null)
+        _$result = new A._$DebugInfo(_this.get$_$this()._appEntrypointPath, _this.get$_$this()._appId, _this.get$_$this()._appInstanceId, _this.get$_$this()._appOrigin, _this.get$_$this()._appUrl, _this.get$_$this()._authUrl, _this.get$_$this()._dwdsVersion, _this.get$_$this()._extensionUrl, _this.get$_$this()._isInternalBuild, _this.get$_$this()._isFlutterApp, _this.get$_$this()._workspaceName, _this.get$_$this()._tabUrl, _this.get$_$this()._tabId);
+      A.ArgumentError_checkNotNull(_$result, "other", type$.DebugInfo);
+      return _this._$v = _$result;
     }
   };
   A.DevToolsRequest.prototype = {};
@@ -22369,7 +22408,8 @@
       return this.serialize$3$specifiedType(serializers, object, B.FullType_null_List_empty_false);
     },
     deserialize$3$specifiedType(serializers, serialized, specifiedType) {
-      var t1, value, _$result,
+      var t1, value, _$result, t2, t3,
+        _s15_ = "promptExtension",
         _s16_ = "DevToolsResponse",
         result = new A.DevToolsResponseBuilder(),
         iterator = J.get$iterator$ax(type$.Iterable_nullable_Object._as(serialized));
@@ -22401,8 +22441,13 @@
       _$result = result._devtools_request$_$v;
       if (_$result == null) {
         t1 = type$.bool;
-        _$result = new A._$DevToolsResponse(A.BuiltValueNullFieldError_checkNotNull(result.get$_devtools_request$_$this()._success, _s16_, "success", t1), A.BuiltValueNullFieldError_checkNotNull(result.get$_devtools_request$_$this()._promptExtension, _s16_, "promptExtension", t1), result.get$_devtools_request$_$this()._error);
+        t2 = A.BuiltValueNullFieldError_checkNotNull(result.get$_devtools_request$_$this()._success, _s16_, "success", t1);
+        t3 = A.BuiltValueNullFieldError_checkNotNull(result.get$_devtools_request$_$this()._promptExtension, _s16_, _s15_, t1);
+        _$result = new A._$DevToolsResponse(t2, t3, result.get$_devtools_request$_$this()._error);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s16_, "success", t1);
+        A.BuiltValueNullFieldError_checkNotNull(t3, _s16_, _s15_, t1);
       }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.DevToolsResponse);
       return result._devtools_request$_$v = _$result;
     },
     deserialize$2(serializers, serialized) {
@@ -22459,13 +22504,19 @@
       return _this;
     },
     _devtools_request$_build$0() {
-      var t1, _this = this,
+      var t1, t2, t3, _this = this,
         _s15_ = "DevToolsRequest",
+        _s10_ = "instanceId",
         _$result = _this._devtools_request$_$v;
       if (_$result == null) {
         t1 = type$.String;
-        _$result = new A._$DevToolsRequest(A.BuiltValueNullFieldError_checkNotNull(_this.get$_devtools_request$_$this()._devtools_request$_appId, _s15_, "appId", t1), A.BuiltValueNullFieldError_checkNotNull(_this.get$_devtools_request$_$this()._devtools_request$_instanceId, _s15_, "instanceId", t1), _this.get$_devtools_request$_$this()._contextId, _this.get$_devtools_request$_$this()._devtools_request$_tabUrl, _this.get$_devtools_request$_$this()._uriOnly, _this.get$_devtools_request$_$this()._devtools_request$_client);
+        t2 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_devtools_request$_$this()._devtools_request$_appId, _s15_, "appId", t1);
+        t3 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_devtools_request$_$this()._devtools_request$_instanceId, _s15_, _s10_, t1);
+        _$result = new A._$DevToolsRequest(t2, t3, _this.get$_devtools_request$_$this()._contextId, _this.get$_devtools_request$_$this()._devtools_request$_tabUrl, _this.get$_devtools_request$_$this()._uriOnly, _this.get$_devtools_request$_$this()._devtools_request$_client);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s15_, "appId", t1);
+        A.BuiltValueNullFieldError_checkNotNull(t3, _s15_, _s10_, t1);
       }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.DevToolsRequest);
       return _this._devtools_request$_$v = _$result;
     }
   };
@@ -22516,7 +22567,8 @@
       return this.serialize$3$specifiedType(serializers, object, B.FullType_null_List_empty_false);
     },
     deserialize$3$specifiedType(serializers, serialized, specifiedType) {
-      var t1, value, $$v, _$result,
+      var t1, value, $$v, _$result, t2, t3,
+        _s10_ = "stackTrace",
         _s13_ = "ErrorResponse",
         result = new A.ErrorResponseBuilder(),
         iterator = J.get$iterator$ax(type$.Iterable_nullable_Object._as(serialized));
@@ -22556,8 +22608,13 @@
       _$result = result._error_response$_$v;
       if (_$result == null) {
         t1 = type$.String;
-        _$result = new A._$ErrorResponse(A.BuiltValueNullFieldError_checkNotNull(result.get$_error_response$_$this()._error_response$_error, _s13_, "error", t1), A.BuiltValueNullFieldError_checkNotNull(result.get$_error_response$_$this()._error_response$_stackTrace, _s13_, "stackTrace", t1));
+        t2 = A.BuiltValueNullFieldError_checkNotNull(result.get$_error_response$_$this()._error_response$_error, _s13_, "error", t1);
+        t3 = A.BuiltValueNullFieldError_checkNotNull(result.get$_error_response$_$this()._error_response$_stackTrace, _s13_, _s10_, t1);
+        _$result = new A._$ErrorResponse(t2, t3);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s13_, "error", t1);
+        A.BuiltValueNullFieldError_checkNotNull(t3, _s13_, _s10_, t1);
       }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.ErrorResponse);
       return result._error_response$_$v = _$result;
     },
     deserialize$2(serializers, serialized) {
@@ -22623,7 +22680,7 @@
       return this.serialize$3$specifiedType(serializers, object, B.FullType_null_List_empty_false);
     },
     deserialize$3$specifiedType(serializers, serialized, specifiedType) {
-      var t1, value, _$result,
+      var t1, value, _$result, t2, t3, t4,
         _s16_ = "ExtensionRequest",
         result = new A.ExtensionRequestBuilder(),
         iterator = J.get$iterator$ax(type$.Iterable_nullable_Object._as(serialized));
@@ -22653,7 +22710,17 @@
         }
       }
       _$result = result._extension_request$_$v;
-      return result._extension_request$_$v = _$result == null ? new A._$ExtensionRequest(A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._id, _s16_, "id", type$.int), A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._command, _s16_, "command", type$.String), result.get$_extension_request$_$this()._commandParams) : _$result;
+      if (_$result == null) {
+        t1 = type$.int;
+        t2 = A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._id, _s16_, "id", t1);
+        t3 = type$.String;
+        t4 = A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._command, _s16_, "command", t3);
+        _$result = new A._$ExtensionRequest(t2, t4, result.get$_extension_request$_$this()._commandParams);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s16_, "id", t1);
+        A.BuiltValueNullFieldError_checkNotNull(t4, _s16_, "command", t3);
+      }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.ExtensionRequest);
+      return result._extension_request$_$v = _$result;
     },
     deserialize$2(serializers, serialized) {
       return this.deserialize$3$specifiedType(serializers, serialized, B.FullType_null_List_empty_false);
@@ -22683,7 +22750,7 @@
       return this.serialize$3$specifiedType(serializers, object, B.FullType_null_List_empty_false);
     },
     deserialize$3$specifiedType(serializers, serialized, specifiedType) {
-      var t1, value, _$result,
+      var t1, value, _$result, t2, t3, t4, t5, t6,
         _s17_ = "ExtensionResponse",
         result = new A.ExtensionResponseBuilder(),
         iterator = J.get$iterator$ax(type$.Iterable_nullable_Object._as(serialized));
@@ -22719,7 +22786,20 @@
         }
       }
       _$result = result._extension_request$_$v;
-      return result._extension_request$_$v = _$result == null ? new A._$ExtensionResponse(A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._id, _s17_, "id", type$.int), A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._extension_request$_success, _s17_, "success", type$.bool), A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._extension_request$_result, _s17_, "result", type$.String), result.get$_extension_request$_$this()._extension_request$_error) : _$result;
+      if (_$result == null) {
+        t1 = type$.int;
+        t2 = A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._id, _s17_, "id", t1);
+        t3 = type$.bool;
+        t4 = A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._extension_request$_success, _s17_, "success", t3);
+        t5 = type$.String;
+        t6 = A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._extension_request$_result, _s17_, "result", t5);
+        _$result = new A._$ExtensionResponse(t2, t4, t6, result.get$_extension_request$_$this()._extension_request$_error);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s17_, "id", t1);
+        A.BuiltValueNullFieldError_checkNotNull(t4, _s17_, "success", t3);
+        A.BuiltValueNullFieldError_checkNotNull(t6, _s17_, "result", t5);
+      }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.ExtensionResponse);
+      return result._extension_request$_$v = _$result;
     },
     deserialize$2(serializers, serialized) {
       return this.deserialize$3$specifiedType(serializers, serialized, B.FullType_null_List_empty_false);
@@ -22742,7 +22822,7 @@
       return this.serialize$3$specifiedType(serializers, object, B.FullType_null_List_empty_false);
     },
     deserialize$3$specifiedType(serializers, serialized, specifiedType) {
-      var t1, value, $$v, _$result,
+      var t1, value, $$v, _$result, t2, t3,
         _s14_ = "ExtensionEvent",
         result = new A.ExtensionEventBuilder(),
         iterator = J.get$iterator$ax(type$.Iterable_nullable_Object._as(serialized));
@@ -22782,8 +22862,13 @@
       _$result = result._extension_request$_$v;
       if (_$result == null) {
         t1 = type$.String;
-        _$result = new A._$ExtensionEvent(A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._params, _s14_, "params", t1), A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._extension_request$_method, _s14_, "method", t1));
+        t2 = A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._params, _s14_, "params", t1);
+        t3 = A.BuiltValueNullFieldError_checkNotNull(result.get$_extension_request$_$this()._extension_request$_method, _s14_, "method", t1);
+        _$result = new A._$ExtensionEvent(t2, t3);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s14_, "params", t1);
+        A.BuiltValueNullFieldError_checkNotNull(t3, _s14_, "method", t1);
       }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.ExtensionEvent);
       return result._extension_request$_$v = _$result;
     },
     deserialize$2(serializers, serialized) {
@@ -23019,10 +23104,17 @@
       return t1;
     },
     _extension_request$_build$0() {
-      var _$failedField, e, _$result0, exception, t1, _this = this, _$result = null;
+      var _$failedField, e, _$result0, t1, exception, t2, _this = this,
+        _s13_ = "BatchedEvents",
+        _$result = null;
       try {
         _$result0 = _this._extension_request$_$v;
-        _$result = _$result0 == null ? new A._$BatchedEvents(_this.get$events().build$0()) : _$result0;
+        if (_$result0 == null) {
+          t1 = _this.get$events().build$0();
+          _$result0 = new A._$BatchedEvents(t1);
+          A.BuiltValueNullFieldError_checkNotNull(t1, _s13_, "events", type$.BuiltList_ExtensionEvent);
+        }
+        _$result = _$result0;
       } catch (exception) {
         _$failedField = A._Cell$named("_$failedField");
         try {
@@ -23030,12 +23122,15 @@
           _this.get$events().build$0();
         } catch (exception) {
           e = A.unwrapException(exception);
-          t1 = A.BuiltValueNestedFieldError$("BatchedEvents", _$failedField.readLocal$0(), J.toString$0$(e));
+          t1 = A.BuiltValueNestedFieldError$(_s13_, _$failedField.readLocal$0(), J.toString$0$(e));
           throw A.wrapException(t1);
         }
         throw exception;
       }
-      _this._extension_request$_$v = type$.BatchedEvents._as(_$result);
+      t1 = type$.BatchedEvents;
+      t2 = t1._as(_$result);
+      A.ArgumentError_checkNotNull(t2, "other", t1);
+      _this._extension_request$_$v = t2;
       return _$result;
     },
     set$_extension_request$_events(_events) {
@@ -23051,7 +23146,8 @@
       return this.serialize$3$specifiedType(serializers, object, B.FullType_null_List_empty_false);
     },
     deserialize$3$specifiedType(serializers, serialized, specifiedType) {
-      var t1, value, $$v, _$result,
+      var t1, value, $$v, _$result, t2,
+        _s16_ = "HotReloadRequest",
         result = new A.HotReloadRequestBuilder(),
         iterator = J.get$iterator$ax(type$.Iterable_nullable_Object._as(serialized));
       for (; iterator.moveNext$0();) {
@@ -23075,7 +23171,14 @@
         }
       }
       _$result = result._hot_reload_request$_$v;
-      return result._hot_reload_request$_$v = _$result == null ? new A._$HotReloadRequest(A.BuiltValueNullFieldError_checkNotNull(result.get$_hot_reload_request$_$this()._hot_reload_request$_id, "HotReloadRequest", "id", type$.String)) : _$result;
+      if (_$result == null) {
+        t1 = type$.String;
+        t2 = A.BuiltValueNullFieldError_checkNotNull(result.get$_hot_reload_request$_$this()._hot_reload_request$_id, _s16_, "id", t1);
+        _$result = new A._$HotReloadRequest(t2);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s16_, "id", t1);
+      }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.HotReloadRequest);
+      return result._hot_reload_request$_$v = _$result;
     },
     deserialize$2(serializers, serialized) {
       return this.deserialize$3$specifiedType(serializers, serialized, B.FullType_null_List_empty_false);
@@ -23223,10 +23326,20 @@
       return _this;
     },
     _hot_reload_response$_build$0() {
-      var _this = this,
+      var t1, t2, t3, t4, _this = this,
         _s17_ = "HotReloadResponse",
         _$result = _this._hot_reload_response$_$v;
-      return _this._hot_reload_response$_$v = _$result == null ? new A._$HotReloadResponse(A.BuiltValueNullFieldError_checkNotNull(_this.get$_hot_reload_response$_$this()._hot_reload_response$_id, _s17_, "id", type$.String), A.BuiltValueNullFieldError_checkNotNull(_this.get$_hot_reload_response$_$this()._hot_reload_response$_success, _s17_, "success", type$.bool), _this.get$_hot_reload_response$_$this()._errorMessage) : _$result;
+      if (_$result == null) {
+        t1 = type$.String;
+        t2 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_hot_reload_response$_$this()._hot_reload_response$_id, _s17_, "id", t1);
+        t3 = type$.bool;
+        t4 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_hot_reload_response$_$this()._hot_reload_response$_success, _s17_, "success", t3);
+        _$result = new A._$HotReloadResponse(t2, t4, _this.get$_hot_reload_response$_$this()._errorMessage);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s17_, "id", t1);
+        A.BuiltValueNullFieldError_checkNotNull(t4, _s17_, "success", t3);
+      }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.HotReloadResponse);
+      return _this._hot_reload_response$_$v = _$result;
     }
   };
   A.IsolateExit.prototype = {};
@@ -23297,7 +23410,10 @@
   A.IsolateExitBuilder.prototype = {
     _isolate_events$_build$0() {
       var _$result = this._isolate_events$_$v;
-      return this._isolate_events$_$v = _$result == null ? new A._$IsolateExit() : _$result;
+      if (_$result == null)
+        _$result = new A._$IsolateExit();
+      A.ArgumentError_checkNotNull(_$result, "other", type$.IsolateExit);
+      return this._isolate_events$_$v = _$result;
     }
   };
   A._$IsolateStart.prototype = {
@@ -23318,7 +23434,10 @@
   A.IsolateStartBuilder.prototype = {
     _isolate_events$_build$0() {
       var _$result = this._isolate_events$_$v;
-      return this._isolate_events$_$v = _$result == null ? new A._$IsolateStart() : _$result;
+      if (_$result == null)
+        _$result = new A._$IsolateStart();
+      A.ArgumentError_checkNotNull(_$result, "other", type$.IsolateStart);
+      return this._isolate_events$_$v = _$result;
     }
   };
   A.RegisterEvent.prototype = {};
@@ -23412,10 +23531,22 @@
       return _this;
     },
     _register_event$_build$0() {
-      var _this = this,
+      var t1, t2, t3, t4, _this = this,
         _s13_ = "RegisterEvent",
+        _s9_ = "eventData",
+        _s9_0 = "timestamp",
         _$result = _this._register_event$_$v;
-      return _this._register_event$_$v = _$result == null ? new A._$RegisterEvent(A.BuiltValueNullFieldError_checkNotNull(_this.get$_register_event$_$this()._register_event$_eventData, _s13_, "eventData", type$.String), A.BuiltValueNullFieldError_checkNotNull(_this.get$_register_event$_$this()._register_event$_timestamp, _s13_, "timestamp", type$.int)) : _$result;
+      if (_$result == null) {
+        t1 = type$.String;
+        t2 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_register_event$_$this()._register_event$_eventData, _s13_, _s9_, t1);
+        t3 = type$.int;
+        t4 = A.BuiltValueNullFieldError_checkNotNull(_this.get$_register_event$_$this()._register_event$_timestamp, _s13_, _s9_0, t3);
+        _$result = new A._$RegisterEvent(t2, t4);
+        A.BuiltValueNullFieldError_checkNotNull(t2, _s13_, _s9_, t1);
+        A.BuiltValueNullFieldError_checkNotNull(t4, _s13_, _s9_0, t3);
+      }
+      A.ArgumentError_checkNotNull(_$result, "other", type$.RegisterEvent);
+      return _this._register_event$_$v = _$result;
     }
   };
   A.RunRequest.prototype = {};
@@ -23428,8 +23559,11 @@
       return this.serialize$3$specifiedType(serializers, object, B.FullType_null_List_empty_false);
     },
     deserialize$3$specifiedType(serializers, serialized, specifiedType) {
+      var _$result;
       type$.Iterable_nullable_Object._as(serialized);
-      return new A._$RunRequest();
+      _$result = new A._$RunRequest();
+      A.ArgumentError_checkNotNull(_$result, "other", type$.RunRequest);
+      return _$result;
     },
     deserialize$2(serializers, serialized) {
       return this.deserialize$3$specifiedType(serializers, serialized, B.FullType_null_List_empty_false);
@@ -26745,7 +26879,7 @@
   };
   A.main__closure.prototype = {
     call$0() {
-      return A.FutureOfJSAnyToJSPromise_get_toJS(this.manager._restarter.hotReloadStart$1(A.hotReloadSourcesPath()), type$.JSArray_nullable_Object);
+      return A.FutureOfJSAnyToJSPromise_get_toJS(this.manager._restarter.hotReloadStart$1(A.hotReloadSourcesPath()), type$.JSObject);
     },
     $signature: 10
   };
@@ -27162,8 +27296,8 @@
     },
     hotReloadStart$1(hotReloadSourcesPath) {
       var $async$goto = 0,
-        $async$completer = A._makeAsyncAwaitCompleter(type$.JSArray_nullable_Object),
-        $async$returnValue, $async$self = this, t4, srcLibraries, filesToLoad, librariesToReload, t5, t6, srcLibraryCast, libraries, t7, t1, t2, t3, xhr, $async$temp1, $async$temp2, $async$temp3;
+        $async$completer = A._makeAsyncAwaitCompleter(type$.JSObject),
+        $async$returnValue, $async$self = this, t4, srcModuleLibraries, filesToLoad, _this, librariesToReload, t5, t6, srcModuleLibraryCast, module, libraries, t7, t1, t2, t3, xhr, $async$temp1, $async$temp2, $async$temp3;
       var $async$hotReloadStart$1 = A._wrapJsFunctionForAsync(function($async$errorCode, $async$result) {
         if ($async$errorCode === 1)
           return A._asyncRethrow($async$result, $async$completer);
@@ -27187,14 +27321,17 @@
               return A._asyncAwait(t1, $async$hotReloadStart$1);
             case 3:
               // returning from await.
-              srcLibraries = $async$temp1.cast$1$0$ax($async$temp2._as($async$temp3.decode$1($async$result)), type$.Map_dynamic_dynamic);
+              srcModuleLibraries = $async$temp1.cast$1$0$ax($async$temp2._as($async$temp3.decode$1($async$result)), type$.Map_dynamic_dynamic);
               t1 = type$.JSArray_nullable_Object;
               filesToLoad = t1._as(new t2.Array());
+              _this = {};
               librariesToReload = t1._as(new t2.Array());
-              for (t1 = srcLibraries.get$iterator(srcLibraries), t5 = type$.String, t6 = type$.Object; t1.moveNext$0();) {
-                srcLibraryCast = t1.get$current().cast$2$0(0, t5, t6);
-                filesToLoad.push(A._asString(srcLibraryCast.$index(0, "src")));
-                libraries = J.cast$1$0$ax(t4._as(srcLibraryCast.$index(0, "libraries")), t5);
+              for (t1 = srcModuleLibraries.get$iterator(srcModuleLibraries), t5 = type$.String, t6 = type$.Object; t1.moveNext$0();) {
+                srcModuleLibraryCast = t1.get$current().cast$2$0(0, t5, t6);
+                filesToLoad.push(A._asString(srcModuleLibraryCast.$index(0, "src")));
+                module = A._asString(srcModuleLibraryCast.$index(0, "module"));
+                libraries = J.cast$1$0$ax(t4._as(srcModuleLibraryCast.$index(0, "libraries")), t5);
+                _this[module] = A.jsify(libraries);
                 for (t7 = libraries.get$iterator(libraries); t7.moveNext$0();)
                   librariesToReload.push(t7.get$current());
               }
@@ -27203,7 +27340,7 @@
               return A._asyncAwait(A.promiseToFuture(t3._as(t3._as(t2.dartDevEmbedder).hotReload(filesToLoad, librariesToReload)), type$.nullable_Object), $async$hotReloadStart$1);
             case 4:
               // returning from await.
-              $async$returnValue = librariesToReload;
+              $async$returnValue = _this;
               // goto return
               $async$goto = 1;
               break;
@@ -28101,6 +28238,8 @@
       BuildResult: findType("BuildResult"),
       BuildStatus: findType("BuildStatus"),
       BuiltListMultimap_dynamic_dynamic: findType("BuiltListMultimap<@,@>"),
+      BuiltList_DebugEvent: findType("BuiltList<DebugEvent>"),
+      BuiltList_ExtensionEvent: findType("BuiltList<ExtensionEvent>"),
       BuiltList_dynamic: findType("BuiltList<@>"),
       BuiltList_nullable_Object: findType("BuiltList<Object?>"),
       BuiltMap_dynamic_dynamic: findType("BuiltMap<@,@>"),

--- a/dwds/lib/src/loaders/ddc_library_bundle.dart
+++ b/dwds/lib/src/loaders/ddc_library_bundle.dart
@@ -223,10 +223,4 @@ window.\$dartLoader.loader.nextAttempt();
 
   @override
   String? g3RelativePath(String absolutePath) => _g3RelativePath(absolutePath);
-
-  @override
-  MetadataProvider createProvider(String entrypoint, AssetReader reader) =>
-  // DDC library bundle format does not provide module names in the module
-  // metadata.
-  MetadataProvider(entrypoint, reader, useModuleName: false);
 }

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -183,7 +183,7 @@ abstract class LoadStrategy {
     return Future.value();
   }
 
-  Future<InvalidatedModuleReport> reinitializeEntrypointAfterReload(
+  Future<ModifiedModuleReport> reinitializeEntrypointAfterReload(
     String entrypoint,
     Map<String, List> reloadedModulesToLibraries,
   ) {

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -183,12 +183,12 @@ abstract class LoadStrategy {
     return Future.value();
   }
 
-  Future<void> reinitializeEntrypointAfterReload(
+  Future<InvalidatedModuleReport> reinitializeEntrypointAfterReload(
     String entrypoint,
-    Set<String> modules,
+    Map<String, List> reloadedModulesToLibraries,
   ) {
     final provider = _providers[entrypoint]!;
-    return provider.reinitializeAfterReload(modules);
+    return provider.reinitializeAfterReload(reloadedModulesToLibraries);
   }
 }
 

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -171,7 +171,7 @@ abstract class LoadStrategy {
   /// Creates and returns a [MetadataProvider] with the given [entrypoint] and
   /// [reader].
   MetadataProvider createProvider(String entrypoint, AssetReader reader) =>
-      MetadataProvider(entrypoint, reader, useModuleName: true);
+      MetadataProvider(entrypoint, reader);
 
   /// Initializes a [MetadataProvider] for the application located at the
   /// provided [entrypoint].
@@ -181,6 +181,14 @@ abstract class LoadStrategy {
     // Returns a Future so that the asynchronous g3-implementation can override
     // this method:
     return Future.value();
+  }
+
+  Future<void> reinitializeEntrypointAfterReload(
+    String entrypoint,
+    Set<String> modules,
+  ) {
+    final provider = _providers[entrypoint]!;
+    return provider.reinitializeAfterReload(modules);
   }
 }
 

--- a/dwds/lib/src/loaders/strategy.dart
+++ b/dwds/lib/src/loaders/strategy.dart
@@ -183,12 +183,12 @@ abstract class LoadStrategy {
     return Future.value();
   }
 
-  Future<ModifiedModuleReport> reinitializeEntrypointAfterReload(
+  Future<ModifiedModuleReport> reinitializeProviderAfterHotReload(
     String entrypoint,
     Map<String, List> reloadedModulesToLibraries,
   ) {
     final provider = _providers[entrypoint]!;
-    return provider.reinitializeAfterReload(reloadedModulesToLibraries);
+    return provider.reinitializeAfterHotReload(reloadedModulesToLibraries);
   }
 }
 

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -243,8 +243,11 @@ class ChromeProxyService implements VmServiceInterface {
     final entrypoint = inspector.appConnection.request.entrypointPath;
     final modifiedModuleReport = await globalToolConfiguration.loadStrategy
         .reinitializeProviderAfterHotReload(entrypoint, reloadedModules);
-    await _initializeEntrypoint(entrypoint, modifiedModuleReport);
-    await inspector.initialize(modifiedModuleReport);
+    await _initializeEntrypoint(
+      entrypoint,
+      modifiedModuleReport: modifiedModuleReport,
+    );
+    await inspector.initialize(modifiedModuleReport: modifiedModuleReport);
   }
 
   /// Initializes metadata in [Locations], [Modules], and [ExpressionCompiler].
@@ -252,12 +255,21 @@ class ChromeProxyService implements VmServiceInterface {
   /// If [modifiedModuleReport] is not null, only removes and reinitializes
   /// modified metadata.
   Future<void> _initializeEntrypoint(
-    String entrypoint, [
+    String entrypoint, {
     ModifiedModuleReport? modifiedModuleReport,
-  ]) async {
-    await _modules.initialize(entrypoint, modifiedModuleReport);
-    await _locations.initialize(entrypoint, modifiedModuleReport);
-    await _skipLists.initialize(entrypoint, modifiedModuleReport);
+  }) async {
+    await _modules.initialize(
+      entrypoint,
+      modifiedModuleReport: modifiedModuleReport,
+    );
+    await _locations.initialize(
+      entrypoint,
+      modifiedModuleReport: modifiedModuleReport,
+    );
+    await _skipLists.initialize(
+      entrypoint,
+      modifiedModuleReport: modifiedModuleReport,
+    );
     // We do not need to wait for compiler dependencies to be updated as the
     // [ExpressionEvaluator] is robust to evaluation requests during updates.
     safeUnawaited(_updateCompilerDependencies(entrypoint));

--- a/dwds/lib/src/services/chrome_proxy_service.dart
+++ b/dwds/lib/src/services/chrome_proxy_service.dart
@@ -249,15 +249,18 @@ class ChromeProxyService implements VmServiceInterface {
     final invalidatedModuleReport = await globalToolConfiguration.loadStrategy
         .reinitializeEntrypointAfterReload(entrypoint, reloadedModules);
     await _initializeEntrypoint(entrypoint, invalidatedModuleReport);
-    await inspector.initialize();
+    await inspector.initialize(invalidatedModuleReport);
   }
 
   /// Initializes metadata in [Locations], [Modules], and [ExpressionCompiler].
+  ///
+  /// If [invalidatedModuleReport] is not null, only removes and reinitializes
+  /// invalidated metadata.
   Future<void> _initializeEntrypoint(
     String entrypoint, [
     InvalidatedModuleReport? invalidatedModuleReport,
   ]) async {
-    _modules.initialize(entrypoint);
+    await _modules.initialize(entrypoint, invalidatedModuleReport);
     await _locations.initialize(entrypoint, invalidatedModuleReport);
     await _skipLists.initialize(entrypoint, invalidatedModuleReport);
     // We do not need to wait for compiler dependencies to be updated as the
@@ -353,7 +356,7 @@ class ChromeProxyService implements VmServiceInterface {
     if (!newConnection) {
       await globalToolConfiguration.loadStrategy.trackEntrypoint(entrypoint);
     }
-    _initializeEntrypoint(entrypoint);
+    await _initializeEntrypoint(entrypoint);
 
     debugger.notifyPausedAtStart();
     _inspector = await AppInspector.create(

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '24.4.0-wip';
+const packageVersion = '24.4.0';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 24.4.0-wip
+version: 24.4.0
 
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM

--- a/dwds/test/debugger_test.dart
+++ b/dwds/test/debugger_test.dart
@@ -88,8 +88,8 @@ void main() async {
       FakeModules(),
       root,
     );
-    locations.initialize('fake_entrypoint');
-    skipLists = SkipLists();
+    await locations.initialize('fake_entrypoint');
+    skipLists = SkipLists(root);
     debugger = await Debugger.create(
       webkitDebugger,
       (_, __) {},

--- a/dwds/test/expression_evaluator_test.dart
+++ b/dwds/test/expression_evaluator_test.dart
@@ -54,9 +54,9 @@ void main() async {
       final root = 'fakeRoot';
       final entry = 'fake_entrypoint';
       final locations = Locations(assetReader, modules, root);
-      locations.initialize(entry);
+      await locations.initialize(entry);
 
-      final skipLists = SkipLists();
+      final skipLists = SkipLists(root);
       final debugger = await Debugger.create(
         webkitDebugger,
         (_, e) => debugEventController.sink.add(e),

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -412,7 +412,7 @@ class TestContext {
                   'remote-debugging-port=$debugPort',
                   if (enableDebugExtension)
                     '--load-extension=debug_extension/prod_build',
-                  if (headless) '--headless',
+                  // if (headless) '--headless',
                 ],
               },
             });

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -412,7 +412,7 @@ class TestContext {
                   'remote-debugging-port=$debugPort',
                   if (enableDebugExtension)
                     '--load-extension=debug_extension/prod_build',
-                  // if (headless) '--headless',
+                  if (headless) '--headless',
                 ],
               },
             });

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -414,12 +414,11 @@ class FakeStrategy extends LoadStrategy {
 }
 
 class FakeAssetReader implements AssetReader {
-  final String? _metadata;
+  String? metadata;
   final String? _dartSource;
   final String? _sourceMap;
-  const FakeAssetReader({metadata, dartSource, sourceMap})
-    : _metadata = metadata,
-      _dartSource = dartSource,
+  FakeAssetReader({this.metadata, dartSource, sourceMap})
+    : _dartSource = dartSource,
       _sourceMap = sourceMap;
 
   @override
@@ -432,7 +431,7 @@ class FakeAssetReader implements AssetReader {
 
   @override
   Future<String> metadataContents(String serverPath) {
-    return _throwUnimplementedOrReturnContents(_metadata);
+    return _throwUnimplementedOrReturnContents(metadata);
   }
 
   @override

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -157,7 +157,10 @@ class FakeModules implements Modules {
        _path = path;
 
   @override
-  void initialize(String entrypoint) {}
+  void initialize(
+    String entrypoint, [
+    InvalidatedModuleReport? invalidatedModuleReport,
+  ]) {}
 
   @override
   Future<Uri> libraryForSource(String serverPath) async => Uri(path: _library);
@@ -166,7 +169,10 @@ class FakeModules implements Modules {
   Future<String> moduleForSource(String serverPath) async => _module;
 
   @override
-  Future<Map<String, String>> modules() async => {_module: _path};
+  Future<Set<String>> sourcesForModule(String module) async => {_path};
+
+  @override
+  Future<Map<String, String>> modules() async => {_path: _module};
 
   @override
   Future<String> moduleForLibrary(String libraryUri) async => _module;

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -68,8 +68,7 @@ class FakeInspector implements AppInspector {
   }
 
   @override
-  Future<void> initialize({ModifiedModuleReport? modifiedModuleReport}) async =>
-      {};
+  Future<void> initialize({ModifiedModuleReport? modifiedModuleReport}) async {}
 
   @override
   Future<InstanceRef?> instanceRefFor(Object value) async =>

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -68,7 +68,7 @@ class FakeInspector implements AppInspector {
   }
 
   @override
-  Future<void> initialize([ModifiedModuleReport? modifiedModuleReport]) async =>
+  Future<void> initialize({ModifiedModuleReport? modifiedModuleReport}) async =>
       {};
 
   @override
@@ -159,9 +159,9 @@ class FakeModules implements Modules {
 
   @override
   Future<void> initialize(
-    String entrypoint, [
+    String entrypoint, {
     ModifiedModuleReport? modifiedModuleReport,
-  ]) async {}
+  }) async {}
 
   @override
   Future<Uri> libraryForSource(String serverPath) async => Uri(path: _library);

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -68,7 +68,9 @@ class FakeInspector implements AppInspector {
   }
 
   @override
-  Future<void> initialize() async => {};
+  Future<void> initialize([
+    InvalidatedModuleReport? invalidatedModuleReport,
+  ]) async => {};
 
   @override
   Future<InstanceRef?> instanceRefFor(Object value) async =>
@@ -157,10 +159,10 @@ class FakeModules implements Modules {
        _path = path;
 
   @override
-  void initialize(
+  Future<void> initialize(
     String entrypoint, [
     InvalidatedModuleReport? invalidatedModuleReport,
-  ]) {}
+  ]) async {}
 
   @override
   Future<Uri> libraryForSource(String serverPath) async => Uri(path: _library);

--- a/dwds/test/fixtures/fakes.dart
+++ b/dwds/test/fixtures/fakes.dart
@@ -68,9 +68,8 @@ class FakeInspector implements AppInspector {
   }
 
   @override
-  Future<void> initialize([
-    InvalidatedModuleReport? invalidatedModuleReport,
-  ]) async => {};
+  Future<void> initialize([ModifiedModuleReport? modifiedModuleReport]) async =>
+      {};
 
   @override
   Future<InstanceRef?> instanceRefFor(Object value) async =>
@@ -161,7 +160,7 @@ class FakeModules implements Modules {
   @override
   Future<void> initialize(
     String entrypoint, [
-    InvalidatedModuleReport? invalidatedModuleReport,
+    ModifiedModuleReport? modifiedModuleReport,
   ]) async {}
 
   @override

--- a/dwds/test/fixtures/utilities.dart
+++ b/dwds/test/fixtures/utilities.dart
@@ -196,9 +196,7 @@ class TestToolConfiguration extends ToolConfiguration {
     TestDebugSettings super.debugSettings =
         const TestDebugSettings.noDevTools(),
     TestBuildSettings buildSettings = const TestBuildSettings.dart(),
-  }) : super(
-         loadStrategy: TestStrategy(const FakeAssetReader(), buildSettings),
-       );
+  }) : super(loadStrategy: TestStrategy(FakeAssetReader(), buildSettings));
 
   TestToolConfiguration.withLoadStrategy({
     TestAppMetadata super.appMetadata = const TestAppMetadata.externalApp(),

--- a/dwds/test/location_test.dart
+++ b/dwds/test/location_test.dart
@@ -20,7 +20,7 @@ final sourceMapContents =
     'AAGV,IAFI,kCAAqC,QAAC;AACX,MAA/B,WAAM,AAAwB,0BAAP,QAAF,AAAE,KAAK,GAAP;'
     ';EAEzB","file":"main.ddc.js"}';
 
-void main() {
+void main() async {
   const lines = 100;
   const lineLength = 150;
   final assetReader = FakeAssetReader(sourceMap: sourceMapContents);
@@ -32,7 +32,7 @@ void main() {
 
   final modules = FakeModules(module: _module);
   final locations = Locations(assetReader, modules, '');
-  locations.initialize('fake_entrypoint');
+  await locations.initialize('fake_entrypoint');
 
   group('JS locations |', () {
     const fakeRuntimeScriptId = '12';

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -36,61 +36,50 @@ void main() {
   );
   setGlobalsForTesting(toolConfiguration: toolConfiguration);
   test('can parse metadata with empty sources', () async {
-    for (final useModuleName in [true, false]) {
-      final provider = MetadataProvider(
-        'foo.bootstrap.js',
-        FakeAssetReader(metadata: _emptySourceMetadata),
-        useModuleName: useModuleName,
-      );
-      expect(
-        await provider.libraries,
-        contains('org-dartlang-app:///web/main.dart'),
-      );
-    }
+    final provider = MetadataProvider(
+      'foo.bootstrap.js',
+      FakeAssetReader(metadata: _emptySourceMetadata),
+    );
+    expect(
+      await provider.libraries,
+      contains('org-dartlang-app:///web/main.dart'),
+    );
   });
 
   test('throws on metadata with absolute import uris', () async {
-    for (final useModuleName in [true, false]) {
-      final provider = MetadataProvider(
-        'foo.bootstrap.js',
-        FakeAssetReader(metadata: _fileUriMetadata),
-        useModuleName: useModuleName,
-      );
-      await expectLater(
-        provider.libraries,
-        throwsA(const TypeMatcher<AbsoluteImportUriException>()),
-      );
-    }
+    final provider = MetadataProvider(
+      'foo.bootstrap.js',
+      FakeAssetReader(metadata: _fileUriMetadata),
+    );
+    await expectLater(
+      provider.libraries,
+      throwsA(const TypeMatcher<AbsoluteImportUriException>()),
+    );
   });
 
   test(
     'module name exists if useModuleName and otherwise use module uri',
     () async {
-      for (final useModuleName in [true, false]) {
-        final provider = MetadataProvider(
-          'foo.bootstrap.js',
-          FakeAssetReader(metadata: _emptySourceMetadata),
-          useModuleName: useModuleName,
-        );
-        final modulePath = 'foo/web/main.ddc.js';
-        final moduleName = 'web/main';
-        final module = useModuleName ? moduleName : modulePath;
-        expect(
-          await provider.scriptToModule,
-          predicate<Map<String, String>>(
-            (scriptToModule) =>
-                !scriptToModule.values.any(
-                  (value) => value == (useModuleName ? modulePath : moduleName),
-                ),
-          ),
-        );
-        expect(await provider.moduleToSourceMap, {
-          module: 'foo/web/main.ddc.js.map',
-        });
-        expect(await provider.modulePathToModule, {modulePath: module});
-        expect(await provider.moduleToModulePath, {module: modulePath});
-        expect(await provider.modules, {module});
-      }
+      final provider = MetadataProvider(
+        'foo.bootstrap.js',
+        FakeAssetReader(metadata: _emptySourceMetadata),
+      );
+      final modulePath = 'foo/web/main.ddc.js';
+      final moduleName = 'web/main';
+      final module = moduleName;
+      expect(
+        await provider.scriptToModule,
+        predicate<Map<String, String>>(
+          (scriptToModule) =>
+              !scriptToModule.values.any((value) => value == modulePath),
+        ),
+      );
+      expect(await provider.moduleToSourceMap, {
+        module: 'foo/web/main.ddc.js.map',
+      });
+      expect(await provider.modulePathToModule, {modulePath: module});
+      expect(await provider.moduleToModulePath, {module: modulePath});
+      expect(await provider.modules, {module});
     },
   );
 

--- a/dwds/test/metadata_test.dart
+++ b/dwds/test/metadata_test.dart
@@ -207,7 +207,8 @@ void main() {
       ],
     };
     final libraryToParts = <String, List<String>>{
-      'l1': ['org-dartlang-app:///web/l1_p1.dart'],
+      'org-dartlang-app:///web/l1.dart': ['org-dartlang-app:///web/l1_p1.dart'],
+      'org-dartlang-app:///web/l3.dart': ['org-dartlang-app:///web/l3_p1.dart'],
     };
     final assetReader = FakeAssetReader(
       metadata: createMetadataContents(moduleToLibraries, libraryToParts),
@@ -227,8 +228,9 @@ void main() {
       ],
     };
     final newLibraryToParts = <String, List<String>>{
-      'l1': ['org-dartlang-app:///web/l1_p1.dart'],
-      'l7': ['org-dartlang-app:///web/l7_p1.dart'],
+      'org-dartlang-app:///web/l2.dart': ['org-dartlang-app:///web/l1_p1.dart'],
+      'org-dartlang-app:///web/l3.dart': ['org-dartlang-app:///web/l3_p2.dart'],
+      'org-dartlang-app:///web/l7.dart': ['org-dartlang-app:///web/l7_p1.dart'],
     };
     final reloadedModulesToLibraries = <String, List<String>>{
       'm3': ['org-dartlang-app:///web/l3.dart'],
@@ -241,7 +243,7 @@ void main() {
       newModuleToLibraries,
       newLibraryToParts,
     );
-    final modifiedModuleReport = await provider.reinitializeAfterReload(
+    final modifiedModuleReport = await provider.reinitializeAfterHotReload(
       reloadedModulesToLibraries,
     );
     expect(modifiedModuleReport.deletedModules, ['m2']);

--- a/dwds/test/skip_list_test.dart
+++ b/dwds/test/skip_list_test.dart
@@ -20,11 +20,11 @@ void main() {
   const fakeRuntimeScriptId = '12';
   group('SkipLists', () {
     setUp(() {
-      skipLists = SkipLists();
+      skipLists = SkipLists('');
     });
 
     test('do not include known ranges', () {
-      final skipList = skipLists.compute('123', {
+      final skipList = skipLists.compute('123', '456', {
         Location.from(
           'foo',
           TargetLineEntry(1, []),
@@ -47,7 +47,7 @@ void main() {
     });
 
     test('do not include start of the file', () {
-      final skipList = skipLists.compute('123', {
+      final skipList = skipLists.compute('123', '456', {
         Location.from(
           'foo',
           TargetLineEntry(0, []),
@@ -69,7 +69,7 @@ void main() {
     });
 
     test('does not depend on order of locations', () {
-      final skipList = skipLists.compute('123', {
+      final skipList = skipLists.compute('123', '456', {
         Location.from(
           'foo',
           TargetLineEntry(10, []),
@@ -92,14 +92,14 @@ void main() {
 
     test('contains the provided id', () {
       final id = '123';
-      final skipList = skipLists.compute(id, {});
+      final skipList = skipLists.compute(id, '456', {});
       for (final range in skipList) {
         expect(range['scriptId'], id);
       }
     });
 
     test('ignores the whole file if provided no locations', () {
-      final skipList = skipLists.compute('123', {});
+      final skipList = skipLists.compute('123', '456', {});
       expect(skipList.length, 1);
       _validateRange(skipList.first, 0, 0, maxValue, maxValue);
     });

--- a/dwds/web/reloader/ddc_restarter.dart
+++ b/dwds/web/reloader/ddc_restarter.dart
@@ -47,7 +47,7 @@ class DdcRestarter implements Restarter {
       );
 
   @override
-  Future<JSArray<JSString>> hotReloadStart(String hotReloadSourcesPath) =>
+  Future<JSObject> hotReloadStart(String hotReloadSourcesPath) =>
       throw UnimplementedError(
         'Hot reload is not supported for the DDC module format.',
       );

--- a/dwds/web/reloader/manager.dart
+++ b/dwds/web/reloader/manager.dart
@@ -43,13 +43,15 @@ class ReloadingManager {
   }
 
   /// Computes the sources and libraries to reload, loads them into the page,
-  /// and returns the list of libraries using [hotReloadSourcesPath] as the path
-  /// to a JSONified list of maps which follows the following format:
+  /// and returns a map of module names to libraries using
+  /// [hotReloadSourcesPath] as the path to a JSONified list of maps which
+  /// follows the following format:
   ///
   /// ```json
   /// [
   ///   {
   ///     "src": "<file_name>",
+  ///     "module": "<module_name>",
   ///     "libraries": ["<lib1>", "<lib2>"],
   ///   },
   /// ]
@@ -57,9 +59,10 @@ class ReloadingManager {
   ///
   /// `src`: A string that corresponds to the file path containing a DDC library
   /// bundle.
+  /// `module`: The name of the library bundle in `src`.
   /// `libraries`: An array of strings containing the libraries that were
   /// compiled in `src`.
-  Future<JSArray<JSString>> hotReloadStart(String hotReloadSourcesPath) =>
+  Future<JSObject> hotReloadStart(String hotReloadSourcesPath) =>
       _restarter.hotReloadStart(hotReloadSourcesPath);
 
   /// Does a hard reload of the application.

--- a/dwds/web/reloader/require_restarter.dart
+++ b/dwds/web/reloader/require_restarter.dart
@@ -168,7 +168,7 @@ class RequireRestarter implements Restarter {
       );
 
   @override
-  Future<JSArray<JSString>> hotReloadStart(String hotReloadSourcesPath) =>
+  Future<JSObject> hotReloadStart(String hotReloadSourcesPath) =>
       throw UnimplementedError(
         'Hot reload is not supported for the AMD module format.',
       );

--- a/dwds/web/reloader/restarter.dart
+++ b/dwds/web/reloader/restarter.dart
@@ -14,13 +14,15 @@ abstract class Restarter {
   Future<void> hotReloadEnd();
 
   /// Computes the sources and libraries to reload, loads them into the page,
-  /// and returns the list of libraries using [hotReloadSourcesPath] as the path
-  /// to a JSONified list of maps which follows the following format:
+  /// and returns a map of module names to libraries using
+  /// [hotReloadSourcesPath] as the path to a JSONified list of maps which
+  /// follows the following format:
   ///
   /// ```json
   /// [
   ///   {
   ///     "src": "<file_name>",
+  ///     "module": "<module_name>",
   ///     "libraries": ["<lib1>", "<lib2>"],
   ///   },
   /// ]
@@ -28,7 +30,8 @@ abstract class Restarter {
   ///
   /// `src`: A string that corresponds to the file path containing a DDC library
   /// bundle.
+  /// `module`: The name of the library bundle in `src`.
   /// `libraries`: An array of strings containing the libraries that were
   /// compiled in `src`.
-  Future<JSArray<JSString>> hotReloadStart(String hotReloadSourcesPath);
+  Future<JSObject> hotReloadStart(String hotReloadSourcesPath);
 }

--- a/frontend_server_common/lib/src/devfs.dart
+++ b/frontend_server_common/lib/src/devfs.dart
@@ -253,10 +253,11 @@ class WebDevFS {
   static const String reloadScriptsFileName = 'reload_scripts.json';
 
   /// Given a list of [modules] that need to be reloaded, writes a file that
-  /// contains a list of objects each with two fields:
+  /// contains a list of objects each with three fields:
   ///
   /// `src`: A string that corresponds to the file path containing a DDC library
   /// bundle.
+  /// `module`: The name of the library bundle in `src`.
   /// `libraries`: An array of strings containing the libraries that were
   /// compiled in `src`.
   ///
@@ -265,6 +266,7 @@ class WebDevFS {
   /// [
   ///   {
   ///     "src": "<file_name>",
+  ///     "module": "<module_name>",
   ///     "libraries": ["<lib1>", "<lib2>"],
   ///   },
   /// ]
@@ -286,6 +288,7 @@ class WebDevFS {
       final libraries = metadata.libraries.keys.toList();
       moduleToLibrary.add(<String, Object>{
         'src': _findModuleToLoad(module, entrypointDirectory),
+        'module': metadata.name,
         'libraries': libraries
       });
     }


### PR DESCRIPTION
Many of the caches we computed on the original load need to be invalidated. Previously, we pessimistically tore down the caches and reinitialized them. With this PR, a ModifiedModuleReport is computed that allows us to only invalidate and recompute information for modules/libraries that were either deleted or reloaded.

Specifically, the caches in `MetadataProvider`, `Modules`, `Locations`, `SkipLists`, `AppInspector`, and `LibraryHelper` are now specially invalidated and recomputed. 

Removes an existing option to use the module URI instead of the module name in the `MetadataProvider`. This option is not relevant until we can unify this change across the ecosystem.

Fixes https://github.com/dart-lang/webdev/issues/2628.