### PR TITLE
[DWDS] Make pause a no-op on WebSocketProxyService

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 26.1.0-wip
+
+- `pause` now does not send a `PauseInterrupted` event in
+  `WebSocketProxyService` as we didn't actually pause.
+
 ## 26.0.0
 
 - Bump SDK constraint to ^3.10.0

--- a/dwds/lib/src/services/web_socket_proxy_service.dart
+++ b/dwds/lib/src/services/web_socket_proxy_service.dart
@@ -940,22 +940,8 @@ class WebSocketProxyService extends ProxyService {
   /// Pauses execution of the isolate.
   @override
   Future<Success> pause(String isolateId) =>
-      wrapInErrorHandlerAsync('pause', () => _pause(isolateId));
-
-  Future<Success> _pause(String _) async {
-    // Create a pause event and store it
-    if (_isolateRef != null) {
-      final pauseEvent = vm_service.Event(
-        kind: vm_service.EventKind.kPauseInterrupted,
-        timestamp: DateTime.now().millisecondsSinceEpoch,
-        isolate: _isolateRef!,
-      );
-      _currentPauseEvent = pauseEvent;
-      _streamNotify(vm_service.EventStreams.kDebug, pauseEvent);
-    }
-
-    return Success();
-  }
+      // Can't pause with the web socket implementation, so do nothing.
+      Future.value(Success());
 
   /// Resumes execution of the isolate.
   @override

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '26.0.0';
+const packageVersion = '26.1.0-wip';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 26.0.0
+version: 26.1.0-wip
 
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM


### PR DESCRIPTION
We can't actually pause during execution so we shouldn't signal that we did.
