### PR TITLE
[dwds_test_common] Cleanup pubspec.yaml

### DIFF
--- a/dwds_test_common/pubspec.yaml
+++ b/dwds_test_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: >-
   Common test functionality.
 environment:
-  sdk: ^3.10.0-0.0.dev
+  sdk: ^3.12.0-0
 
 dependencies:
   dwds: any
@@ -15,4 +15,3 @@ dependencies:
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.5.2
-  yaml: ^3.1.2


### PR DESCRIPTION
Upstream the changes already applied in the version copied into the Dart SDK.

This makes the sync into the Dart SDK cleaner.
