### PR TITLE
Fix CI flake in dwds/test/hot_restart_breakpoints_test.dart

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -39,7 +39,7 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global activate mono_repo 6.6.2
       - name: mono_repo self validate
-        run: dart pub global run mono_repo generate --validate
+        run: true
   job_002:
     name: "analyzer_and_format; linux; Dart dev; PKG: dwds; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`, `dart test test/build/ensure_version_test.dart`"
     runs-on: ubuntu-latest

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -267,8 +267,12 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
+      - name: "dwds; dart test specific"
+        run: "dart test/hot_restart_breakpoints_test.dart"
+        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
+        working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -303,7 +307,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -338,7 +342,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -525,7 +529,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -560,7 +564,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -595,7 +599,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -758,7 +762,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -783,7 +787,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -808,7 +812,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -933,7 +937,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -958,7 +962,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -983,7 +987,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
+        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension --no-retry --fail-fast"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -39,7 +39,7 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global activate mono_repo 6.6.2
       - name: mono_repo self validate
-        run: true
+        run: dart pub global run mono_repo generate --validate
   job_002:
     name: "analyzer_and_format; linux; Dart dev; PKG: dwds; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`, `dart test test/build/ensure_version_test.dart`"
     runs-on: ubuntu-latest
@@ -267,12 +267,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
-      - name: "dwds; dart test specific"
-        run: "dart test/hot_restart_breakpoints_test.dart"
-        if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
-        working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -307,7 +303,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -342,7 +338,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -529,7 +525,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -564,7 +560,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -599,7 +595,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -762,7 +758,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -787,7 +783,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -812,7 +808,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -937,7 +933,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 0 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -962,7 +958,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 1 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:
@@ -987,7 +983,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: dwds
       - name: "dwds; dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
-        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension --no-retry --fail-fast"
+        run: "dart test --total-shards 3 --shard-index 2 --exclude-tags=extension"
         if: "always() && steps.dwds_pub_upgrade.conclusion == 'success'"
         working-directory: dwds
     needs:

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -433,6 +433,10 @@ class TestContext {
           ' -> notice chrome driver identity hash code is '
           '${identityHashCode(_chromeDriver)}',
         );
+        log('Also notice Platform.environment:');
+        for(var entry in Platform.environment.entries) {
+          log('  ${entry.key}: ${entry.value}');
+        }
         _webDriver = await createDriver(
           spec: WebDriverSpec.JsonWire,
           desired: capabilities,

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -434,7 +434,7 @@ class TestContext {
           '${identityHashCode(_chromeDriver)}',
         );
         log('Also notice Platform.environment:');
-        for(var entry in Platform.environment.entries) {
+        for (var entry in Platform.environment.entries) {
           log('  ${entry.key}: ${entry.value}');
         }
         _webDriver = await createDriver(

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -154,14 +154,12 @@ class TestContext {
 
       DartUri.currentDirectory = project.absolutePackageDirectory;
 
-      void log(String s) {
-        _logger.info('${DateTime.now()}: $s');
-      }
-
-      log('Serving: ${project.directoryToServe}/${project.filePathToServe}');
-      log('Project: ${project.absolutePackageDirectory}');
-      log('Packages: ${project.packageConfigFile}');
-      log('Entry: ${project.dartEntryFilePath}');
+      _logger.info(
+        'Serving: ${project.directoryToServe}/${project.filePathToServe}',
+      );
+      _logger.info('Project: ${project.absolutePackageDirectory}');
+      _logger.info('Packages: ${project.packageConfigFile}');
+      _logger.info('Entry: ${project.dartEntryFilePath}');
 
       configureLogWriter();
 
@@ -212,13 +210,13 @@ class TestContext {
               line.contains('was started successfully')) {
             chromeDriverStartup.complete();
           }
-          log('ChromeDriver stdout: $line');
+          _logger.finest('ChromeDriver stdout: $line');
         });
-        stdErrLines.listen((line) => log('ChromeDriver stderr: $line'));
+        stdErrLines.listen(
+          (line) => _logger.warning('ChromeDriver stderr: $line'),
+        );
 
-        await stdOutLines.first;
         await chromeDriverStartup.future;
-        log('ChromeDriver has now started');
       } catch (e) {
         throw StateError(
           'Could not start ChromeDriver. Is it installed?\nError: $e',
@@ -434,52 +432,14 @@ class TestContext {
                 ],
               },
             });
-        log(
-          'Now creating web driver for chrome driver port; '
-          'going for port $chromeDriverPort',
+        _webDriver = await createDriver(
+          spec: WebDriverSpec.JsonWire,
+          desired: capabilities,
+          uri: Uri.parse(
+            'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/',
+          ),
         );
-        log(
-          ' -> notice chrome driver identity hash code is '
-          '${identityHashCode(_chromeDriver)}',
-        );
-        try {
-          final localWebDriver =
-              _webDriver = await createDriver(
-                spec: WebDriverSpec.JsonWire,
-                desired: capabilities,
-                uri: Uri.parse(
-                  'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/',
-                ),
-              );
-          log(
-            'After first try: _webDriver = $_webDriver; '
-            'localWebDriver = $localWebDriver',
-          );
-        } on SocketException catch (e) {
-          log('Got "$e". Will wait a bit and try again.');
-          await Future.delayed(const Duration(seconds: 2));
-          log('Back after the wait. Will now try again.');
-          try {
-            final localWebDriver =
-                _webDriver = await createDriver(
-                  spec: WebDriverSpec.JsonWire,
-                  desired: capabilities,
-                  uri: Uri.parse(
-                    'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/',
-                  ),
-                );
-            log(
-              'After second try: _webDriver = $_webDriver; '
-              'localWebDriver = $localWebDriver',
-            );
-          } on SocketException catch (e) {
-            log('Got exception again: "$e"');
-            rethrow;
-          }
-        }
       }
-
-      log('Is now after the testSettings.launchChrome stuff.');
 
       // The debugger tab must be enabled and connected before certain
       // listeners in DWDS or `main` is run.

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -433,17 +433,30 @@ class TestContext {
           ' -> notice chrome driver identity hash code is '
           '${identityHashCode(_chromeDriver)}',
         );
-        log('Also notice Platform.environment:');
-        for (final entry in Platform.environment.entries) {
-          log('  ${entry.key}: ${entry.value}');
+        try {
+          _webDriver = await createDriver(
+            spec: WebDriverSpec.JsonWire,
+            desired: capabilities,
+            uri: Uri.parse(
+              'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/',
+            ),
+          );
+        } on SocketException catch (e) {
+          log('Got "$e". Will wait a bit and try again.');
+          await Future.delayed(const Duration(seconds: 2));
+          try {
+            _webDriver = await createDriver(
+              spec: WebDriverSpec.JsonWire,
+              desired: capabilities,
+              uri: Uri.parse(
+                'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/',
+              ),
+            );
+          } on SocketException catch (e) {
+            log('Got exception again: "$e"');
+            rethrow;
+          }
         }
-        _webDriver = await createDriver(
-          spec: WebDriverSpec.JsonWire,
-          desired: capabilities,
-          uri: Uri.parse(
-            'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/',
-          ),
-        );
       }
 
       // The debugger tab must be enabled and connected before certain

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -434,7 +434,7 @@ class TestContext {
           '${identityHashCode(_chromeDriver)}',
         );
         log('Also notice Platform.environment:');
-        for (var entry in Platform.environment.entries) {
+        for (final entry in Platform.environment.entries) {
           log('  ${entry.key}: ${entry.value}');
         }
         _webDriver = await createDriver(

--- a/dwds/test/fixtures/context.dart
+++ b/dwds/test/fixtures/context.dart
@@ -434,23 +434,34 @@ class TestContext {
           '${identityHashCode(_chromeDriver)}',
         );
         try {
-          _webDriver = await createDriver(
-            spec: WebDriverSpec.JsonWire,
-            desired: capabilities,
-            uri: Uri.parse(
-              'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/',
-            ),
+          final localWebDriver =
+              _webDriver = await createDriver(
+                spec: WebDriverSpec.JsonWire,
+                desired: capabilities,
+                uri: Uri.parse(
+                  'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/',
+                ),
+              );
+          log(
+            'After first try: _webDriver = $_webDriver; '
+            'localWebDriver = $localWebDriver',
           );
         } on SocketException catch (e) {
           log('Got "$e". Will wait a bit and try again.');
           await Future.delayed(const Duration(seconds: 2));
+          log('Back after the wait. Will now try again.');
           try {
-            _webDriver = await createDriver(
-              spec: WebDriverSpec.JsonWire,
-              desired: capabilities,
-              uri: Uri.parse(
-                'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/',
-              ),
+            final localWebDriver =
+                _webDriver = await createDriver(
+                  spec: WebDriverSpec.JsonWire,
+                  desired: capabilities,
+                  uri: Uri.parse(
+                    'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/',
+                  ),
+                );
+            log(
+              'After second try: _webDriver = $_webDriver; '
+              'localWebDriver = $localWebDriver',
             );
           } on SocketException catch (e) {
             log('Got exception again: "$e"');
@@ -458,6 +469,8 @@ class TestContext {
           }
         }
       }
+
+      log('Is now after the testSettings.launchChrome stuff.');
 
       // The debugger tab must be enabled and connected before certain
       // listeners in DWDS or `main` is run.

--- a/dwds/test/hot_restart_breakpoints_test.dart
+++ b/dwds/test/hot_restart_breakpoints_test.dart
@@ -21,8 +21,6 @@ import 'fixtures/context.dart';
 import 'fixtures/project.dart';
 import 'fixtures/utilities.dart';
 
-int setupNum = 0;
-
 void main() {
   // Enable verbose logging for debugging.
   const debug = true;
@@ -54,7 +52,6 @@ void main() {
     setUp(() async {
       setCurrentLogWriter(debug: debug);
       await context.setUp(
-        setupNum: ++setupNum,
         testSettings: TestSettings(
           enableExpressionEvaluation: true,
           compilationMode: CompilationMode.frontendServer,

--- a/dwds/test/hot_restart_breakpoints_test.dart
+++ b/dwds/test/hot_restart_breakpoints_test.dart
@@ -21,6 +21,8 @@ import 'fixtures/context.dart';
 import 'fixtures/project.dart';
 import 'fixtures/utilities.dart';
 
+int setupNum = 0;
+
 void main() {
   // Enable verbose logging for debugging.
   const debug = false;
@@ -52,6 +54,7 @@ void main() {
     setUp(() async {
       setCurrentLogWriter(debug: debug);
       await context.setUp(
+        setupNum: ++setupNum,
         testSettings: TestSettings(
           enableExpressionEvaluation: true,
           compilationMode: CompilationMode.frontendServer,

--- a/dwds/test/hot_restart_breakpoints_test.dart
+++ b/dwds/test/hot_restart_breakpoints_test.dart
@@ -23,7 +23,7 @@ import 'fixtures/utilities.dart';
 
 void main() {
   // Enable verbose logging for debugging.
-  const debug = true;
+  const debug = false;
   final provider = TestSdkConfigurationProvider(
     verbose: debug,
     canaryFeatures: true,

--- a/dwds/test/hot_restart_breakpoints_test.dart
+++ b/dwds/test/hot_restart_breakpoints_test.dart
@@ -25,7 +25,7 @@ int setupNum = 0;
 
 void main() {
   // Enable verbose logging for debugging.
-  const debug = false;
+  const debug = true;
   final provider = TestSdkConfigurationProvider(
     verbose: debug,
     canaryFeatures: true,

--- a/dwds/test/hot_restart_breakpoints_test.dart
+++ b/dwds/test/hot_restart_breakpoints_test.dart
@@ -49,7 +49,7 @@ void main() {
     late Stream<Event> stream;
     // Fetch the log statements that are sent to console.
     final consoleLogs = <String>[];
-    late StreamSubscription<ConsoleAPIEvent> consoleSubscription;
+    StreamSubscription<ConsoleAPIEvent>? consoleSubscription;
 
     setUp(() async {
       setCurrentLogWriter(debug: debug);
@@ -74,7 +74,7 @@ void main() {
     });
 
     tearDown(() async {
-      await consoleSubscription.cancel();
+      await consoleSubscription?.cancel();
       consoleLogs.clear();
       await context.tearDown();
     });


### PR DESCRIPTION
This fixes flakes on the CI for dwds/test/hot_restart_breakpoints_test.dart where a few tests would fail because the ChromeDriver hadn't started up properly yet --- it seemingly takes 200-500 ms for the first launch on github actions.
The test itself was also changed slightly to not give a late initialization error when/if the test times out.