### PR TITLE
Fixing failing DDS-served DevTools test expectations

### DIFF
--- a/dwds/test/integration/devtools_common.dart
+++ b/dwds/test/integration/devtools_common.dart
@@ -57,7 +57,7 @@ void testAll({required TestSdkConfigurationProvider provider}) {
       test('can launch devtools', () async {
         final windows = await context.webDriver.windows.toList();
         await context.webDriver.driver.switchTo.window(windows.last);
-        expect(await context.webDriver.pageSource, contains('DevTools'));
+        expect(await context.webDriver.pageSource, contains('flutter-view'));
         expect(await context.webDriver.currentUrl, contains('ide=Dwds'));
         // TODO(https://github.com/dart-lang/webdev/issues/1888): Re-enable.
       }, skip: Platform.isWindows);


### PR DESCRIPTION
The latest version of DevTools is rendered with Flutter Web, so we're likely missing specific DOM elements. I've changed this to check that Flutter Web's loaded. 

See: https://docs.flutter.dev/tools/devtools/release-notes/release-notes-2.58.0