### PR TITLE
Re-enabling analysis in `test/integration/`

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -9,7 +9,6 @@
     a new connection request.
 - Add sourcemap logic fixes to DDC Library Bundle + build_runner execution scheme.
 - Update pathing logic for Windows and the DDC Library Bundle module system.
-- Re-enabling analysis in `test/integration/`.
 
 ## 27.0.0
 - Remove `package:built_value`, `package:built_value_generator`, and `package:built_collection` dependencies.


### PR DESCRIPTION
These were disabled during an earlier test migration but should be stable now https://github.com/dart-lang/webdev/pull/2778/changes#diff-522f85594aacd72118e6795a25464dcfe101717c85a33237a2654f3415167b80
