### PR TITLE
Handle Version Skew Errors from build_daemon

### DIFF
--- a/debug_extension/pubspec.yaml
+++ b/debug_extension/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   args: ^2.5.0
   build: ^4.0.8
-  build_runner: ^2.15.2
+  build_runner: ^2.16.0
   build_web_compilers: ^4.4.1
   dwds: ^24.1.0
   lints: ^6.1.0

--- a/dwds/pubspec.yaml
+++ b/dwds/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
 
 dev_dependencies:
   args: ^2.7.0
-  build_daemon: ^4.0.0
+  build_daemon: ^4.1.4
   dart_flutter_team_lints: ^3.5.2
   dwds_test_common:
     path: ../dwds_test_common

--- a/dwds_test_common/fixtures/_experiment/pubspec.yaml
+++ b/dwds_test_common/fixtures/_experiment/pubspec.yaml
@@ -11,5 +11,6 @@ dependencies:
   path: ^1.8.2
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_experiment/pubspec.yaml
+++ b/dwds_test_common/fixtures/_experiment/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   path: ^1.8.2
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   path: ^1.8.2
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.8.1
 

--- a/dwds_test_common/fixtures/_test/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test/pubspec.yaml
@@ -11,6 +11,6 @@ dependencies:
   path: ^1.8.2
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.16.0
   build_web_compilers: ^4.8.1
 

--- a/dwds_test_common/fixtures/_test_circular1/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_circular1/pubspec.yaml
@@ -13,5 +13,6 @@ dependencies:
     path: ../_test_circular2
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_circular1/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_circular1/pubspec.yaml
@@ -13,5 +13,5 @@ dependencies:
     path: ../_test_circular2
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_circular2/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_circular2/pubspec.yaml
@@ -11,5 +11,6 @@ dependencies:
     path: ../_test_circular1
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_circular2/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_circular2/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
     path: ../_test_circular1
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_dot_shorthands/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_dot_shorthands/pubspec.yaml
@@ -7,5 +7,6 @@ environment:
   sdk: ^3.10.0
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_dot_shorthands/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_dot_shorthands/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
   sdk: ^3.10.0
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_hot_reload/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_hot_reload/pubspec.yaml
@@ -5,3 +5,8 @@ description: >-
 publish_to: none
 environment:
   sdk: ^3.10.0-0.0.dev
+
+dev_dependencies:
+  build_daemon: ^4.1.4
+  build_runner: ^2.16.0
+  build_web_compilers: ^4.8.1

--- a/dwds_test_common/fixtures/_test_hot_reload_breakpoints/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_hot_reload_breakpoints/pubspec.yaml
@@ -5,3 +5,8 @@ description: >-
 publish_to: none
 environment:
   sdk: ^3.10.0-0.0.dev
+
+dev_dependencies:
+  build_daemon: ^4.1.4
+  build_runner: ^2.16.0
+  build_web_compilers: ^4.8.1

--- a/dwds_test_common/fixtures/_test_hot_restart1/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_hot_restart1/pubspec.yaml
@@ -11,5 +11,6 @@ dependencies:
   path: ^1.6.1
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_hot_restart1/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_hot_restart1/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   path: ^1.6.1
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_hot_restart2/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_hot_restart2/pubspec.yaml
@@ -13,5 +13,6 @@ dependencies:
     path: ../_test_hot_restart1
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.8.1

--- a/dwds_test_common/fixtures/_test_hot_restart2/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_hot_restart2/pubspec.yaml
@@ -13,5 +13,5 @@ dependencies:
     path: ../_test_hot_restart1
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.16.0
   build_web_compilers: ^4.8.1

--- a/dwds_test_common/fixtures/_test_hot_restart_breakpoints/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_hot_restart_breakpoints/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.10.0-0.0.dev
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.8.1
 

--- a/dwds_test_common/fixtures/_test_hot_restart_breakpoints/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_hot_restart_breakpoints/pubspec.yaml
@@ -7,6 +7,6 @@ environment:
   sdk: ^3.10.0-0.0.dev
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.16.0
   build_web_compilers: ^4.8.1
 

--- a/dwds_test_common/fixtures/_test_package/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_package/pubspec.yaml
@@ -11,5 +11,6 @@ dependencies:
     path: ../_test
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_package/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_package/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
     path: ../_test
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_parts/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_parts/pubspec.yaml
@@ -11,5 +11,6 @@ dependencies:
   path: ^1.6.1
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_test_parts/pubspec.yaml
+++ b/dwds_test_common/fixtures/_test_parts/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   path: ^1.6.1
 
 dev_dependencies:
-  build_runner: ^2.5.0
+  build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_webdev_smoke/pubspec.yaml
+++ b/dwds_test_common/fixtures/_webdev_smoke/pubspec.yaml
@@ -7,5 +7,6 @@ environment:
   sdk: ^3.10.0-0.0.dev
 
 dev_dependencies:
+  build_daemon: ^4.1.4
   build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/dwds_test_common/fixtures/_webdev_smoke/pubspec.yaml
+++ b/dwds_test_common/fixtures/_webdev_smoke/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
   sdk: ^3.10.0-0.0.dev
 
 dev_dependencies:
-  build_runner: ^2.15.2
+  build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
   sdk: ^3.10.0-0.0.dev
 
 dev_dependencies:
-  build_runner: ^2.15.2
+  build_runner: ^2.16.0
   build_web_compilers: ^4.4.12

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+- Catch and report version skew errors when incompatible versions of `build_daemon` are used.
+
 ## 4.0.0
 
 - Add `module-format` flag for testing new DDC Library Bundle module format prior to release.

--- a/webdev/lib/src/command/build_command.dart
+++ b/webdev/lib/src/command/build_command.dart
@@ -135,13 +135,7 @@ class BuildCommand extends Command<int> {
       );
       return 1;
     } on VersionSkew catch (_) {
-      logWriter(
-        logging.Level.SEVERE,
-        'Incompatible build_daemon version detected.\n\nYour project\'s '
-        'build_daemon version is incompatible with this version of webdev.\n'
-        'Please run `dart pub upgrade build_daemon` '
-        'in your project to resolve this.\n\n',
-      );
+      logWriter(logging.Level.SEVERE, versionSkewMessage);
       return 1;
     }
   }

--- a/webdev/lib/src/command/build_command.dart
+++ b/webdev/lib/src/command/build_command.dart
@@ -134,6 +134,15 @@ class BuildCommand extends Command<int> {
         'before starting a new instance with these options.\n\n',
       );
       return 1;
+    } on VersionSkew catch (_) {
+      logWriter(
+        logging.Level.SEVERE,
+        'Incompatible build_daemon version detected.\n\nYour project\'s '
+        'build_daemon version is incompatible with this version of webdev.\n'
+        'Please run `dart pub upgrade build_daemon` '
+        'in your project to resolve this.\n\n',
+      );
+      return 1;
     }
   }
 }

--- a/webdev/lib/src/daemon_client.dart
+++ b/webdev/lib/src/daemon_client.dart
@@ -11,6 +11,14 @@ import 'package:build_daemon/data/server_log.dart';
 
 import 'util.dart';
 
+const versionSkewMessage =
+    'Incompatible build_daemon version detected.\n\n'
+    'Try upgrading `build_daemon` in your project:\n\n'
+    '  dart pub upgrade build_daemon\n\n'
+    'If the issue persists, another dependency might be constraining '
+    '`build_daemon` to an older version. Try running:\n\n'
+    '  dart pub upgrade\n\n';
+
 /// Connects to the `build_runner` daemon.
 Future<BuildDaemonClient> connectClient(
   String workingDirectory,

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -42,12 +42,7 @@ Future<BuildDaemonClient> _startBuildDaemon(
       'before starting a new instance with these options.',
     );
   } on VersionSkew {
-    throw StateError(
-      'Incompatible build_daemon version detected.\n\nYour project\'s '
-      'build_daemon version is incompatible with this version of webdev.\n'
-      'Please run `dart pub upgrade build_daemon` '
-      'in your project to resolve this.\n\n',
-    );
+    throw StateError(versionSkewMessage);
   }
 }
 

--- a/webdev/lib/src/serve/dev_workflow.dart
+++ b/webdev/lib/src/serve/dev_workflow.dart
@@ -41,6 +41,13 @@ Future<BuildDaemonClient> _startBuildDaemon(
       'Please stop other WebDev instances running in this directory '
       'before starting a new instance with these options.',
     );
+  } on VersionSkew {
+    throw StateError(
+      'Incompatible build_daemon version detected.\n\nYour project\'s '
+      'build_daemon version is incompatible with this version of webdev.\n'
+      'Please run `dart pub upgrade build_daemon` '
+      'in your project to resolve this.\n\n',
+    );
   }
 }
 

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.0';
+const packageVersion = '4.0.1';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `dart run build_runner build`.
-version: 4.0.0
+version: 4.0.1
 # We should not depend on a dev SDK before publishing.
 # publish_to: none
 description: >-
@@ -13,7 +13,7 @@ environment:
 dependencies:
   args: ^2.3.1
   async: ^2.9.0
-  build_daemon: ^4.0.0
+  build_daemon: ^4.1.4
   browser_launcher: ^1.1.0
   collection: ^1.15.0
   crypto: ^3.0.2

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -43,7 +43,7 @@ dev_dependencies:
   analysis_config:
     path: ../_analysis_config
   build: ^4.0.8
-  build_runner: ^2.15.2
+  build_runner: ^2.16.0
   build_verify: ^3.0.0
   build_version: ^2.1.1
   test: ^1.21.1


### PR DESCRIPTION
Reports version skew issues in webdev when incompatible `build_daemon` versions are used.

See: https://github.com/dart-lang/build/pull/5061

Also makes build_runner versions consistent across tests/fixtures (v2.16.0).