### PR TITLE
Fix awaiting for  future

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Bump `build_web_compilers` to ^4.4.1.
 - Remove unused `clientFuture` arg from `DwdsVmClient` methods.
+- Fix pausing starting of `main` after the hot restart.
 
 ## 26.2.2
 

--- a/dwds/web/reloader/ddc_restarter.dart
+++ b/dwds/web/reloader/ddc_restarter.dart
@@ -13,7 +13,17 @@ import 'restarter.dart';
 external DartLibrary dartLibrary;
 
 extension type DartLibrary._(JSObject _) implements JSObject {
-  external void reload(String? runId, JSPromise? readyToRunMain);
+  external void reload(ReloadConfiguration configuration);
+}
+
+@anonymous
+@JS()
+@staticInterop
+class ReloadConfiguration {
+  external factory ReloadConfiguration({
+    String? runId,
+    JSPromise? readyToRunMain,
+  });
 }
 
 class DdcRestarter implements Restarter {
@@ -27,7 +37,9 @@ class DdcRestarter implements Restarter {
       reloadedSourcesPath == null,
       "'reloadedSourcesPath' should not be used for the DDC module format.",
     );
-    dartLibrary.reload(runId, readyToRunMain?.toJS);
+    dartLibrary.reload(
+      ReloadConfiguration(runId: runId, readyToRunMain: readyToRunMain?.toJS),
+    );
     final reloadCompleter = Completer<bool>();
     final sub = window.onMessage.listen((event) {
       final message = event.data?.dartify();


### PR DESCRIPTION
In https://github.com/dart-lang/webdev/pull/2491, the reloader was changed to pass two arguments instead of an object with two fields into dartLibrary.reload. As a result, the javascript side couldn't find the promise in a field of the first argument and ignored the second argument. Usually it is fine, but this broke postponing main launch until the attached debugger can configure breakpoints.

Again, this is not a big deal for interactive long-running apps, but if the main is fast and short (e.g. tests), this effectively prevents interactive debugging from an IDE.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
