### PR TITLE
[dwds] Remove unconditional TLS certificate trust in ProxyServerAssetReader

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 27.1.2-wip
 
+- Remove the `badCertificateCallback` override in `ProxyServerAssetReader` that
+  unconditionally accepted any TLS certificate when `isHttps: true` was set.
+  Callers that need to trust a private CA should configure a `SecurityContext`
+  on the `HttpClient` themselves. (CWE-295)
+
 ## 27.1.1
 
 - Fix deserialization errors appearing in the chrome console.

--- a/dwds/lib/src/readers/proxy_server_asset_reader.dart
+++ b/dwds/lib/src/readers/proxy_server_asset_reader.dart
@@ -32,9 +32,7 @@ class ProxyServerAssetReader implements AssetReader {
       ..maxConnectionsPerHost = 200
       ..idleTimeout = const Duration(seconds: 30)
       ..connectionTimeout = const Duration(seconds: 30);
-    final client = isHttps
-        ? IOClient(inner..badCertificateCallback = (cert, host, port) => true)
-        : IOClient(inner);
+    final client = IOClient(inner);
     var url = '$scheme$host:$assetServerPort/';
     if (root.isNotEmpty) url += '$root/';
     final handler = proxyHandler(url, client: client);


### PR DESCRIPTION
## Summary

Remove the `badCertificateCallback = (cert, host, port) => true` override on the `HttpClient` used by `ProxyServerAssetReader` when `isHttps: true`. The default `dart:io` certificate validation now applies.

The override caused the asset reader to silently accept self-signed, expired, hostname-mismatched, or attacker-controlled certificates with equal trust (CWE-295). The in-tree `webdev serve` invocation does not reach this path, but third-party tools that embed `dwds` and pass `isHttps: true` were exposed to MITM on the asset/proxy connection.

Callers that need to trust a private/internal CA should configure a `SecurityContext` on the `HttpClient` themselves rather than disabling validation globally.

The Dart security team has already been notified through the channel listed in `dart-lang/.github/SECURITY.md`.