### PR TITLE
Use evaluate instead of periodic timer to test dot shorthands

### DIFF
--- a/dwds/test/fixtures/project.dart
+++ b/dwds/test/fixtures/project.dart
@@ -119,6 +119,14 @@ class TestProject {
     htmlEntryFileName: 'index.html',
   );
 
+  static final testDotShorthands = TestProject._(
+    packageName: '_test_dot_shorthands',
+    packageDirectory: '_test_dot_shorthands',
+    webAssetsPath: 'web',
+    dartEntryFileName: 'main.dart',
+    htmlEntryFileName: 'index.html',
+  );
+
   static final testHotRestart1 = TestProject._(
     packageName: '_test_hot_restart1',
     packageDirectory: '_test_hot_restart1',

--- a/dwds/test/instances/common/dot_shorthands_common.dart
+++ b/dwds/test/instances/common/dot_shorthands_common.dart
@@ -100,14 +100,14 @@ void runTests({
       final bp = onBreakpoint('testDotShorthands', (event) async {
         final scriptBasename = basename(mainScript.uri!);
 
-        const lineA = 11;
-        const lineB = 13;
-        const lineC = 14;
-        const lineD = 15;
-        const lineE = 22;
-        const lineF = 24;
-        const lineG = 26;
-        const lineH = 27;
+        const lineA = 9;
+        const lineB = 11;
+        const lineC = 12;
+        const lineD = 13;
+        const lineE = 20;
+        const lineF = 22;
+        const lineG = 24;
+        const lineH = 25;
 
         final expected = [
           '$scriptBasename:$lineE:3', // on 'c'

--- a/fixtures/_experiment/web/main.dart
+++ b/fixtures/_experiment/web/main.dart
@@ -6,9 +6,10 @@
 
 import 'dart:async';
 import 'dart:core';
-// TODO: https://github.com/dart-lang/webdev/issues/2508
-// ignore: deprecated_member_use
-import 'dart:html';
+import 'dart:js_interop';
+
+@JS('document.body.append')
+external void append(String text);
 
 void main() {
   // for evaluation
@@ -26,11 +27,9 @@ void main() {
     testPattern2();
     print('Classes');
     testClass();
-    print('Dot shorthands');
-    testDotShorthands();
   });
 
-  document.body!.appendText('Program is running!');
+  append('Program is running!');
 }
 
 void printSimpleLocalRecord() {
@@ -93,10 +92,7 @@ class GreeterClass {
   final String greeteeName;
   final bool useFrench;
 
-  GreeterClass({
-    this.greeteeName = 'Snoopy',
-    this.useFrench = false,
-  });
+  GreeterClass({this.greeteeName = 'Snoopy', this.useFrench = false});
 
   void sayHello() {
     useFrench ? greetInFrench() : greetInEnglish();
@@ -109,25 +105,4 @@ class GreeterClass {
   void greetInFrench() {
     print('Bonjour $greeteeName');
   }
-}
-
-class C {
-  int value;
-  C(this.value); // lineA
-
-  static C two = C(2); // lineB
-  static C get three => C(3); // lineC
-  static C four() => C(4); // lineD
-}
-
-void testDotShorthands() {
-  C c = C(1);
-  print('breakpoint'); // Breakpoint: testDotShorthands
-  // ignore: experiment_not_enabled
-  c = .two; // lineE
-  // ignore: experiment_not_enabled
-  c = .three; // lineF
-  // ignore: experiment_not_enabled
-  c = .four(); // lineG
-  print(c.value); // lineH
 }

--- a/fixtures/_test_dot_shorthands/pubspec.yaml
+++ b/fixtures/_test_dot_shorthands/pubspec.yaml
@@ -1,0 +1,16 @@
+name: _test_dot_shorthands
+version: 1.0.0
+description: >-
+  A fake package used for testing dot shorthands.
+publish_to: none
+
+environment:
+  sdk: ^3.2.0
+
+dependencies:
+  intl: ^0.17.0
+  path: ^1.8.2
+
+dev_dependencies:
+  build_runner: ^2.5.0
+  build_web_compilers: ^4.0.4

--- a/fixtures/_test_dot_shorthands/pubspec.yaml
+++ b/fixtures/_test_dot_shorthands/pubspec.yaml
@@ -5,12 +5,4 @@ description: >-
 publish_to: none
 
 environment:
-  sdk: ^3.2.0
-
-dependencies:
-  intl: ^0.17.0
-  path: ^1.8.2
-
-dev_dependencies:
-  build_runner: ^2.5.0
-  build_web_compilers: ^4.0.4
+  sdk: ^3.9.0

--- a/fixtures/_test_dot_shorthands/pubspec.yaml
+++ b/fixtures/_test_dot_shorthands/pubspec.yaml
@@ -6,3 +6,7 @@ publish_to: none
 
 environment:
   sdk: ^3.9.0
+
+dev_dependencies:
+  build_runner: ^2.5.0
+  build_web_compilers: ^4.0.4

--- a/fixtures/_test_dot_shorthands/web/index.html
+++ b/fixtures/_test_dot_shorthands/web/index.html
@@ -1,0 +1,7 @@
+<html>
+
+<head>
+  <script defer src="main.dart.js"></script>
+</head>
+
+</html>

--- a/fixtures/_test_dot_shorthands/web/main.dart
+++ b/fixtures/_test_dot_shorthands/web/main.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/fixtures/_test_dot_shorthands/web/main.dart
+++ b/fixtures/_test_dot_shorthands/web/main.dart
@@ -4,8 +4,6 @@
 
 // @dart = 3.9
 
-import 'dart:core';
-
 class C {
   int value;
   C(this.value); // lineA

--- a/fixtures/_test_dot_shorthands/web/main.dart
+++ b/fixtures/_test_dot_shorthands/web/main.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart = 3.9
+
+import 'dart:core';
+
+class C {
+  int value;
+  C(this.value); // lineA
+
+  static C two = C(2); // lineB
+  static C get three => C(3); // lineC
+  static C four() => C(4); // lineD
+}
+
+void testDotShorthands() {
+  C c = C(1);
+  print('breakpoint'); // Breakpoint: testDotShorthands
+  // ignore: experiment_not_enabled
+  c = .two; // lineE
+  // ignore: experiment_not_enabled
+  c = .three; // lineF
+  // ignore: experiment_not_enabled
+  c = .four(); // lineG
+  print(c.value); // lineH
+}
+
+void main() {}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/2638

Fields are cached after their first execution. When debugging, this means we may not hit the body of the field when using the AMD module format. The DDC library bundle format always has a getter for fields, however, even with the cached value.

To make the test consistent for all formats, we should avoid any previous executions of the field by using an evaluate call instead of a periodic timer in main.

This requires moving the dot shorthands test to its own fixture.
