### PR TITLE
allow package_config version 3.x.x

### DIFF
--- a/dwds/CHANGELOG.md
+++ b/dwds/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 27.1.2-wip
 
+- Allow package_config `3.x.x`.
+
 ## 27.1.1
 
 - Fix deserialization errors appearing in the chrome console.

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   http_multi_server: ^3.2.0
   logging: ^1.0.2
   meta: ^1.9.1
-  package_config: ^2.0.2
+  package_config: '>=2.0.2 <4.0.0'
   path: ^1.8.1
   pool: ^1.5.0
   pub_semver: ^2.1.1

--- a/frontend_server_client/CHANGELOG.md
+++ b/frontend_server_client/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.0.1-wip
 
 - Update Dart SDK constraint to `^3.10.0`.
+- Allow package_config `3.x.x`.
 
 ## 4.0.0
 

--- a/frontend_server_client/pubspec.yaml
+++ b/frontend_server_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   async: ^2.5.0
-  package_config: ^2.1.0
+  package_config: '>=2.1.0 <4.0.0'
   path: ^1.8.0
 
 dev_dependencies:


### PR DESCRIPTION
Just expands the constraint to allow the latest version. This is already in the SDK/Google3 so there should be no issue.