### PR TITLE
Default to not injecting script loads for build runner + ddc library bundles

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 27.0.1
+## 27.0.1-wip
 - Replace `package:uuid` dependency with internal `Uuid` class for generating version 4 UUIDs.
 - Add DDC Library Bundle tests in `dwds/test/integration/instances`.
 - Don't inject script loads from within DWDS when executing with build_runner + DDC Module Bundles.

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '27.0.1';
+const packageVersion = '27.0.1-wip';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 27.0.1
+version: 27.0.1-wip
 
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM


### PR DESCRIPTION
This was causing failures for some tests in CI due main being called 'twice' after a hot restart in tests.