### PR TITLE
feat(serve): Add --spa-fallback flag for SPA routing

### DIFF
--- a/webdev/lib/src/command/configuration.dart
+++ b/webdev/lib/src/command/configuration.dart
@@ -38,6 +38,7 @@ const disableDdsFlag = 'disable-dds';
 const enableExperimentOption = 'enable-experiment';
 const canaryFeaturesFlag = 'canary';
 const offlineFlag = 'offline';
+const spaFallbackFlag = 'spa-fallback';
 
 ReloadConfiguration _parseReloadConfiguration(ArgResults argResults) {
   var auto = argResults.options.contains(autoOption)
@@ -109,6 +110,7 @@ class Configuration {
   final List<String>? _experiments;
   final bool? _canaryFeatures;
   final bool? _offline;
+  final bool? _spaFallback;
 
   Configuration({
     bool? autoRun,
@@ -136,6 +138,7 @@ class Configuration {
     List<String>? experiments,
     bool? canaryFeatures,
     bool? offline,
+    bool? spaFallback,
   })  : _autoRun = autoRun,
         _chromeDebugPort = chromeDebugPort,
         _debugExtension = debugExtension,
@@ -158,7 +161,8 @@ class Configuration {
         _nullSafety = nullSafety,
         _experiments = experiments,
         _canaryFeatures = canaryFeatures,
-        _offline = offline {
+        _offline = offline,
+        _spaFallback = spaFallback {
     _validateConfiguration();
   }
 
@@ -234,7 +238,8 @@ class Configuration {
       nullSafety: other._nullSafety ?? _nullSafety,
       experiments: other._experiments ?? _experiments,
       canaryFeatures: other._canaryFeatures ?? _canaryFeatures,
-      offline: other._offline ?? _offline);
+      offline: other._offline ?? _offline,
+      spaFallback: other._spaFallback ?? _spaFallback);
 
   factory Configuration.noInjectedClientDefaults() =>
       Configuration(autoRun: false, debug: false, debugExtension: false);
@@ -290,6 +295,8 @@ class Configuration {
   bool get canaryFeatures => _canaryFeatures ?? false;
 
   bool get offline => _offline ?? false;
+
+  bool get spaFallback => _spaFallback ?? false;
 
   /// Returns a new configuration with values updated from the parsed args.
   static Configuration fromArgs(ArgResults? argResults,
@@ -419,6 +426,10 @@ class Configuration {
         ? argResults[offlineFlag] as bool?
         : defaultConfiguration.verbose;
 
+    final spaFallback = argResults.options.contains(spaFallbackFlag)
+        ? argResults[spaFallbackFlag] as bool?
+        : defaultConfiguration.spaFallback;
+
     return Configuration(
       autoRun: defaultConfiguration.autoRun,
       chromeDebugPort: chromeDebugPort,
@@ -445,6 +456,7 @@ class Configuration {
       experiments: experiments,
       canaryFeatures: canaryFeatures,
       offline: offline,
+      spaFallback: spaFallback,
     );
   }
 }

--- a/webdev/lib/src/command/serve_command.dart
+++ b/webdev/lib/src/command/serve_command.dart
@@ -75,6 +75,10 @@ refresh: Performs a full page refresh.
     ..addFlag(logRequestsFlag,
         negatable: false,
         help: 'Enables logging for each request to the server.')
+    ..addFlag('spa-fallback',
+        negatable: false,
+        help: 'Serves index.html for any 404 from a non-asset request. '
+            'Useful for single-page applications with client-side routing.')
     ..addOption(tlsCertChainFlag,
         help:
             'The file location to a TLS Certificate to create an HTTPs server.\n'

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -195,6 +195,25 @@ class WebDevServer {
       cascade = cascade.add(assetHandler);
     }
 
+    if (options.configuration.spaFallback) {
+      FutureOr<Response> spaFallbackHandler(Request request) async {
+        final uri = request.requestedUri;
+        final hasExtension =
+            uri.pathSegments.isNotEmpty && uri.pathSegments.last.contains('.');
+        if (request.method != 'GET' || hasExtension) {
+          return Response.notFound('Not Found');
+        }
+        final indexResponse =
+            await assetHandler(request.change(path: 'index.html'));
+
+        return indexResponse.statusCode == 200
+            ? indexResponse
+            : Response.notFound('Not Found');
+      }
+
+      cascade = cascade.add(spaFallbackHandler);
+    }
+
     final hostname = options.configuration.hostname;
     final tlsCertChain = options.configuration.tlsCertChain ?? '';
     final tlsCertKey = options.configuration.tlsCertKey ?? '';


### PR DESCRIPTION
When developing Single Page Applications (SPAs) that use client-side routing with the HTML5 History API (e.g., Angular's PathLocationStrategy), refreshing the page on a deep link results in a 404 error because the server can't find a corresponding file for the route. This change introduces a --spa-fallback flag to the webdev serve command. When enabled, the development server will serve the root index.html file for any GET request that would otherwise result in a 404, as long as the path does not appear to be a direct file asset (i.e., does not contain a file extension). This allows the client-side router to take over and handle the request, enabling a seamless development workflow for modern web applications.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
