### PR TITLE
sync changes from g3 to enable testing of dwds_test_common

### DIFF
--- a/dwds_test_common/lib/test_sdk_layout.dart
+++ b/dwds_test_common/lib/test_sdk_layout.dart
@@ -12,7 +12,26 @@ import 'package:path/path.dart' as p;
 /// Contains definition of the default SDK layout required for tests.
 /// We keep all the path constants in one place for ease of update.
 class TestSdkLayout {
-  static final defaultSdkDirectory = SdkLayout.defaultSdkDirectory;
+  static final defaultSdkDirectory = _getDefaultSdkDirectory();
+
+  static String _getDefaultSdkDirectory() {
+    // When running tests in Google3, the TEST_SRCDIR environment variable
+    // provides the absolute path to the root of the runfiles tree during tests
+    // executions. We use it to locate the Dart SDK within the test sandbox.
+    final testSrcDir = Platform.environment['TEST_SRCDIR'];
+    if (testSrcDir != null) {
+      final g3SdkDir = p.join(
+        testSrcDir,
+        'google3',
+        'third_party',
+        'dart_lang',
+        'v2',
+        'sdk',
+      );
+      if (Directory(g3SdkDir).existsSync()) return g3SdkDir;
+    }
+    return SdkLayout.defaultSdkDirectory;
+  }
 
   static TestSdkLayout defaultSdkLayout = TestSdkLayout.createDefault(
     defaultSdkDirectory,
@@ -183,17 +202,180 @@ class TestSdkLayout {
 
 // Update modified files.
 Future<void> copyDirectory(String from, String to) async {
+  // If running in a Google3 environment, augment the copied SDK with required
+  // artifacts that might be missing or in different locations compared to the
+  // standard SDK layout.
+  final testSrcDir = Platform.environment['TEST_SRCDIR'];
+  if (testSrcDir != null && from == TestSdkLayout.defaultSdkDirectory) {
+    await _copyGoogle3Artifacts(testSrcDir, to);
+    _createGoogle3DummyFiles(to);
+  }
+
+  await _copyDirectory(from, to);
+}
+
+Future<void> _copyDirectory(String from, String to) async {
   if (!Directory(from).existsSync()) return;
   await Directory(to).create(recursive: true);
 
   await for (final file in Directory(from).list(followLinks: false)) {
     final copyTo = p.join(to, p.relative(file.path, from: from));
     if (file is Directory) {
-      await copyDirectory(file.path, copyTo);
+      await _copyDirectory(file.path, copyTo);
     } else if (file is File) {
       await File(file.path).copy(copyTo);
     } else if (file is Link) {
       await Link(copyTo).create(await file.target(), recursive: true);
+    }
+  }
+}
+
+void _createGoogle3DummyFiles(String to) {
+  // Create a dummy require.js to satisfy the SDK layout checks.
+  final requireJs = p.join(to, 'lib', 'dev_compiler', 'amd', 'require.js');
+  if (!File(requireJs).existsSync()) {
+    File(requireJs).createSync(recursive: true);
+  }
+
+  // Create a dummy devtools directory to satisfy the SDK layout checks.
+  final devtools = p.join(to, 'bin', 'resources', 'devtools');
+  if (!Directory(devtools).existsSync()) {
+    Directory(devtools).createSync(recursive: true);
+  }
+}
+
+Future<void> _copyGoogle3Artifacts(String testSrcDir, String to) async {
+  // Copy dart binary from the platform-specific directory
+  // (e.g., `linux/sdk/bin`).
+  final platform = Platform.isMacOS ? 'darwin' : 'linux';
+  final g3DartBinDir = p.join(
+    testSrcDir,
+    'google3',
+    'third_party',
+    'dart_lang',
+    'v2',
+    platform,
+    'sdk',
+    'bin',
+  );
+  if (Directory(g3DartBinDir).existsSync()) {
+    await _copyDirectory(g3DartBinDir, p.join(to, 'bin'));
+  }
+
+  // Copy dartdevc_aot.dart.snapshot. TestSdkLayout checks for
+  // 'dartdevc.dart.snapshot', so we copy it under both names.
+  final g3DartdevcSnapshot = p.join(
+    testSrcDir,
+    'google3',
+    'third_party',
+    'dart',
+    'dev_compiler',
+    'dartdevc_aot.dart.snapshot',
+  );
+  if (File(g3DartdevcSnapshot).existsSync()) {
+    final snapshotsDir = Directory(p.join(to, 'bin', 'snapshots'));
+    if (!snapshotsDir.existsSync()) {
+      snapshotsDir.createSync(recursive: true);
+    }
+    File(
+      g3DartdevcSnapshot,
+    ).copySync(p.join(snapshotsDir.path, 'dartdevc.dart.snapshot'));
+    File(
+      g3DartdevcSnapshot,
+    ).copySync(p.join(snapshotsDir.path, 'dartdevc_aot.dart.snapshot'));
+  }
+
+  // Copy ddc_module_loader.js from the dev_compiler package.
+  final ddcLoaderSrc = p.join(
+    testSrcDir,
+    'google3',
+    'third_party',
+    'dart',
+    'dev_compiler',
+    'lib',
+    'js',
+    'ddc',
+    'ddc_module_loader.js',
+  );
+  final ddcLoaderDst = p.join(
+    to,
+    'lib',
+    'dev_compiler',
+    'ddc',
+    'ddc_module_loader.js',
+  );
+  if (!File(ddcLoaderDst).existsSync()) {
+    if (File(ddcLoaderSrc).existsSync()) {
+      File(ddcLoaderDst).createSync(recursive: true);
+      File(ddcLoaderSrc).copySync(ddcLoaderDst);
+    }
+  }
+
+  // Copy dart_stack_trace_mapper.js from the dev_compiler package's
+  // build output (ddc_stack_trace_mapper.js).
+  final stackTraceMapperSrc = p.join(
+    testSrcDir,
+    'google3',
+    'third_party',
+    'dart',
+    'dev_compiler',
+    'ddc_stack_trace_mapper.js',
+  );
+  final stackTraceMapperDst = p.join(
+    to,
+    'lib',
+    'dev_compiler',
+    'web',
+    'dart_stack_trace_mapper.js',
+  );
+  if (!File(stackTraceMapperDst).existsSync()) {
+    if (File(stackTraceMapperSrc).existsSync()) {
+      File(stackTraceMapperDst).createSync(recursive: true);
+      File(stackTraceMapperSrc).copySync(stackTraceMapperDst);
+    }
+  }
+
+  // Copy frontend_server_aot.dart.snapshot from the frontend_server package.
+  final frontendServerSrc = p.join(
+    testSrcDir,
+    'google3',
+    'third_party',
+    'dart',
+    'frontend_server',
+    'frontend_server_aot.dart.snapshot',
+  );
+  final frontendServerDst = p.join(
+    to,
+    'bin',
+    'snapshots',
+    'frontend_server_aot.dart.snapshot',
+  );
+  if (!File(frontendServerDst).existsSync()) {
+    if (File(frontendServerSrc).existsSync()) {
+      File(frontendServerDst).createSync(recursive: true);
+      File(frontendServerSrc).copySync(frontendServerDst);
+    }
+  }
+
+  // Copy kernel_worker_aot.dart.snapshot from the dart_lang package.
+  final kernelWorkerSrc = p.join(
+    testSrcDir,
+    'google3',
+    'third_party',
+    'dart_lang',
+    'v2',
+    'kernel_worker_aot.dart.snapshot',
+  );
+  final kernelWorkerDst = p.join(
+    to,
+    'bin',
+    'snapshots',
+    'kernel_worker_aot.dart.snapshot',
+  );
+  if (!File(kernelWorkerDst).existsSync()) {
+    if (File(kernelWorkerSrc).existsSync()) {
+      File(kernelWorkerDst).createSync(recursive: true);
+      File(kernelWorkerSrc).copySync(kernelWorkerDst);
     }
   }
 }

--- a/dwds_test_common/test/external_webdev_sdk_configuration_test.dart
+++ b/dwds_test_common/test/external_webdev_sdk_configuration_test.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+@Timeout(Duration(minutes: 2))
+library;
+
+import 'dart:io';
+
+import 'package:dwds/expression_compiler.dart';
+import 'package:dwds_test_common/logging.dart';
+import 'package:dwds_test_common/test_sdk_configuration.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const debug = false;
+
+  for (final format in [ModuleFormat.ddc, ModuleFormat.amd]) {
+    group('External Webdev SDK configuration | ${format.name} modules |', () {
+      setUpAll(() {
+        setCurrentLogWriter(debug: debug);
+      });
+
+      final provider = TestSdkConfigurationProvider(
+        verbose: debug,
+        ddcModuleFormat: format,
+      );
+      tearDownAll(provider.dispose);
+
+      test('SDK layout exists', () async {
+        await provider.configuration;
+        final sdkLayout = provider.sdkLayout;
+
+        expect(sdkLayout.devToolsDirectory, _directoryExists);
+        if (format == ModuleFormat.amd) {
+          expect(sdkLayout.requireJsPath, _fileExists);
+        }
+      });
+    });
+  }
+}
+
+Matcher _fileExists = predicate(
+  (String path) => File(path).existsSync(),
+  'File exists',
+);
+
+Matcher _directoryExists = predicate(
+  (String path) => Directory(path).existsSync(),
+  'Directory exists',
+);

--- a/dwds_test_common/test/test_sdk_configuration_test.dart
+++ b/dwds_test_common/test/test_sdk_configuration_test.dart
@@ -85,7 +85,6 @@ void main() {
       expect(sdkLayout.frontendServerSnapshotPath, _fileExists);
       expect(sdkLayout.dartdevcSnapshotPath, _fileExists);
       expect(sdkLayout.kernelWorkerSnapshotPath, _fileExists);
-      expect(sdkLayout.devToolsDirectory, _directoryExists);
     });
   });
 
@@ -110,7 +109,6 @@ void main() {
       expect(sdkLayout.summaryPath, _fileExists);
       expect(sdkLayout.fullDillPath, _fileExists);
 
-      expect(sdkLayout.requireJsPath, _fileExists);
       expect(sdkLayout.stackTraceMapperPath, _fileExists);
 
       expect(sdkLayout.dartPath, _fileExists);
@@ -118,7 +116,6 @@ void main() {
       expect(sdkLayout.frontendServerSnapshotPath, _fileExists);
       expect(sdkLayout.dartdevcSnapshotPath, _fileExists);
       expect(sdkLayout.kernelWorkerSnapshotPath, _fileExists);
-      expect(sdkLayout.devToolsDirectory, _directoryExists);
     });
   });
 }


### PR DESCRIPTION
Sync changes to enable testing of dwds_test_common.

Changes made in https://critique.corp.google.com/cl/907801123.

Fixes https://github.com/dart-lang/sdk/issues/63238.