### PR TITLE
[dwds] Fix bug where no-op hot restart doesn't cancel a subscription

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 25.0.1
+
+### Bug Fixes:
+
+- Fix issue in hot restart where a hot restart with no changes followed by one
+  with changes, a `Future` was completed again, resulting in a crash.
+
 ## 25.0.0
 
 - Implemented hot restart over websockets with multi window support.

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '25.0.0';
+const packageVersion = '25.0.1';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 25.0.0
+version: 25.0.1
 
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM


### PR DESCRIPTION
In hot restart, we wait for all sources to be parsed before continuing to create the isolate. In order to do so, we listen on parsed sources by registering a subscription. In the case where we have no sources to restart, we don't cancel the subscription. This results in an issue where on the next hot restart that contains changes, the old subscription is triggered, potentially completing an already completed completer. Instead, we should always cancel the subscription. Hot reload code is changed as well to do the same.

Additional checks are added to check if the completer is completed before we complete again. While this is not needed for this issue, it is possible other sources can be downloaded by the app, which may trigger the function in the listener, which could potentially try and complete the completed completer.

Tests are added for both hot restart and hot reload to check that alternating empty hot restarts and non-empty hot restarts work.
