### PR TITLE
[ webdev ] Use DDS to serve DevTools instead of `package:dds/devtools_server.dart`

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.8.1-wip
 
+- Serve Dart DevTools from DDS instead of launching it manually.
+
 ## 3.8.0
 
 - Adding initial DDC library bundler support behind the `canary` flag.

--- a/webdev/lib/src/serve/webdev_server.dart
+++ b/webdev/lib/src/serve/webdev_server.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:build_daemon/data/build_status.dart' as daemon;
-import 'package:dds/devtools_server.dart';
 import 'package:dwds/data/build_result.dart';
 import 'package:dwds/dwds.dart';
 import 'package:dwds/sdk_configuration.dart';
@@ -227,20 +226,11 @@ class WebDevServer {
       final debugSettings = DebugSettings(
         enableDebugExtension: options.configuration.debugExtension,
         enableDebugging: options.configuration.debug,
-        // ignore: deprecated_member_use
-        spawnDds: !options.configuration.disableDds,
+        ddsConfiguration: DartDevelopmentServiceConfiguration(
+          enable: !options.configuration.disableDds,
+          serveDevTools: shouldServeDevTools,
+        ),
         expressionCompiler: ddcService,
-        // ignore: deprecated_member_use
-        devToolsLauncher: shouldServeDevTools
-            ? (String hostname) async {
-                final server = await DevToolsServer().serveDevTools(
-                  hostname: hostname,
-                  enableStdinCommands: false,
-                  customDevToolsPath: devToolsPath,
-                );
-                return DevTools(server!.address.host, server.port, server);
-              }
-            : null,
       );
 
       final appMetadata = AppMetadata(hostname: options.configuration.hostname);


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/2759