### PR TITLE
Adding unchanged local field to avoid flakes in inspector tests

### DIFF
--- a/dwds/test/integration/inspector_test.dart
+++ b/dwds/test/integration/inspector_test.dart
@@ -155,8 +155,11 @@ void main() {
 
     test('for num', () async {
       final remoteObject = await libraryPublicFinal();
-      final count = await inspector.loadField(remoteObject, 'count');
-      expect(count.value, 0);
+      final unchangedCount = await inspector.loadField(
+        remoteObject,
+        'unchangedCount',
+      );
+      expect(unchangedCount.value, 42);
     });
   });
 
@@ -176,6 +179,7 @@ void main() {
       'myselfField',
       'notFinal',
       'tornOff',
+      'unchangedCount',
     ];
     names.sort();
     expect(names, expected);

--- a/dwds/test/integration/instances/common/instance_common.dart
+++ b/dwds/test/integration/instances/common/instance_common.dart
@@ -342,6 +342,7 @@ void runTests({
           'myselfField',
           'notFinal',
           'tornOff',
+          'unchangedCount',
         ]);
         final fieldNames = instance.fields!
             .map((boundField) => boundField.name)

--- a/dwds_test_common/fixtures/_test/example/scopes/main.dart
+++ b/dwds_test_common/fixtures/_test/example/scopes/main.dart
@@ -145,6 +145,8 @@ class MyTestClass<T> extends MyAbstractClass {
   late final MyTestClass myselfField;
 
   var count = 0;
+  // This should never be updated during execution.
+  var unchangedCount = 42;
 
   // An easy location to add a breakpoint.
   void printCount() {


### PR DESCRIPTION
Fixes `inspector_test.dart` flaking out if the expression eval happens too late (after the periodic timer fires and modifies its old local).