### PR TITLE
Remove stale calls to dartSdkIsAtLeast.

### DIFF
--- a/dwds/test/instances/common/instance_common.dart
+++ b/dwds/test/instances/common/instance_common.dart
@@ -8,7 +8,6 @@ import 'package:dwds/src/debugging/inspector.dart';
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
@@ -72,12 +71,7 @@ void runTypeSystemVerificationTests({
         final remoteObject = await inspector.jsEvaluate(
           libraryVariableTypeExpression('libraryPublicFinal', compilationMode),
         );
-        expect(
-          remoteObject.json['className'],
-          canaryFeatures || dartSdkIsAtLeast(newDdcTypeSystemVersion)
-              ? 'dart_rti.Rti.new'
-              : 'Function',
-        );
+        expect(remoteObject.json['className'], 'dart_rti.Rti.new');
       });
     });
   });
@@ -243,7 +237,7 @@ void runTests({
         expect(classRef.name, '_ControllerStream<int>');
         expect(classRef.id, 'classes|dart:async|_ControllerStream<int>');
         expect(inspector.isDisplayableObject(ref), isTrue);
-      }, skip: !dartSdkIsAtLeast('3.6.0-148.0.dev'));
+      });
 
       test(
         'for a Dart error',
@@ -431,7 +425,7 @@ void runTests({
         final classRef = instance.classRef!;
         expect(classRef.name, '_ControllerStream<int>');
         expect(inspector.isDisplayableObject(instance), isTrue);
-      }, skip: !dartSdkIsAtLeast('3.6.0-148.0.dev'));
+      });
 
       test(
         'for a Dart error',

--- a/dwds/test/instances/common/patterns_inspection_common.dart
+++ b/dwds/test/instances/common/patterns_inspection_common.dart
@@ -5,7 +5,6 @@
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../fixtures/context.dart';
@@ -98,30 +97,15 @@ void runTests({
       await onBreakPoint('testPatternCase2', (event) async {
         final frame = event.topFrame!;
 
-        if (dartSdkIsAtLeast('3.7.0-246.0.dev')) {
-          expect(await getFrameVariables(frame), {
-            'obj': matchListInstance(type: 'Object'),
-            // Renamed to avoid shadowing variables from previous case.
-            'a\$': matchPrimitiveInstance(
-              kind: InstanceKind.kString,
-              value: 'b',
-            ),
-            'n\$': matchPrimitiveInstance(
-              kind: InstanceKind.kDouble,
-              value: 3.14,
-            ),
-          });
-        } else {
-          expect(await getFrameVariables(frame), {
-            'obj': matchListInstance(type: 'Object'),
-            // Renamed to avoid shadowing variables from previous case.
-            'a': matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
-            'n': matchPrimitiveInstance(
-              kind: InstanceKind.kDouble,
-              value: 3.14,
-            ),
-          });
-        }
+        expect(await getFrameVariables(frame), {
+          'obj': matchListInstance(type: 'Object'),
+          // Renamed to avoid shadowing variables from previous case.
+          'a\$': matchPrimitiveInstance(kind: InstanceKind.kString, value: 'b'),
+          'n\$': matchPrimitiveInstance(
+            kind: InstanceKind.kDouble,
+            value: 3.14,
+          ),
+        });
       });
     });
 

--- a/dwds/test/instances/common/record_type_inspection_common.dart
+++ b/dwds/test/instances/common/record_type_inspection_common.dart
@@ -5,7 +5,6 @@
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../fixtures/context.dart';
@@ -126,7 +125,7 @@ void runTests({
           matchDisplayedTypeObjectGetters,
         );
       });
-    }, skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'));
+    });
 
     test('simple record type display', () async {
       await onBreakPoint('printSimpleLocalRecord', (event) async {
@@ -190,7 +189,7 @@ void runTests({
           matchDisplayedTypeObjectGetters,
         );
       });
-    }, skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'));
+    });
 
     test('complex record type display', () async {
       await onBreakPoint('printComplexLocalRecord', (event) async {
@@ -245,21 +244,17 @@ void runTests({
       });
     });
 
-    test(
-      'complex record type with named fields getters',
-      () async {
-        await onBreakPoint('printComplexNamedLocalRecord', (event) async {
-          final frame = event.topFrame!.index!;
-          final instanceRef = await getInstanceRef(frame, 'record.runtimeType');
+    test('complex record type with named fields getters', () async {
+      await onBreakPoint('printComplexNamedLocalRecord', (event) async {
+        final frame = event.topFrame!.index!;
+        final instanceRef = await getInstanceRef(frame, 'record.runtimeType');
 
-          expect(
-            await getDisplayedGetters(instanceRef),
-            matchDisplayedTypeObjectGetters,
-          );
-        });
-      },
-      skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'),
-    );
+        expect(
+          await getDisplayedGetters(instanceRef),
+          matchDisplayedTypeObjectGetters,
+        );
+      });
+    });
 
     test('complex record type with named fields display', () async {
       await onBreakPoint('printComplexNamedLocalRecord', (event) async {
@@ -332,7 +327,7 @@ void runTests({
           matchDisplayedTypeObjectGetters,
         );
       });
-    }, skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'));
+    });
 
     test('nested record type display', () async {
       await onBreakPoint('printNestedLocalRecord', (event) async {
@@ -392,26 +387,22 @@ void runTests({
       });
     });
 
-    test(
-      'nested record type with named fields getters',
-      () async {
-        await onBreakPoint('printNestedNamedLocalRecord', (event) async {
-          final frame = event.topFrame!.index!;
-          final instanceRef = await getInstanceRef(frame, 'record.runtimeType');
-          final elements = await getElements(instanceRef.id!);
+    test('nested record type with named fields getters', () async {
+      await onBreakPoint('printNestedNamedLocalRecord', (event) async {
+        final frame = event.topFrame!.index!;
+        final instanceRef = await getInstanceRef(frame, 'record.runtimeType');
+        final elements = await getElements(instanceRef.id!);
 
-          expect(
-            await getDisplayedGetters(instanceRef),
-            matchDisplayedTypeObjectGetters,
-          );
-          expect(
-            await getDisplayedGetters(elements[1]),
-            matchDisplayedTypeObjectGetters,
-          );
-        });
-      },
-      skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'),
-    );
+        expect(
+          await getDisplayedGetters(instanceRef),
+          matchDisplayedTypeObjectGetters,
+        );
+        expect(
+          await getDisplayedGetters(elements[1]),
+          matchDisplayedTypeObjectGetters,
+        );
+      });
+    });
 
     test('nested record type with named fields display', () async {
       await onBreakPoint('printNestedNamedLocalRecord', (event) async {

--- a/dwds/test/instances/common/type_inspection_common.dart
+++ b/dwds/test/instances/common/type_inspection_common.dart
@@ -5,7 +5,6 @@
 import 'package:test/test.dart';
 import 'package:test_common/logging.dart';
 import 'package:test_common/test_sdk_configuration.dart';
-import 'package:test_common/utilities.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../fixtures/context.dart';
@@ -135,7 +134,7 @@ void runTests({
           matchDisplayedTypeObjectGetters,
         );
       });
-    }, skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'));
+    });
 
     test('int type', () async {
       await onBreakPoint('printSimpleLocalRecord', (event) async {
@@ -167,7 +166,7 @@ void runTests({
           matchDisplayedTypeObjectGetters,
         );
       });
-    }, skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'));
+    });
 
     test('list type', () async {
       await onBreakPoint('printSimpleLocalRecord', (event) async {
@@ -229,7 +228,7 @@ void runTests({
           matchDisplayedTypeObjectGetters,
         );
       });
-    }, skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'));
+    });
 
     test('set type', () async {
       await onBreakPoint('printSimpleLocalRecord', (event) async {
@@ -261,7 +260,7 @@ void runTests({
           matchDisplayedTypeObjectGetters,
         );
       });
-    }, skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'));
+    });
 
     test('record type', () async {
       await onBreakPoint('printSimpleLocalRecord', (event) async {
@@ -297,7 +296,7 @@ void runTests({
           matchDisplayedTypeObjectGetters,
         );
       });
-    }, skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'));
+    });
 
     test('class type', () async {
       await onBreakPoint('printSimpleLocalRecord', (event) async {
@@ -335,6 +334,6 @@ void runTests({
           matchDisplayedTypeObjectGetters,
         );
       });
-    }, skip: !dartSdkIsAtLeast('3.4.0-56.0.dev'));
+    });
   });
 }

--- a/test_common/lib/utilities.dart
+++ b/test_common/lib/utilities.dart
@@ -10,8 +10,6 @@ const webdevDirName = 'webdev';
 const dwdsDirName = 'dwds';
 const fixturesDirName = 'fixtures';
 
-const newDdcTypeSystemVersion = '3.3.0-242.0.dev';
-
 /// The path to the webdev directory in the local machine, e.g.
 /// '/workstation/webdev'.
 String get webdevPath {

--- a/webdev/test/e2e_test.dart
+++ b/webdev/test/e2e_test.dart
@@ -13,7 +13,6 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
-import 'package:test_common/utilities.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 import 'package:vm_service/vm_service.dart';
@@ -446,9 +445,7 @@ void main() {
               const TypeMatcher<InstanceRef>().having(
                   (instance) => instance.classRef?.name,
                   'class name',
-                  dartSdkIsAtLeast('3.3.0-242.0.dev')
-                      ? 'JSArray<bool>'
-                      : 'List<bool>'));
+                  'JSArray<bool>'));
 
           final instanceRef = result as InstanceRef;
           final list = await vmService.getObject(isolateId, instanceRef.id!);
@@ -457,9 +454,7 @@ void main() {
               const TypeMatcher<Instance>().having(
                   (instance) => instance.classRef?.name,
                   'class name',
-                  dartSdkIsAtLeast('3.3.0-242.0.dev')
-                      ? 'JSArray<bool>'
-                      : 'List<bool>'));
+                  'JSArray<bool>'));
 
           final elements = (list as Instance).elements;
           expect(elements, [


### PR DESCRIPTION
These calls to `dartSdkIsAtLeast` all refer to old SDK versions and therefore no longer require being checked.