### PR TITLE
Fix unawaited_return_in_try_block warning in chrome_inspector.dart

### DIFF
--- a/dwds/lib/src/debugging/chrome_inspector.dart
+++ b/dwds/lib/src/debugging/chrome_inspector.dart
@@ -360,7 +360,7 @@ class ChromeAppInspector extends AppInspector {
       }
       final scriptRef = scriptRefsById[objectId];
       if (scriptRef != null) {
-        return _getScript(scriptRef);
+        return await _getScript(scriptRef);
       }
       final instance = await _instanceHelper.instanceFor(
         remoteObjectFor(objectId),


### PR DESCRIPTION
Await `_getScript` call inside the try block to ensure errors are caught and logged.
