### PR TITLE
fix dartExecutable passed through to dwds

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,7 +1,9 @@
+## 27.0.3
+
+- Fix `dartExecutable` not being correctly passed to the DebugService.
 
 ## 27.0.2
 
-- Add `appName` to `DartDevelopmentServiceConfiguration`.
 - Add `dartExecutable` to `DartDevelopmentServiceConfiguration`.
 
 ## 27.0.1

--- a/dwds/lib/dart_web_debug_service.dart
+++ b/dwds/lib/dart_web_debug_service.dart
@@ -156,6 +156,7 @@ class Dwds {
             launchedDevToolsUri ??
             debugSettings.ddsConfiguration.devToolsServerAddress,
         serveDevTools: debugSettings.ddsConfiguration.serveDevTools,
+        dartExecutable: debugSettings.ddsConfiguration.dartExecutable,
       ),
       debugSettings.launchDevToolsInNewWindow,
       useWebSocketConnection: useDwdsWebSocketConnection,

--- a/dwds/lib/src/version.dart
+++ b/dwds/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '27.0.2';
+const packageVersion = '27.0.3';

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dwds
 # Every time this changes you need to run `dart run build_runner build`.
-version: 27.0.2
+version: 27.0.3
 
 description: >-
   A service that proxies between the Chrome debug protocol and the Dart VM


### PR DESCRIPTION
@Markzipan After testing this I noticed the `dartExecutable` needs to be passed here to work correctly.

Resolves #2813 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
