### PR TITLE
Bump dev_dependencies.

### DIFF
--- a/debug_extension/pubspec.yaml
+++ b/debug_extension/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
 
 dev_dependencies:
   args: ^2.5.0
-  build: ^2.4.1
-  build_runner: ^2.4.12
+  build: ^4.0.8
+  build_runner: ^2.15.2
   build_web_compilers: ^4.4.1
   dwds: ^24.1.0
   lints: ^6.1.0

--- a/dwds_test_common/fixtures/_webdev_smoke/pubspec.yaml
+++ b/dwds_test_common/fixtures/_webdev_smoke/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
   sdk: ^3.10.0-0.0.dev
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.15.2
   build_web_compilers: ^4.4.12

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
   sdk: ^3.10.0-0.0.dev
 
 dev_dependencies:
-  build_runner: ^2.4.0
+  build_runner: ^2.15.2
   build_web_compilers: ^4.4.12

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -42,8 +42,8 @@ dependencies:
 dev_dependencies:
   analysis_config:
     path: ../_analysis_config
-  build: ^2.3.0
-  build_runner: ^2.5.0
+  build: ^4.0.8
+  build_runner: ^2.15.2
   build_verify: ^3.0.0
   build_version: ^2.1.1
   test: ^1.21.1


### PR DESCRIPTION
There were some outdated dev_dependencies preventing testing with latest build/build_runner.

The test fixture does run with the latest build_runner, but put the latest version number there as well: it's clearer.