### PR TITLE
Fix failing test ('NoSuchAlertException (27): no such alert') after #2681

### DIFF
--- a/dwds/lib/dart_web_debug_service.dart
+++ b/dwds/lib/dart_web_debug_service.dart
@@ -155,6 +155,7 @@ class Dwds {
         devToolsServerAddress:
             launchedDevToolsUri ??
             debugSettings.ddsConfiguration.devToolsServerAddress,
+        serveDevTools: debugSettings.ddsConfiguration.serveDevTools,
       ),
       debugSettings.launchDevToolsInNewWindow,
       useWebSocketConnection: useDwdsWebSocketConnection,

--- a/dwds/test/devtools_test.dart
+++ b/dwds/test/devtools_test.dart
@@ -8,6 +8,7 @@ library;
 
 import 'dart:io';
 
+import 'package:dwds/src/config/tool_configuration.dart';
 import 'package:test/test.dart';
 import 'package:test_common/test_sdk_configuration.dart';
 import 'package:vm_service/vm_service.dart';
@@ -163,6 +164,9 @@ void main() {
       await context.setUp(
         debugSettings: TestDebugSettings.noDevToolsLaunch().copyWith(
           enableDevToolsLaunch: true,
+          ddsConfiguration: DartDevelopmentServiceConfiguration(
+            serveDevTools: false,
+          ),
         ),
       );
     });


### PR DESCRIPTION
PR #2681 made the `test/devtools_test.dart: Injected client without a DevTools server gives a good error if devtools is not served` fail.
This makes it pass again.