### PR TITLE
Support reconnects on page refreshes for SSE client connections

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fix pausing starting of `main` after the hot restart.
 - Updating bootstrapper for DDC library bundler module format + Frontend Server.
 - Fix setting up breakpoints when handling in-app restarts with attached debugger.
+- Fix setting up breakpoints when handling full reloads from attached
+  debugger / page refreshes.
 
 ## 26.2.2
 

--- a/dwds/lib/src/handlers/dev_handler.dart
+++ b/dwds/lib/src/handlers/dev_handler.dart
@@ -636,21 +636,11 @@ class DevHandler {
       readyToRunMainCompleter.future,
     );
 
-    // We can take over a connection if there is no connectedInstanceId (this
-    // means the client completely disconnected), or if the existing
-    // AppConnection is in the KeepAlive state (this means it disconnected but
-    // is still waiting for a possible reconnect - this happens during a page
-    // reload).
-    final canReconnect =
-        services != null &&
-        (services.connectedInstanceId == null ||
-            existingConnection?.isInKeepAlivePeriod == true);
-
-    if (canReconnect) {
+    if (_canReconnect(existingConnection, message)) {
       // Disconnect any old connection (eg. those in the keep-alive waiting
       // state when reloading the page).
       existingConnection?.shutDown();
-      final chromeProxy = services.proxyService;
+      final chromeProxy = services!.proxyService;
       if (chromeProxy is ChromeProxyService) {
         chromeProxy.destroyIsolate();
       }
@@ -703,24 +693,10 @@ class DevHandler {
       readyToRunMainCompleter.future,
     );
 
-    // Allow connection reuse for page refreshes and same instance reconnections
-    final isSameInstance =
-        existingConnection?.request.instanceId == message.instanceId;
-    final isKeepAliveReconnect =
-        existingConnection?.isInKeepAlivePeriod == true;
-    final hasNoActiveConnection = services?.connectedInstanceId == null;
-    final noExistingConnection = existingConnection == null;
-
-    final canReconnect =
-        services != null &&
-        (isSameInstance ||
-            (isKeepAliveReconnect && hasNoActiveConnection) ||
-            (noExistingConnection && hasNoActiveConnection));
-
-    if (canReconnect) {
+    if (_canReconnect(existingConnection, message)) {
       // Reconnect to existing service.
       await _reconnectToService(
-        services,
+        services!,
         existingConnection,
         connection,
         message,
@@ -747,6 +723,30 @@ class DevHandler {
     _connectedApps.add(connection);
     _logger.fine('App connection established for: ${message.appId}');
     return connection;
+  }
+
+  /// Allow connection reuse for page refreshes and same instance reconnections
+  bool _canReconnect(
+    AppConnection? existingConnection,
+    ConnectRequest message,
+  ) {
+    final services = _servicesByAppId[message.appId];
+
+    if (services == null) {
+      return false;
+    }
+
+    if (existingConnection?.request.instanceId == message.instanceId) {
+      return true;
+    }
+
+    final isKeepAliveReconnect =
+        existingConnection?.isInKeepAlivePeriod == true;
+    final hasNoActiveConnection = services.connectedInstanceId == null;
+    final noExistingConnection = existingConnection == null;
+
+    return (isKeepAliveReconnect && hasNoActiveConnection) ||
+        (noExistingConnection && hasNoActiveConnection);
   }
 
   /// Handles reconnection to existing services for web-socket mode.

--- a/dwds/lib/src/injected/client.js
+++ b/dwds/lib/src/injected/client.js
@@ -27899,7 +27899,7 @@
     $call$body$main_closure() {
       var $async$goto = 0,
         $async$completer = A._makeAsyncAwaitCompleter(type$.void),
-        uri, fixedPath, fixedUri, client, _0_0, t2, manager, t3, t4, t5, debugEventController, t6, _box_0, t1;
+        storedInstanceId, t2, t3, uri, fixedPath, fixedUri, client, _0_0, manager, t4, t5, debugEventController, t6, _box_0, t1;
       var $async$call$0 = A._wrapJsFunctionForAsync(function($async$errorCode, $async$result) {
         if ($async$errorCode === 1)
           return A._asyncRethrow($async$result, $async$completer);
@@ -27909,8 +27909,18 @@
               // Function start
               _box_0 = {};
               t1 = init.G;
-              if (A._asStringQ(t1.$dartAppInstanceId) == null)
-                t1.$dartAppInstanceId = new A.UuidV1(null).generate$1$options(null);
+              if (A._asStringQ(t1.$dartAppInstanceId) == null) {
+                storedInstanceId = A._asStringQ(A._asJSObject(A._asJSObject(t1.window).sessionStorage).getItem("dartAppInstanceId"));
+                if (storedInstanceId != null)
+                  t1.$dartAppInstanceId = storedInstanceId;
+                else {
+                  t1.$dartAppInstanceId = new A.UuidV1(null).generate$1$options(null);
+                  t2 = A._asJSObject(A._asJSObject(t1.window).sessionStorage);
+                  t3 = A._asStringQ(t1.$dartAppInstanceId);
+                  t3.toString;
+                  t2.setItem("dartAppInstanceId", t3);
+                }
+              }
               uri = A.Uri_parse(A._asString(t1.$dwdsDevHandlerPath));
               if (A._asString(A._asJSObject(A._asJSObject(t1.window).location).protocol) === "https:" && uri.get$scheme() === "http" && uri.get$host() !== "localhost")
                 uri = uri.replace$1$scheme("https");

--- a/dwds/web/client.dart
+++ b/dwds/web/client.dart
@@ -47,7 +47,22 @@ Future<void>? main() {
     () async {
       // Set the unique id for this instance of the app.
       // Test apps may already have this set.
-      dartAppInstanceId ??= const Uuid().v1();
+      const dartAppInstanceIdKey = 'dartAppInstanceId';
+      if (dartAppInstanceId == null) {
+        // Check the session storage for the instance id.
+        final storedInstanceId = window.sessionStorage.getItem(
+          dartAppInstanceIdKey,
+        );
+        if (storedInstanceId != null) {
+          dartAppInstanceId = storedInstanceId;
+        } else {
+          dartAppInstanceId = const Uuid().v1();
+          window.sessionStorage.setItem(
+            dartAppInstanceIdKey,
+            dartAppInstanceId!,
+          );
+        }
+      }
 
       final fixedPath = _fixProtocol(dwdsDevHandlerPath);
       final fixedUri = Uri.parse(fixedPath);


### PR DESCRIPTION
1. reuse reconnection logic between websockets and sse connections
2. persist app instance id on the client side

If we treat reloads as parts of an app lifecycle, it seems natural to preserve an app instance id on full reloads, and looks like a session storage is a good fit.

Fixes #2726.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
