### PR TITLE
Replace getmdl.io CDN CSS (403) to restore Dart Debug Extension startup

### DIFF
--- a/dwds/debug_extension/web/static_assets/debugger_panel.html
+++ b/dwds/debug_extension/web/static_assets/debugger_panel.html
@@ -3,7 +3,7 @@
   <head>
     <link
       rel="stylesheet"
-      href="https://code.getmdl.io/1.3.0/material.indigo-blue.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.indigo-blue.min.css"
       type="text/css"
     />
     <link

--- a/dwds/debug_extension/web/static_assets/inspector_panel.html
+++ b/dwds/debug_extension/web/static_assets/inspector_panel.html
@@ -3,7 +3,7 @@
   <head>
     <link
       rel="stylesheet"
-      href="https://code.getmdl.io/1.3.0/material.indigo-blue.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.indigo-blue.min.css"
       type="text/css"
     />
     <link

--- a/dwds/debug_extension/web/static_assets/popup.html
+++ b/dwds/debug_extension/web/static_assets/popup.html
@@ -3,7 +3,7 @@
   <head>
     <link
       rel="stylesheet"
-      href="https://code.getmdl.io/1.3.0/material.indigo-blue.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.indigo-blue.min.css"
       type="text/css"
     />
     <link


### PR DESCRIPTION
This PR fixes Dart Debug Extension failing to start when the MDL CSS cannot be loaded.

The extension UI depends on MDL CSS that was previously loaded from `getmdl.io`, which now returns `403 Forbidden`. When the CSS fails to load, the UI never initializes and web debugging is completely blocked.

This change replaces the deprecated `getmdl.io` CDN with a Cloudflare-hosted equivalent to restore reliable startup and remove the hard dependency on a broken third-party CDN.

No functional behavior is changed beyond restoring the extension startup.

- Fixes extension startup failure caused by broken CDN
- No API changes
- No behavior changes aside from UI initialization

Fixes #2750 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
