### PR TITLE
Prepare 4.0.2 release

### DIFF
--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.1
+## 4.0.2
 
 - **Internal**: Resolve Chrome test flakes.
 

--- a/webdev/CHANGELOG.md
+++ b/webdev/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 4.0.1
 
+- **Internal**: Resolve Chrome test flakes.
+
+## 4.0.1
+
 - Catch and report version skew errors when incompatible versions of `build_daemon` are used.
 
 ## 4.0.0

--- a/webdev/lib/src/version.dart
+++ b/webdev/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.1';
+const packageVersion = '4.0.2';

--- a/webdev/pubspec.yaml
+++ b/webdev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdev
 # Every time this changes you need to run `dart run build_runner build`.
-version: 4.0.1
+version: 4.0.2
 # We should not depend on a dev SDK before publishing.
 # publish_to: none
 description: >-


### PR DESCRIPTION
Fixes our daily stable tests (they were resolved in daily but not pushed to stable).