### PR TITLE
Update test file with dot-shorthands to use dart 3.10

### DIFF
--- a/fixtures/_experimentSound/web/main.dart
+++ b/fixtures/_experimentSound/web/main.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart = 3.9
+// @dart = 3.10
 
 import 'dart:async';
 import 'dart:core';


### PR DESCRIPTION
The minimum allowed version of this flag has been updated to 3.10.
