### PR TITLE
Wait for any remaining output in e2e_test.dart

### DIFF
--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -5,6 +5,7 @@
 @Timeout(Duration(minutes: 5))
 library;
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:io/io.dart';
@@ -210,8 +211,12 @@ void main() {
           args.add('--release');
         }
 
+        final stdoutDone = Completer<void>();
+        final stderrDone = Completer<void>();
         final process = await testRunner.runWebDev(args,
             workingDirectory: soundExampleDirectory);
+        process.stdoutStream().listen((_) => {}, onDone: stdoutDone.complete);
+        process.stderrStream().listen((_) => {}, onDone: stderrDone.complete);
 
         final hostUrl = 'http://localhost:$openPort';
 
@@ -239,6 +244,7 @@ void main() {
 
         await process.kill();
         await process.shouldExit();
+        await Future.wait([stdoutDone.future, stderrDone.future]);
       });
     }
   });


### PR DESCRIPTION
This is intended to fix the flakes appearing on the windows bot. I suspect the test runner is marking it as failing when output comes through on the stream after the test has exited.